### PR TITLE
fixed syntax error in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "build/js/onsenui.js"
   ],
   "styles": [
-    "build/css/onsenui.css"
+    "build/css/onsenui.css",
     "build/css/onsen-css-components.css"
   ],
   "keywords": [


### PR DESCRIPTION
`bower install` fails because of a syntax error.
