### PR TITLE
Add BlackBerry 10 and BlackBerry PlayBook detection to if_platform directive

### DIFF
--- a/framework/directives/if_platform.js
+++ b/framework/directives/if_platform.js
@@ -46,7 +46,7 @@
 					platform = "android";
 				}
 
-				if (navigator.userAgent.match(/BlackBerry/i)) {
+				if ((navigator.userAgent.match(/BlackBerry/i)) || (navigator.userAgent.match(/RIM Tablet OS/i)) || (navigator.userAgent.match(/BB10/i))) {
 					platform = "blackberry";
 				}
 


### PR DESCRIPTION
Added two regex checks for BlackBerry 10 and BlackBerry Tablet OS (PlayBook) in addition to the existing one for legacy BlackBerry devices.
