### PR TITLE
"type" attribute docs. Closes #523

### DIFF
--- a/framework/directives/slidingMenu.js
+++ b/framework/directives/slidingMenu.js
@@ -150,6 +150,15 @@
  */
 
 /**
+ * @ngdoc attribute
+ * @name type
+ * @type {String}
+ * @description
+ *   [en]Sliding menu animator. Possible values are reveal (default), push and overlay.[/en]
+ *   [ja][/ja]
+ */
+
+/**
  * @ngdoc method
  * @signature setMainPage(pageUrl, [options])
  * @param {String} pageUrl

--- a/framework/directives/slidingMenu.js
+++ b/framework/directives/slidingMenu.js
@@ -155,7 +155,7 @@
  * @type {String}
  * @description
  *   [en]Sliding menu animator. Possible values are reveal (default), push and overlay.[/en]
- *   [ja][/ja]
+ *   [ja]スライディングメニューのアニメーションです。"reveal"（デフォルト）、"push"、"overlay"のいずれかを指定できます。[/ja]
  */
 
 /**


### PR DESCRIPTION
Documentation of sliding menu "type" attribute was missing.