### PR TITLE
Small fix for carousel docs

### DIFF
--- a/framework/directives/carousel.js
+++ b/framework/directives/carousel.js
@@ -247,7 +247,7 @@
 
 /**
  * @ngdoc method
- * @signature getActiveCarouselItemIndex(index)
+ * @signature getActiveCarouselItemIndex()
  * @return {Number}
  *   [en]The current carousel item index.[/en]
  *   [ja]現在表示しているカルーセル要素のインデックスが返されます。[/ja]


### PR DESCRIPTION
getActiveCarouselItemIndex() should not receive any parameter.