### PR TITLE
Fixed error if event is undefined.

### DIFF
--- a/core/css/scroller.css
+++ b/core/css/scroller.css
@@ -17,6 +17,7 @@ limitations under the License.
 
 ons-scroller {
   display: block;
+  height: 100%;
   overflow: scroll;
   -webkit-overflow-scrolling: touch;   
   -ms-overflow-style: none;
@@ -24,4 +25,9 @@ ons-scroller {
 
 ons-scroller::-webkit-scrollbar {
   display: none;
+}
+
+.ons-scroller__content {
+  height: 100%;
+  overflow: scroll;
 }

--- a/framework/views/carousel.js
+++ b/framework/views/carousel.js
@@ -469,7 +469,7 @@ limitations under the License.
 
         event.stopPropagation();
 
-        this._lastDragEvent = event;
+        this._lastDragEvent = event || null;
 
         var scroll = this._scroll - this._getScrollDelta(event);
         this._scrollTo(scroll);


### PR DESCRIPTION
Sometimes the variable 'event' maybe undefined, the following code only think about the null value condition.