### PR TITLE
feat(css-components): Add "material" modifier to "page" class.

### DIFF
--- a/css-components/components-src/stylus/components/page.styl
+++ b/css-components/components-src/stylus/components/page.styl
@@ -38,3 +38,18 @@ var-page-background-color = $background-color
 
 .content-padded
   padding 8px
+
+.page--material
+  material-font()
+
+.page--material__content
+  material-font()
+  font-weight 400
+
+.page--material__content h1
+.page--material__content h2
+.page--material__content h3
+.page--material__content h4
+.page--material__content h5
+  material-font()
+  font-weight 400

--- a/css-components/components-src/stylus/components/util.styl
+++ b/css-components/components-src/stylus/components/util.styl
@@ -100,3 +100,4 @@ retina-query()
 
 material-font()
   font-family 'Roboto', 'Noto', sans-serif
+  -webkit-font-smoothing antialiased


### PR DESCRIPTION
@anatoo 

This will add Roboto/Noto font to `<ons-page>` elements by using "material" modifier:

I think this is necessary in order to override default Helvetica font.

```
<ons-page modifier="material">
...
</ons-page>
```