### PR TITLE
refactor(all): Fix typos to enable strict mode in some view codes.

### DIFF
--- a/framework/views/carousel.js
+++ b/framework/views/carousel.js
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 (function() {
-  'use strict;';
+  'use strict';
 
   var module = angular.module('onsen');
 

--- a/framework/views/modal.js
+++ b/framework/views/modal.js
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 (function() {
-  'use strict;';
+  'use strict';
 
   var module = angular.module('onsen');
 

--- a/framework/views/navigator.js
+++ b/framework/views/navigator.js
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 (function() {
-  'use strict;';
+  'use strict';
 
   var module = angular.module('onsen');
 

--- a/framework/views/page.js
+++ b/framework/views/page.js
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 (function() {
-  'use strict;';
+  'use strict';
 
   var module = angular.module('onsen');
 

--- a/framework/views/tabbarView.js
+++ b/framework/views/tabbarView.js
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 (function() {
-  'use strict;';
+  'use strict';
 
   var module = angular.module('onsen');
 


### PR DESCRIPTION
I found some typos in framework/views codes.
If  you want to enable strict mode, you must write "'use strict';" instead of "'use strict;';"
