### PR TITLE
Fix for rapid popPage() call

### DIFF
--- a/framework/views/navigator.js
+++ b/framework/views/navigator.js
@@ -469,16 +469,15 @@ limitations under the License.
        */
       popPage: function(options) {
         options = options || {};
-
-        if (this.pages.length <= 1) {
-          throw new Error('NavigatorView\'s page stack is empty.');
-        }
-
-        if (this._emitPrePopEvent()) {
-          return;
-        }
-
+        
         this._doorLock.waitUnlock(function() {
+          if (this.pages.length <= 1) {
+            throw new Error('NavigatorView\'s page stack is empty.');
+          }
+
+          if (this._emitPrePopEvent()) {
+            return;
+          }
           this._popPage(options);
         }.bind(this));
       },


### PR DESCRIPTION
We discovered a issue with the popPage() call, when you are rapidly firing the back-button. You can get a empty page or a error in _popPage(), because there doesn't exist one. This is because there is a small delay with between the this.page.length <= 1 check and the this.page.pop() call, where there can be sended a new popPage() call thats get accepted because the amount of pages is not lowered.

Issues with this fix:
- The _emitPrePopEvent does not return fails.
- The performance will be a bit lower. But there will be no invalid popping
