### PR TITLE
Fix 950

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ v2.0.0-alpha.2
  * ons-toolbar: Added "material" modifier.
  * ons-back-button: Change style when parent toolbar has modifier "material".
  * ons-list: Added "material" modifier.
+ * ons-page: Fixed [#950](https://github.com/OnsenUI/OnsenUI/issues/950)
 
 v1.3.11
 ----

--- a/core/css/common.css
+++ b/core/css/common.css
@@ -60,29 +60,29 @@ input, textarea {
   background: transparent !important;
 }
 
-.page__status-bar-fill ~ .page__content {
+.page__status-bar-fill + .page__background + .page__content {
   padding-top: 20px;
 }
 
-ons-toolbar ~ .page__content {
+ons-toolbar + .page__background + .page__content {
   top: 44px;
 }
 
-.navigation-bar--material ~ .page__content {
+.navigation-bar--material + .page__background + .page__content {
   top: 56px;
 }
 
-.page__status-bar-fill ~ ons-toolbar {
+.page__status-bar-fill + ons-toolbar {
   height: 64px;
 }
 
-.page__status-bar-fill ~ ons-toolbar > .center,
-.page__status-bar-fill ~ ons-toolbar > .left,
-.page__status-bar-fill ~ ons-toolbar > .right {
+.page__status-bar-fill + ons-toolbar > .center,
+.page__status-bar-fill + ons-toolbar > .left,
+.page__status-bar-fill + ons-toolbar > .right {
   padding-top: 20px;
 }
 
-.page__status-bar-fill ~ ons-toolbar ~ .page__content {
+.page__status-bar-fill + ons-toolbar + .page__background + .page__content {
   top: 64px;
   padding-top: 0px;
 }


### PR DESCRIPTION
@anatoo 

This fixes a bug with status bar filling on iOS9. The ~ selector doesn't work as expected in the new UIWebView so I have replaced with + selectors.

Please merge if there are no problems.