### PR TITLE
Add animation option to `popPage()`

### DIFF
--- a/framework/directives/navigator.js
+++ b/framework/directives/navigator.js
@@ -19,7 +19,7 @@
  * @guide DefiningMultiplePagesinSingleHTML
  *   [en]Defining multiple pages in single html[/en]
  *   [ja]複数のページを1つのHTMLに記述する[/ja]
- * @seealso ons-toolbar 
+ * @seealso ons-toolbar
  *   [en]ons-toolbar component[/en]
  *   [ja]ons-toolbarコンポーネント[/ja]
  * @seealso ons-back-button
@@ -187,6 +187,9 @@
  * @param {Object} [options]
  *   [en]Parameter object.[/en]
  *   [ja]オプションを指定するオブジェクト。[/ja]
+ * @param {String} [options.animation]
+ *   [en]Animation name. Available animations are "slide", "simpleslide", "lift", "fade" and "none".[/en]
+ *   [ja]アニメーション名を指定します。"slide", "simpleslide", "lift", "fade", "none"のいずれかを指定できます。[/ja]
  * @param {Function} [options.onTransitionEnd]
  *   [en]Function that is called when the transition has ended.[/en]
  *   [ja]このメソッドによる画面遷移が終了した際に呼び出される関数オブジェクトを指定します。[/ja]

--- a/framework/views/navigator.js
+++ b/framework/views/navigator.js
@@ -329,8 +329,9 @@ limitations under the License.
 
       /**
        * @param {Object} options pushPage()'s options parameter
+       * @param {NavigatorTransitionAnimator} [defaultAnimator]
        */
-      _getAnimatorOption: function(options) {
+      _getAnimatorOption: function(options, defaultAnimator) {
         var animator = null;
 
         if (options.animation instanceof NavigatorTransitionAnimator) {
@@ -346,7 +347,7 @@ limitations under the License.
         }
 
         if (!animator) {
-          animator = NavigatorView._transitionAnimatorDict['default'];
+          animator = defaultAnimator || NavigatorView._transitionAnimatorDict['default'];
         }
 
         if (!(animator instanceof NavigatorTransitionAnimator)) {
@@ -487,7 +488,7 @@ limitations under the License.
        */
       popPage: function(options) {
         options = options || {};
-        
+
         this._doorLock.waitUnlock(function() {
           if (this.pages.length <= 1) {
             throw new Error('NavigatorView\'s page stack is empty.');
@@ -532,7 +533,9 @@ limitations under the License.
         }.bind(this);
 
         this._isPopping = true;
-        leavePage.options.animator.pop(enterPage, leavePage, callback);
+
+        var animator = this._getAnimatorOption(options, leavePage.options.animator);
+        animator.pop(enterPage, leavePage, callback);
       },
 
       /**
@@ -569,7 +572,7 @@ limitations under the License.
        * Use this method to access options passed by pushPage() or resetToPage() method.
        * eg. ons.navigator.getCurrentPage().options
        *
-       * @return {Object} 
+       * @return {Object}
        */
       getCurrentPage: function() {
         return this.pages[this.pages.length - 1];

--- a/test/manual-testcases/navigator/00-pushpop.html
+++ b/test/manual-testcases/navigator/00-pushpop.html
@@ -5,8 +5,8 @@
     <link rel="stylesheet" href="../../../build/css/onsenui.css"/>
     <link rel="stylesheet" href="../../../build/css/onsen-css-components.css"/>
 
-    <script src="../../../build/js/angular/angular.js"></script>    
-    <script src="../../../build/js/onsenui.js"></script>    
+    <script src="../../../build/js/angular/angular.js"></script>
+    <script src="../../../build/js/onsenui.js"></script>
     <script>
       ons.bootstrap();
 
@@ -54,9 +54,31 @@
     <script type="text/ons-template" id="page.html">
       <ons-toolbar>
         <div class="left"><ons-back-button>Back</ons-back-button></div>
-        <div class="center">Page</div>
+
       </ons-toolbar>
+
+      <p>Transition Animations</p>
+
+      <ons-list-item modifier="chevron" ng-click="navi.popPage()">
+        pop(default)
+      </ons-list-item>
+
+      <ons-list-item modifier="chevron" ng-click="navi.popPage({animation: 'slide'})">
+        pop(slide)
+      </ons-list-item>
+
+      <ons-list-item modifier="chevron" ng-click="navi.popPage({animation: 'lift'})">
+        pop(lift)
+      </ons-list-item>
+
+      <ons-list-item modifier="chevron" ng-click="navi.popPage({animation: 'fade'})">
+        pop(fade)
+      </ons-list-item>
+
+      <ons-list-item modifier="chevron" ng-click="navi.popPage({animation: 'none'})">
+        pop(none)
+      </ons-list-item>
     </script>
-   
+
   </body>
 </html>


### PR DESCRIPTION
Current `popPage()` method has no animation option and performs the same animation as specified in `pushPage()`.

Add 'animation' option to `popPage()` method to specify different animation.

```javascript
myNavigator.pushPage("page.html", {
  animation: "slide" 
});
myNavigator.popPage({
  animation: "lift" 
});
```