### PR TITLE
Lazy repeat reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ v2.0.0-dev
  * ons-navigator: Added `bringPageTop()` method.
  * ons-carousel: Added `getCarouselItemCount()` method.
  * ons-carousel: Fixed [#929](https://github.com/OnsenUI/OnsenUI/issues/929)
+ * ons-lazy-repeat: Add `reload()` method to delegate object to enable manual reloading.
 
 v1.3.11
 ----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ v2.0.0-dev
  * ons-carousel: Added `getCarouselItemCount()` method.
  * ons-carousel: Fixed [#929](https://github.com/OnsenUI/OnsenUI/issues/929)
  * ons-lazy-repeat: Add `reload()` method to delegate object to enable manual reloading.
+ * ons-lazy-repeat: Fix layout of list when it's not placed on top of page.
 
 v1.3.11
 ----

--- a/core/lib/lazy-repeat-provider.es6
+++ b/core/lib/lazy-repeat-provider.es6
@@ -147,6 +147,11 @@ limitations under the License.
       }
 
       this._wrapperElement.style.height = this._calculateListHeight() + 'px';
+
+      // Fix layout bug
+      if (this._wrapperElement.style.marginTop === '') {
+        this._wrapperElement.style.marginTop = '-1px';
+      }
     }
 
     _calculateListHeight() {
@@ -176,7 +181,7 @@ limitations under the License.
 
         // Fix position.
         let element = this._renderedItems[index].element;
-        element.style.top = top + 'px';
+        element.style.top = (this._wrapperElement.offsetTop + top) + 'px';
 
         return;
       }

--- a/core/lib/lazy-repeat-provider.es6
+++ b/core/lib/lazy-repeat-provider.es6
@@ -147,11 +147,6 @@ limitations under the License.
       }
 
       this._wrapperElement.style.height = this._calculateListHeight() + 'px';
-
-      // Fix layout bug
-      if (this._wrapperElement.style.marginTop === '') {
-        this._wrapperElement.style.marginTop = '-1px';
-      }
     }
 
     _calculateListHeight() {

--- a/css-components/components-src/stylus/components/list.styl
+++ b/css-components/components-src/stylus/components/list.styl
@@ -134,6 +134,9 @@ list__item()
   background-color var-list-background-color
   retina-list-border()
 
+.list:first-child
+  border-top 0
+
 .list__item
   list__item()
   padding var-list-item-padding

--- a/css-components/components-src/stylus/components/list.styl
+++ b/css-components/components-src/stylus/components/list.styl
@@ -137,6 +137,9 @@ list__item()
 .list:first-child
   border-top 0
 
+.list + .list
+  border-top 0
+
 .list__item
   list__item()
   padding var-list-item-padding

--- a/framework/views/lazyRepeat.js
+++ b/framework/views/lazyRepeat.js
@@ -53,7 +53,6 @@ limitations under the License.
 
         if (typeof oldReload === 'function') {
           userDelegate.reload = function() {
-            console.log("HI");
             oldReload();
             provider._onChange();
           }.bind(this);

--- a/framework/views/lazyRepeat.js
+++ b/framework/views/lazyRepeat.js
@@ -40,15 +40,30 @@ limitations under the License.
         this._provider = new ons._internal.LazyRepeatProvider(element[0].parentNode, element[0], internalDelegate);
         element.remove();
 
-        userDelegate.reload = function() {
-          this._provider._onChange();
-        }.bind(this);
+        this._injectReloadMethod(userDelegate, this._provider);
 
         // Render when number of items change.
         this._scope.$watch(internalDelegate.countItems.bind(internalDelegate), this._provider._onChange.bind(this._provider));
 
         this._scope.$on('$destroy', this._destroy.bind(this));
       },
+
+      _injectReloadMethod: function(userDelegate, provider) {
+        var oldReload = userDelegate.reload;
+
+        if (typeof oldReload === 'function') {
+          userDelegate.reload = function() {
+            console.log("HI");
+            oldReload();
+            provider._onChange();
+          }.bind(this);
+        }
+        else {
+          userDelegate.reload = function() {
+            provider._onChange();
+          }.bind(this);
+        }
+      }.bind(this),
 
       _getDelegate: function() {
         var delegate = this._scope.$eval(this._attrs.onsLazyRepeat);

--- a/framework/views/lazyRepeat.js
+++ b/framework/views/lazyRepeat.js
@@ -40,6 +40,10 @@ limitations under the License.
         this._provider = new ons._internal.LazyRepeatProvider(element[0].parentNode, element[0], internalDelegate);
         element.remove();
 
+        userDelegate.reload = function() {
+          this._provider._onChange();
+        }.bind(this);
+
         // Render when number of items change.
         this._scope.$watch(internalDelegate.countItems.bind(internalDelegate), this._provider._onChange.bind(this._provider));
 


### PR DESCRIPTION
@anatoo I've added a `reload()` method to the Delegate object.

I also fixed a bug with the layout of the wrapper element. 

Also, I made it easier to put elements before the list. Now you can do

```html
  <ons-page>
    <ons-toolbar>
      ...
    </ons-toolbar>
    <p>Before list</p>
    <ons-list>
      <ons-list-item ons-lazy-repeat="Delegate">
        ...
      </ons-list-item>
    </ons-list>
  </ons-page>
```

Without breaking the layout.