### PR TITLE
Add replace() method to ons-navigator

### DIFF
--- a/framework/directives/navigator.js
+++ b/framework/directives/navigator.js
@@ -19,7 +19,7 @@
  * @guide DefiningMultiplePagesinSingleHTML
  *   [en]Defining multiple pages in single html[/en]
  *   [ja]複数のページを1つのHTMLに記述する[/ja]
- * @seealso ons-toolbar 
+ * @seealso ons-toolbar
  *   [en]ons-toolbar component[/en]
  *   [ja]ons-toolbarコンポーネント[/ja]
  * @seealso ons-back-button
@@ -193,6 +193,26 @@
  * @description
  *   [en]Pops the current page from the page stack. The previous page will be displayed.[/en]
  *   [ja]現在表示中のページをページスタックから取り除きます。一つ前のページに戻ります。[/ja]
+ */
+
+/**
+ * @ngdoc method
+ * @signature replacePage(pageUrl, [options])
+ * @param {String} pageUrl
+ *   [en]Page URL. Can be either a HTML document or an <code>&lt;ons-template&gt;</code>.[/en]
+ *   [ja]pageのURLか、もしくはons-templateで宣言したテンプレートのid属性の値を指定できます。[/ja]
+ * @param {Object} [options]
+ *   [en]Parameter object.[/en]
+ *   [ja]オプションを指定するオブジェクト。[/ja]
+ * @param {String} [options.animation]
+ *   [en]Animation name. Available animations are "slide", "simpleslide", "lift", "fade" and "none".[/en]
+ *   [ja]アニメーション名を指定できます。"slide", "simpleslide", "lift", "fade", "none"のいずれかを指定できます。[/ja]
+ * @param {Function} [options.onTransitionEnd]
+ *   [en]Function that is called when the transition has ended.[/en]
+ *   [ja]このメソッドによる画面遷移が終了した際に呼び出される関数オブジェクトを指定します。[/ja]
+ * @description
+ *   [en]Replaces the current page with the specified one.[/en]
+ *   [ja]現在表示中のページをを指定したページに置き換えます。[/ja]
  */
 
 /**

--- a/framework/views/navigator.js
+++ b/framework/views/navigator.js
@@ -536,6 +536,27 @@ limitations under the License.
       },
 
       /**
+       * Replaces the current page with the specified one.
+       *
+       * @param {String} page
+       * @param {Object} [options]
+       */
+      replacePage: function(page, options) {
+        options = options || {};
+
+        var onTransitionEnd = options.onTransitionEnd || function() {};
+
+        options.onTransitionEnd = function() {
+          if (this.pages.length > 1) {
+            this.pages[this.pages.length - 2].destroy();
+          }
+          onTransitionEnd();
+        }.bind(this);
+
+        this.pushPage(page, options);
+      },
+
+      /**
        * Clears page stack and add the specified pageUrl to the page stack.
        * If options object is specified, apply the options.
        * the options object include all the attributes of this navigator.

--- a/test/e2e/navigator/index.html
+++ b/test/e2e/navigator/index.html
@@ -27,7 +27,18 @@
         <div style="text-align: center;">
           <p>Page 2</p>
           <br>
-          <ons-button id="btn2" onclick="myNavigator.popPage()">Pop Page</ons-button>        
+          <ons-button id="btn2" onclick="myNavigator.popPage()">Pop Page</ons-button>
+          <ons-button id="btn3" onclick="myNavigator.replacePage('page3.html')">Replace Page</ons-button>
+        </div>
+      </ons-page>
+    </ons-template>
+
+    <ons-template id="page3.html">
+      <ons-page id="page3">
+        <div style="text-align: center;">
+          <p>Page 3</p>
+          <br>
+          <ons-button id="btn4" onclick="myNavigator.popPage()">Pop Page</ons-button>
         </div>
       </ons-page>
     </ons-template>

--- a/test/e2e/navigator/scenarios.js
+++ b/test/e2e/navigator/scenarios.js
@@ -5,36 +5,63 @@
     var path = '/test/e2e/navigator/index.html';
     var EC = protractor.ExpectedConditions;
 
-    it('should exist', function() {
+    beforeEach(function () {
       browser.get(path);
       browser.waitForAngular();
+    });
 
+    it('should exist', function() {
       var navi = element(by.css('ons-navigator'));
       browser.wait(EC.presenceOf(navi));
       expect(navi.isDisplayed()).toBeTruthy();
     });
 
-    it('should switch page when a button is clicked', function() {
-      browser.get(path);
+    describe('page pushing', function () {
+      it('should switch page when a button is clicked', function() {
+        var page1 = element(by.id('page1'));
+        var page2 = element(by.id('page2'));
 
-      var page1 = element(by.id('page1'));
-      var page2 = element(by.id('page2'));
+        element(by.id('btn1')).click();
+        browser.wait(EC.visibilityOf(page2));
+        browser.wait(EC.invisibilityOf(page1));
 
-      element(by.id('btn1')).click();
-      browser.wait(EC.visibilityOf(page2));
-      browser.wait(EC.invisibilityOf(page1));
+        // Check that page2 was created and that it's displayed.
+        expect((page2).isDisplayed()).toBeTruthy();
+        expect((page1).isDisplayed()).not.toBeTruthy();
+        expect((page1).isPresent()).toBeTruthy();
 
-      // Check that page2 was created and that it's displayed.
-      expect((page2).isDisplayed()).toBeTruthy();
-      expect((page1).isDisplayed()).not.toBeTruthy();
-      expect((page1).isPresent()).toBeTruthy();
+        element(by.id('btn2')).click();
+        browser.wait(EC.stalenessOf(page2));
 
-      element(by.id('btn2')).click();
-      browser.wait(EC.stalenessOf(page2));
+        // Check that page2 was destroyed.
+        expect((page1).isDisplayed()).toBeTruthy();
+        expect((page2).isPresent()).not.toBeTruthy();
+      });
+    });
 
-      // Check that page2 was destroyed.
-      expect((page1).isDisplayed()).toBeTruthy();
-      expect((page2).isPresent()).not.toBeTruthy();
+    describe('page replacing', function () {
+      it('should replace current page when a button is clicked', function () {
+        var page1 = element(by.id('page1'));
+        var page2 = element(by.id('page2'));
+        var page3 = element(by.id('page3'));
+
+        element(by.id('btn1')).click();
+        browser.wait(EC.visibilityOf(page2));
+        browser.wait(EC.invisibilityOf(page1));
+
+        element(by.id('btn3')).click();
+        browser.wait(EC.stalenessOf(page2));
+
+        expect(page3.isDisplayed()).toBeTruthy();
+        expect(page2.isPresent()).not.toBeTruthy();
+        expect(page1.isPresent()).toBeTruthy();
+
+        element(by.id('btn4')).click();
+        browser.wait(EC.stalenessOf(page3));
+
+        expect(page1.isDisplayed()).toBeTruthy();
+        expect(page3.isPresent()).not.toBeTruthy();
+      });
     });
   });
 })();


### PR DESCRIPTION
Add replace() method that replaces the stack top of the navigator.

```javascript
myNavigation.replacePage("page.html");
```

## Events

`prepush` before replacing
`postpush` after replacing

## Animation

Same as `pushPage()`.

```javascript
// the new page will slide over the old page
myNavigation.replacePage("page.html", {
  animation: 'slide'
});
```