### PR TITLE
Disable sliding menu swipe gesture on specific element

### DIFF
--- a/framework/directives/sliding_menu.js
+++ b/framework/directives/sliding_menu.js
@@ -261,8 +261,13 @@ limitations under the License.
 						}
 					},
 
-					isInsideIgnoredElement: function(el) {
-					    return ($(el).attr("sliding-menu-ignore") == "true" || $(el).parents("[sliding-menu-ignore=true]").length > 0);
+					isInsideIgnoredElement: function (el) {
+					    do {
+					        if (el.getAttribute && el.getAttribute("sliding-menu-ignore"))
+					            return true;
+					        el = el.parentNode;
+					    } while (el);
+					    return false;
 					},
 
 					isInsideSwipeTargetArea: function(x){


### PR DESCRIPTION
Adding the attribute `sliding-menu-ignore="true"` on specific element the sliding menu gesture will be ignored. issue #63

This could be really useful when playing with other swipable element like carousels.

```
<div ignore-sliding-menu="true">
   <!-- Swiping here does not trigger sliding menu events -->
</div>
```
