### PR TITLE
perf(ons-page): Copy child nodes instead of innerHTML.

### DIFF
--- a/core/elements/ons-page.es6
+++ b/core/elements/ons-page.es6
@@ -149,10 +149,8 @@ limitations under the License.
       var content = document.createElement('div');
       content.classList.add('page__content');
 
-      var html = this.innerHTML;
-      content.innerHTML = html;
-      while (this.childNodes[0]) {
-        this.removeChild(this.childNodes[0]);
+      for (let child of ons._util.arrayFrom(this.childNodes)) {
+        content.appendChild(child);
       }
 
       if (this.hasAttribute('style')) {

--- a/core/elements/ons-page.es6
+++ b/core/elements/ons-page.es6
@@ -149,8 +149,8 @@ limitations under the License.
       var content = document.createElement('div');
       content.classList.add('page__content');
 
-      for (let child of ons._util.arrayFrom(this.childNodes)) {
-        content.appendChild(child);
+      while (this.childNodes[0]) {
+        content.appendChild(this.childNodes[0]);
       }
 
       if (this.hasAttribute('style')) {


### PR DESCRIPTION
@anatoo 

Copying innerHTML caused createdCallback to be triggered again for all children.