### PR TITLE
Lazy repeat fix

### DIFF
--- a/framework/views/lazyRepeat.js
+++ b/framework/views/lazyRepeat.js
@@ -76,7 +76,7 @@ limitations under the License.
       },
 
       _getTopOffset: function() {
-        if (typeof this._parentElement[0] !== "undefined" && this._parentElement[0] !== null) {
+        if (typeof this !== "undefined" && this !== null) {
           return this._parentElement[0].getBoundingClientRect().top;
         }
         else return 0;

--- a/framework/views/lazyRepeat.js
+++ b/framework/views/lazyRepeat.js
@@ -76,7 +76,7 @@ limitations under the License.
       },
 
       _getTopOffset: function() {
-        if (typeof this !== "undefined" && this !== null) {
+        if (typeof this._parentElement !== "undefined" && this._parentElement !== null) {
           return this._parentElement[0].getBoundingClientRect().top;
         }
         else return 0;

--- a/framework/views/lazyRepeat.js
+++ b/framework/views/lazyRepeat.js
@@ -74,9 +74,12 @@ limitations under the License.
       _getItemHeight: function(i) {
         return this._delegate.calculateItemHeight(i);
       },
-      
+
       _getTopOffset: function() {
-        return this._parentElement[0].getBoundingClientRect().top;
+        if (typeof this._parentElement[0] !== "undefined" && this._parentElement[0] !== null) {
+          return this._parentElement[0].getBoundingClientRect().top;
+        }
+        else return 0;
       },
 
       _render: function() {
@@ -101,7 +104,7 @@ limitations under the License.
       _isRendered: function(i) {
         return this._renderedElements.hasOwnProperty(i);
       },
-      
+
       _renderElement: function(item) {
         if (this._isRendered(item.index)) {
           // Update content even if it's already added to DOM


### PR DESCRIPTION
Minor fixed mainly for windows phone.
Sometimes this._parentElement[0] threw an error on windows when switching away from a LazyRepeat List or switching back to one.
This checks if this._parentElement is defined before getting the first entry.
