### PR TITLE
Small build fix

### DIFF
--- a/css-components/www/scripts/controllers/components.js
+++ b/css-components/www/scripts/controllers/components.js
@@ -21,7 +21,7 @@ angular.module('app').controller('ComponentsController', function ($scope) {
   $scope.updateVarNamesHighlight = function() {
     var result = {};
 
-    var dicts = $scope.components.filter(function(component) {
+    $scope.components.filter(function(component) {
       return component.checked;
     }).map(function(component) {
       return component.varNameDict;


### PR DESCRIPTION
Fixes `gulp build` for the css-components:

```
[08:18:05] Starting 'jshint'...

/Users/dave/Projects/OnsenUI/css-components/www/scripts/controllers/components.js
  line 24  col 9  'dicts' is defined but never used.

✖ 1 problem
```