### PR TITLE
isIOS7above name fixed. Closes #669

### DIFF
--- a/core/lib/ons-internal.es6
+++ b/core/lib/ons-internal.es6
@@ -42,7 +42,7 @@ limitations under the License.
    * @return {Boolean}
    */
   ons._internal.shouldFillStatusBar = (element) => {
-    if (ons._internal.isEnabledAutoStatusBarFill() && ons.platform.isWebView() && ons.platform.isIOS7Above()) {
+    if (ons._internal.isEnabledAutoStatusBarFill() && ons.platform.isWebView() && ons.platform.isIOS7above()) {
       if (!(element instanceof HTMLElement)) {
         throw new Error('element must be an instance of HTMLElement');
       }

--- a/framework/services/onsen.js
+++ b/framework/services/onsen.js
@@ -356,7 +356,7 @@ limitations under the License.
         /**
          * @return {Boolean}
          */
-        isIOS7Above: (function() {
+        isIOS7above: (function() {
           var ua = window.navigator.userAgent;
           var match = ua.match(/(iPad|iPhone|iPod touch);.*CPU.*OS (\d+)_(\d+)/i);
 


### PR DESCRIPTION
The error was in `core/lib/ons-internal.es6`. Just changed `framework/services/onsen.js` as well to be coherent. Those two were the only places where the uppercase version was used.