### PR TITLE
fix(ons-tab): closes #1017

### DIFF
--- a/core/elements/ons-tab.es6
+++ b/core/elements/ons-tab.es6
@@ -215,7 +215,7 @@ limitations under the License.
         const tabIndex = this._findTabIndex();
 
         window.OnsTabbarElement.rewritables.ready(tabbar, () => {
-          tabbar.setActiveTab(tabIndex, {animation: 'none'});
+          setImmediate(() => tabbar.setActiveTab(tabIndex, {animation: 'none'}));
         });
       }
 


### PR DESCRIPTION
Looks like `ons-tabbar` methods are not defined by the time `ons-tab` calls them if `active` attribute is present.