### PR TITLE
Changed the way to trigger custom events.

### DIFF
--- a/core/elements/ons-alert-dialog.es6
+++ b/core/elements/ons-alert-dialog.es6
@@ -130,15 +130,12 @@ limitations under the License.
       let cancel = false;
       const callback = options.callback || function() {};
 
-      this.dispatchEvent(new CustomEvent('preshow', {
-        bubbles: true,
-        detail: {
-          alertDialog: this,
-          cancel: function() {
-            cancel = true;
-          }
+      util.triggerElementEvent(this, 'preshow', {
+        alertDialog: this,
+        cancel: function() {
+          cancel = true;
         }
-      }));
+      });
 
       if (!cancel) {
         this._doorLock.waitUnlock(() => {
@@ -152,10 +149,7 @@ limitations under the License.
           animator.show(this, () => {
             this._visible = true;
             unlock();
-            this.dispatchEvent(new CustomEvent('postshow', {
-              bubbles: true,
-              detail: {alertDialog: this}
-            }));
+            util.triggerElementEvent(this, 'postshow', {alertDialog: this});
             callback();
           });
         });
@@ -174,15 +168,12 @@ limitations under the License.
       let cancel = false;
       const callback = options.callback || function() {};
 
-      this.dispatchEvent(new CustomEvent('prehide', {
-        bubbles: true,
-        detail: {
-          alertDialog: this,
-          cancel: function() {
-            cancel = true;
-          }
+      util.triggerElementEvent(this, 'prehide', {
+        alertDialog: this,
+        cancel: function() {
+          cancel = true;
         }
-      }));
+      });
 
       if (!cancel) {
         this._doorLock.waitUnlock(() => {
@@ -194,10 +185,7 @@ limitations under the License.
             this._mask.style.display = 'none';
             this._visible = false;
             unlock();
-            this.dispatchEvent(new CustomEvent('posthide', {
-              bubbles: true,
-              detail: {alertDialog: this}
-            }));
+            util.triggerElementEvent(this, 'posthide', {alertDialog: this});
             callback();
           });
         });
@@ -242,7 +230,7 @@ limitations under the License.
       if (this.isCancelable()) {
         this.hide({
           callback: () => {
-            this.dispatchEvent(new CustomEvent('cancel', {bubbles: true}));
+            util.triggerElementEvent(this, 'cancel');
           }
         });
       }

--- a/core/elements/ons-carousel.es6
+++ b/core/elements/ons-carousel.es6
@@ -19,6 +19,7 @@ limitations under the License.
   'use strict';
 
   const ModifierUtil = ons._internal.ModifierUtil;
+  const util = ons._util;
   const scheme = {'': 'carousel--*'};
 
   const VerticalModeTrait = {
@@ -411,15 +412,11 @@ limitations under the License.
         const lastActiveIndex = this._lastActiveIndex;
         this._lastActiveIndex = currentIndex;
 
-        const event = new CustomEvent('postchange', {
-          bubbles: true,
-          detail: {
-            carousel: this,
-            activeIndex: currentIndex,
-            lastActiveIndex: lastActiveIndex
-          }
+        util.triggerElementEvent(this, 'postchange', {
+          carousel: this,
+          activeIndex: currentIndex,
+          lastActiveIndex: lastActiveIndex
         });
-        this.dispatchEvent(event);
       }
     }
 
@@ -459,19 +456,15 @@ limitations under the License.
 
       if (this._isOverScroll(this._scroll)) {
         let waitForAction = false;
-        const overscrollEvent = new CustomEvent('overscroll', {
-          bubbles: true,
-          detail: {
-            carousel: this,
-            activeIndex: this.getActiveCarouselItemIndex(),
-            direction: this._getOverScrollDirection(),
-            waitToReturn: (promise) => {
-              waitForAction = true;
-              promise.then(() => this._scrollToKillOverScroll());
-            }
+        util.triggerElementEvent(this, 'overscroll', {
+          carousel: this,
+          activeIndex: this.getActiveCarouselItemIndex(),
+          direction: this._getOverScrollDirection(),
+          waitToReturn: (promise) => {
+            waitForAction = true;
+            promise.then(() => this._scrollToKillOverScroll());
           }
         });
-        this.dispatchEvent(overscrollEvent);
 
         if (!waitForAction) {
           this._scrollToKillOverScroll();
@@ -709,11 +702,7 @@ limitations under the License.
 
       this._saveLastState();
 
-      const event = new CustomEvent('refresh', {
-        bubbles: true,
-        detail: {carousel: this}
-      });
-      this.dispatchEvent(event);
+      util.triggerElementEvent(this, 'refresh', {carousel: this});
     }
 
     first() {

--- a/core/elements/ons-dialog.es6
+++ b/core/elements/ons-dialog.es6
@@ -113,7 +113,7 @@ limitations under the License.
       if (this.isCancelable()) {
         this.hide({
           callback: () => {
-            this.dispatchEvent(new CustomEvent('cancel', {bubbles: true}));
+            util.triggerElementEvent(this, 'cancel');
           }
         });
       }
@@ -131,15 +131,12 @@ limitations under the License.
       let cancel = false;
       const callback = options.callback || function() {};
 
-      this.dispatchEvent(new CustomEvent('preshow', {
-        bubbles: true,
-        detail: {
-          dialog: this,
-          cancel: function() {
-            cancel = true;
-          }
+      util.triggerElementEvent(this, 'preshow', {
+        dialog: this,
+        cancel: function() {
+          cancel = true;
         }
-      }));
+      });
 
       if (!cancel) {
         this._doorLock.waitUnlock(() => {
@@ -154,10 +151,7 @@ limitations under the License.
             this._visible = true;
             unlock();
 
-            this.dispatchEvent(new CustomEvent('postshow', {
-              bubbles: true,
-              detail: {dialog: this}
-            }));
+            util.triggerElementEvent(this, 'postshow', {dialog: this});
 
             callback();
           });
@@ -177,15 +171,12 @@ limitations under the License.
       let cancel = false;
       const callback = options.callback || function() {};
 
-      this.dispatchEvent(new CustomEvent('prehide', {
-        bubbles: true,
-        detail: {
-          dialog: this,
-          cancel: function() {
-            cancel = true;
-          }
+      util.triggerElementEvent(this, 'prehide', {
+        dialog: this,
+        cancel: function() {
+          cancel = true;
         }
-      }));
+      });
 
       if (!cancel) {
         this._doorLock.waitUnlock(() => {
@@ -196,10 +187,7 @@ limitations under the License.
             this.style.display = 'none';
             this._visible = false;
             unlock();
-            this.dispatchEvent(new CustomEvent('posthide', {
-              bubbles: true,
-              detail: {dialog: this}
-            }));
+            util.triggerElementEvent(this, 'posthide', {dialog: this});
             callback();
           });
         });

--- a/core/elements/ons-navigator.es6
+++ b/core/elements/ons-navigator.es6
@@ -159,8 +159,7 @@ limitations under the License.
         this._isPopping = false;
         unlock();
 
-        util.triggerElementEvent(this, 'postpop', eventDetail);
-
+        const event = util.triggerElementEvent(this, 'postpop', eventDetail);
         event.leavePage = null;
 
         if (typeof options.onTransitionEnd === 'function') {

--- a/core/elements/ons-navigator.es6
+++ b/core/elements/ons-navigator.es6
@@ -159,11 +159,7 @@ limitations under the License.
         this._isPopping = false;
         unlock();
 
-        const event = new CustomEvent('postpop', {
-          bubbles: true,
-          detail: eventDetail
-        });
-        this.dispatchEvent(event);
+        util.triggerElementEvent(this, 'postpop', eventDetail);
 
         event.leavePage = null;
 
@@ -404,12 +400,7 @@ limitations under the License.
         this._isPushing = false;
         unlock();
 
-        const event = new CustomEvent('postpush', {
-          bubbles: true,
-          detail: eventDetail
-        });
-        this.dispatchEvent(event);
-
+        util.triggerElementEvent(this, 'postpush', eventDetail);
 
         if (typeof options.onTransitionEnd === 'function') {
           options.onTransitionEnd();
@@ -447,18 +438,14 @@ limitations under the License.
      */
     _emitPrePushEvent() {
       let isCanceled = false;
-      const event = new CustomEvent('prepush', {
-        bubbles: true,
-        detail: {
-          navigator: this,
-          currentPage: this._pages.length > 0 ? this.getCurrentPage() : undefined,
-          cancel: function() {
-            isCanceled = true;
-          }
+
+      util.triggerElementEvent(this, 'prepush', {
+        navigator: this,
+        currentPage: this._pages.length > 0 ? this.getCurrentPage() : undefined,
+        cancel: function() {
+          isCanceled = true;
         }
       });
-
-      this.dispatchEvent(event);
 
       return isCanceled;
     }
@@ -470,20 +457,16 @@ limitations under the License.
       let isCanceled = false;
 
       const leavePage = this.getCurrentPage();
-      const event = new CustomEvent('prepop', {
-        bubbles: true,
-        detail: {
-          navigator: this,
-          // TODO: currentPage will be deprecated
-          currentPage: leavePage,
-          leavePage: leavePage,
-          enterPage: this._pages[this._pages.length - 2],
-          cancel: function() {
-            isCanceled = true;
-          }
+      util.triggerElementEvent(this, 'prepop', {
+        navigator: this,
+        // TODO: currentPage will be deprecated
+        currentPage: leavePage,
+        leavePage: leavePage,
+        enterPage: this._pages[this._pages.length - 2],
+        cancel: function() {
+          isCanceled = true;
         }
       });
-      this.dispatchEvent(event);
 
       return isCanceled;
     }

--- a/core/elements/ons-page.es6
+++ b/core/elements/ons-page.es6
@@ -25,6 +25,7 @@ limitations under the License.
   };
   const ModifierUtil = ons._internal.ModifierUtil;
   const nullToolbarElement = document.createElement('ons-toolbar');
+  const util = ons._util;
 
   class PageElement extends ons._BaseElement {
 
@@ -41,14 +42,10 @@ limitations under the License.
 
     attachedCallback() {
       if (!this._isMuted) {
-        const event = new CustomEvent('init', {
-          bubbles: true,
-          detail: this.eventDetail
-        });
-        this.dispatchEvent(event);
+        util.triggerElementEvent(this, 'init', this.eventDetail);
       }
 
-      if(!ons._util.hasAnyComponentAsParent(this)) {
+      if(!util.hasAnyComponentAsParent(this)) {
         this._show();
       }
     }
@@ -244,11 +241,7 @@ limitations under the License.
         this.isShown = true;
 
         if (!this._isMuted) {
-          const event = new CustomEvent('show', {
-            bubbles: true,
-            detail: this.eventDetail
-          });
-          this.dispatchEvent(event);
+          util.triggerElementEvent(this, 'show', this.eventDetail);
         }
 
         ons._util.propagateAction(this._getContentElement(), '_show');
@@ -260,11 +253,7 @@ limitations under the License.
         this.isShown = false;
 
         if (!this._isMuted) {
-          const event = new CustomEvent('hide', {
-            bubbles: true,
-            detail: this.eventDetail
-          });
-          this.dispatchEvent(event);
+          util.triggerElementEvent(this, 'hide', this.eventDetail);
         }
 
         ons._util.propagateAction(this._getContentElement(), '_hide');
@@ -275,11 +264,7 @@ limitations under the License.
       this._hide();
 
       if (!this._isMuted) {
-        const event = new CustomEvent('destroy', {
-          bubbles: true,
-          detail: this.eventDetail
-        });
-        this.dispatchEvent(event);
+        util.triggerElementEvent(this, 'destroy', this.eventDetail);
       }
 
       if (this.getDeviceBackButtonHandler()) {

--- a/core/elements/ons-popover.es6
+++ b/core/elements/ons-popover.es6
@@ -276,16 +276,12 @@ limitations under the License.
       }
 
       let canceled = false;
-      const event = new CustomEvent('preshow', {
-        bubbles: true,
-        detail: {
-          popover: this,
-          cancel: function() {
-            canceled = true;
-          }
+      util.triggerElementEvent(this, 'preshow', {
+        popover: this,
+        cancel: function() {
+          canceled = true;
         }
       });
-      this.dispatchEvent(event);
 
       if (!canceled) {
         this._doorLock.waitUnlock(() => {
@@ -301,11 +297,7 @@ limitations under the License.
             this._visible = true;
             unlock();
 
-            const event = new CustomEvent('postshow', {
-              bubbles: true,
-              detail: {popover: this}
-            });
-            this.dispatchEvent(event);
+            util.triggerElementEvent(this, 'postshow', {popover: this});
           });
         });
       }
@@ -322,16 +314,12 @@ limitations under the License.
       options = options || {};
 
       let canceled = false;
-      const event = new CustomEvent('prehide', {
-        bubbles: true,
-        detail: {
-          popover: this,
-          cancel: function() {
-            canceled = true;
-          }
+      util.triggerElementEvent(this, 'prehide', {
+        popover: this,
+        cancel: function() {
+          canceled = true;
         }
       });
-      this.dispatchEvent(event);
 
       if (!canceled) {
         this._doorLock.waitUnlock(() => {
@@ -342,11 +330,7 @@ limitations under the License.
             this.style.display = 'none';
             this._visible = false;
             unlock();
-            const event = new CustomEvent('posthide', {
-              bubbles: true,
-              detail: {popover: this}
-            });
-            this.dispatchEvent(event);
+            util.triggerElementEvent(this, 'posthide', {popover: this});
           });
         });
       }

--- a/core/elements/ons-pull-hook.es6
+++ b/core/elements/ons-pull-hook.es6
@@ -220,14 +220,11 @@ limitations under the License.
       this.setAttribute('state', state);
 
       if (!noEvent && lastState !== this._getState()) {
-        this.dispatchEvent(new CustomEvent('changestate', {
-          bubbles: true,
-          detail: {
-            pullHook: this,
-            state: state,
-            lastState: lastState
-          }
-        }));
+        util.triggerElementEvent(this, 'changestate', {
+          pullHook: this,
+          state: state,
+          lastState: lastState
+        });
       }
     }
 

--- a/core/elements/ons-splitter-side.es6
+++ b/core/elements/ons-splitter-side.es6
@@ -475,17 +475,11 @@ limitations under the License.
     }
 
     _emitPostOpenEvent() {
-      this.dispatchEvent(new CustomEvent('postopen', {
-        bubbles: true,
-        detail: {side: this}
-      }));
+      util.triggerElementEvent(this, 'postopen', {side: this});
     }
 
     _emitPostCloseEvent() {
-      this.dispatchEvent(new CustomEvent('postclose', {
-        bubbles: true,
-        detail: {side: this}
-      }));
+      util.triggerElementEvent(this, 'postclose', {side: this});
     }
 
     /**
@@ -498,15 +492,11 @@ limitations under the License.
     _emitCancelableEvent(name) {
       let isCanceled = false;
 
-      const event = new CustomEvent(name, {
-        bubbles: true,
-        detail: {
-          side: this,
-          cancel: () => isCanceled = true
-        }
+      util.triggerElementEvent(this, name, {
+        side: this,
+        cancel: () => isCanceled = true
       });
 
-      this.dispatchEvent(event);
       return isCanceled;
     }
 
@@ -571,14 +561,10 @@ limitations under the License.
       currentMode.enterMode();
       this.setAttribute('mode', mode);
 
-      const event = new CustomEvent('modechange', {
-        bubbles: true,
-        detail: {
-          side: this,
-          mode: mode
-        }
+      util.triggerElementEvent(this, 'modechange', {
+        side: this,
+        mode: mode
       });
-      this.dispatchEvent(event);
     }
 
     _layout() {

--- a/core/elements/ons-tabbar.es6
+++ b/core/elements/ons-tabbar.es6
@@ -252,28 +252,21 @@ limitations under the License.
       }
 
       if ((selectedTab.hasAttribute('no-reload') || selectedTab.isPersistent()) && index === previousTabIndex) {
-        var event = new CustomEvent('reactive', {
-          bubbles: true,
-          detail: {
-            index: index,
-            tabItem: selectedTab
-          }
+        util.triggerElementEvent(this, 'reactive', {
+          index: index,
+          tabItem: selectedTab
         });
-        this.dispatchEvent(event);
 
         return false;
       }
 
       var canceled = false;
 
-      this.dispatchEvent(new CustomEvent('prechange', {
-        bubbles: true,
-        detail: {
-          index: index,
-          tabItem: selectedTab,
-          cancel: () => canceled = true
-        }
-      }));
+      util.triggerElementEvent(this, 'prechange', {
+        index: index,
+        tabItem: selectedTab,
+        cancel: () => canceled = true
+      });
 
       if (canceled) {
         selectedTab.setInactive();
@@ -296,13 +289,10 @@ limitations under the License.
 
         var params = {
           callback: () => {
-            this.dispatchEvent(new CustomEvent('postchange', {
-              bubbles: true,
-              detail: {
-                index: index,
-                tabItem: selectedTab
-              }
-            }));
+            util.triggerElementEvent(this, 'postchange', {
+              index: index,
+              tabItem: selectedTab
+            });
 
             if (options.callback instanceof Function) {
               options.callback();
@@ -331,13 +321,10 @@ limitations under the License.
           tab.setInactive();
         } else {
           if (!needLoad) {
-            this.dispatchEvent(new CustomEvent('postchange', {
-              bubbles: true,
-              detail: {
-                index: index,
-                tabItem: selectedTab
-              }
-            }));
+            util.triggerElementEvent(this, 'postchange', {
+              index: index,
+              tabItem: selectedTab
+            });
           }
         }
       });

--- a/core/lib/ons-util.es6
+++ b/core/lib/ons-util.es6
@@ -207,7 +207,7 @@ limitations under the License.
     const event = new CustomEvent(eventName, {
       bubbles: true,
       cancelable: true,
-      detail: eventDetail
+      detail: detail
     });
 
     Object.keys(detail).forEach(key => {

--- a/core/lib/ons-util.es6
+++ b/core/lib/ons-util.es6
@@ -196,4 +196,27 @@ limitations under the License.
     return failSafe;
   };
 
+  /**
+   * @param {Element} element
+   * @param {String} eventName
+   * @param {Object} [detail]
+   * @return {CustomEvent}
+   */
+  util.triggerElementEvent = (target, eventName, detail = {}) => {
+
+    const event = new CustomEvent(eventName, {
+      bubbles: true,
+      cancelable: true,
+      detail: eventDetail
+    });
+
+    Object.keys(detail).forEach(key => {
+      event[key] = detail[key];
+    });
+
+    target.dispatchEvent(event);
+
+    return event;
+  };
+
 })(window.ons = window.ons || {});

--- a/framework/directives/carousel.js
+++ b/framework/directives/carousel.js
@@ -27,16 +27,16 @@
  * @description
  *   [en]Fired just after the current carousel item has changed.[/en]
  *   [ja]現在表示しているカルーセルの要素が変わった時に発火します。[/ja]
- * @param {Object} event 
+ * @param {Object} event
  *   [en]Event object.[/en]
  *   [ja]イベントオブジェクトです。[/ja]
- * @param {Object} event.details.carousel
+ * @param {Object} event.carousel
  *   [en]Carousel object.[/en]
  *   [ja]イベントが発火したCarouselオブジェクトです。[/ja]
- * @param {Number} event.details.activeIndex
+ * @param {Number} event.activeIndex
  *   [en]Current active index.[/en]
  *   [ja]現在アクティブになっている要素のインデックス。[/ja]
- * @param {Number} event.details.lastActiveIndex
+ * @param {Number} event.lastActiveIndex
  *   [en]Previous active index.[/en]
  *   [ja]以前アクティブだった要素のインデックス。[/ja]
  */


### PR DESCRIPTION
This changes allows to refer custom event properties like the below:

```
navigatorElement.addEventListener('poppage', function(event) {
  console.log(event.detail.foobar); // old way
  console.log(event.foobar); // new way
});
```

@argelius Please review and merge this pull request after https://github.com/OnsenUI/OnsenUI/pull/896.