### PR TITLE
Useful API methods for ons.navigator

### DIFF
--- a/framework/directives/navigator.js
+++ b/framework/directives/navigator.js
@@ -145,6 +145,8 @@ limitations under the License.
 				this.scope.pushPage = this.pushPage.bind(this);
 				this.scope.popPage = this.popPage.bind(this);
 				this.scope.resetToPage = this.resetToPage.bind(this);
+				this.scope.getCurrentNavigatorItem = this.getCurrentNavigatorItem.bind(this);
+				this.scope.pages = this.navigatorItems;
 			},
 
 			attachFastClickEvent: function(el) {
@@ -560,6 +562,9 @@ limitations under the License.
 				if (options && typeof options != "object") {
 					throw new Error('options must be an objected. You supplied ' + options);
 				}
+				options = options || {};
+				options["page"] = page;
+
 				if (!this.isReady()) {
 					return;
 				}

--- a/framework/directives/navigator_stack.js
+++ b/framework/directives/navigator_stack.js
@@ -11,6 +11,8 @@
 				$rootScope.ons.navigator.pushPage = this.pushPage.bind(this);
 				$rootScope.ons.navigator.popPage = this.popPage.bind(this);
 				$rootScope.ons.navigator.resetToPage = this.resetToPage.bind(this);
+				$rootScope.ons.navigator.getCurrentPage = this.getCurrentPage.bind(this);
+				$rootScope.ons.navigator.getPages = this.getPages.bind(this);
 			},
 
 			_findNavigator: function($event) {
@@ -63,6 +65,20 @@
 
 				var navigator = this._findNavigator($event);
 				navigator.popPage();
+			},
+
+			getCurrentPage: function() {
+			    this._checkExistence();
+
+			    var navigator = this._findNavigator();
+			    return navigator.getCurrentNavigatorItem();
+			},
+
+			getPages: function() {
+			    this._checkExistence();
+
+			    var navigator = this._findNavigator();
+			    return navigator.pages;
 			}
 		});
 


### PR DESCRIPTION
I think the `ons.navigator` should have more features. 
Hope those could be useful to improve the framework.
-  **Pass and retrieve parameters between pages** (issue #65)
-  **Know which is the current page** (issue #68)
-  **Retrieve the entire page stack** (In my case to know if the back button on the device should go back on the stack or close the app if there are no pages to pop.)

All those methods are exposed on the `ons.navigator` object or in the `NavigatorStack` service.

```
// Pass parameters to another page
ons.navigator.pushPage("path/to/page.html", {foo: "bar"})

// Retrieve parameters from the other page
ons.navigator.getCurrentPage().options.foo //  "bar"

// Retrieve the current page
ons.navigator.getCurrentPage().options.page //  "path/to/page.html"

// Retrieve the entire stack
ons.navigator.getPages() //  [pageObj1, pageObg2, ... , pageObj3]

// Example of using the stack to change the behavior of the back button
 document.addEventListener("backbutton", function (e) {
            if ($rootScope.ons.navigator.getPages().length > 1) {
                e.preventDefault();
                $rootScope.ons.navigator.popPage();
            }
            else
                navigator.app.exitApp();
}, false);
```
