### PR TITLE
feat(ons-back-button): automatically hides if navigator has only 1 page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ v2.0.0-alpha.15
  * ons-splitter: Fixed [#952](https://github.com/OnsenUI/OnsenUI/issues/952).
  * core: Add support for Browserify.
  * ons.platform: uses cordova-plugin-device if installed.
+ * ons-back-button: automatically hides if navigator has only 1 page.
 
 v1.3.13
 ----

--- a/core/elements/ons-navigator.es6
+++ b/core/elements/ons-navigator.es6
@@ -172,6 +172,8 @@ limitations under the License.
       const leavePage = this._pages.pop();
       const enterPage = this._pages[this._pages.length - 1];
 
+      enterPage.updateBackButton();
+
       leavePage.element._hide();
       if (enterPage) {
         enterPage.element.style.display = 'block';
@@ -240,6 +242,7 @@ limitations under the License.
             element.style.display = 'none';
             this.insertBefore(element, this._pages[index].element);
             this._pages.splice(index, 0, pageObject);
+            this.getCurrentPage().updateBackButton();
 
             setTimeout(() => {
               unlock();
@@ -326,6 +329,7 @@ limitations under the License.
         while (this._pages.length > 1) {
           this._pages.shift().destroy();
         }
+        this._pages[0].updateBackButton();
         onTransitionEnd();
       };
 
@@ -435,6 +439,7 @@ limitations under the License.
       };
 
       this._pages.push(pageObject);
+      pageObject.updateBackButton();
 
       const done = () => {
         if (this._pages[this._pages.length - 2]) {

--- a/core/lib/navigator-page.es6
+++ b/core/lib/navigator-page.es6
@@ -37,6 +37,7 @@ limitations under the License.
       this.options = params.options;
       this.navigator = params.navigator;
       this.initialContent = params.initialContent;
+      this.backButton = util.findChildRecursively(this.element, 'ons-back-button');
 
       // Block events while page is being animated to stop scrolling, pressing buttons, etc.
       this._blockEvents = (event) => {
@@ -68,6 +69,16 @@ limitations under the License.
         }
       }
       return this._page;
+    }
+
+    updateBackButton() {
+      if(this.backButton) {
+        if(this.navigator._pages.length > 1) {
+          this.backButton.style.display = 'block';
+        } else {
+          this.backButton.style.display = 'none';
+        }
+      }
     }
 
     destroy() {

--- a/core/lib/ons-util.es6
+++ b/core/lib/ons-util.es6
@@ -21,16 +21,24 @@ limitations under the License.
   const util = ons._util = ons._util || {};
 
   /**
+   * @param {String/Function} query dot class name or node name or matcher function.
+   * @return {Function}
+   */
+  util.prepareQuery = (query) => {
+    return query instanceof Function
+      ? query
+      : query.substr(0, 1) === '.' ?
+        (node) => node.classList.contains(query.substr(1)) :
+        (node) => node.nodeName.toLowerCase() === query;
+  };
+
+  /**
    * @param {Element} element
    * @param {String/Function} query dot class name or node name or matcher function.
    * @return {HTMLElement/null}
    */
   util.findChild = (element, query) => {
-    const match = query instanceof Function
-      ? query
-      : query.substr(0, 1) === '.' ?
-        (node) => node.classList.contains(query.substr(1)) :
-        (node) => node.nodeName.toLowerCase() === query;
+    const match = util.prepareQuery(query);
 
     for (let i = 0; i < element.children.length; i++) {
       const node = element.children[i];
@@ -38,6 +46,29 @@ limitations under the License.
         return node;
       }
     }
+    return null;
+  };
+
+  /**
+   * @param {Element} element
+   * @param {String/Function} query dot class name or node name or matcher function.
+   * @return {HTMLElement/null}
+   */
+  util.findChildRecursively = (element, query) => {
+    const match = util.prepareQuery(query);
+
+    for (let i = 0; i < element.children.length; i++) {
+      const node = element.children[i];
+      if (match(node)) {
+        return node;
+      } else {
+        let nodeMatch = util.findChildRecursively(node, match);
+        if (nodeMatch) {
+          return nodeMatch;
+        }
+      }
+    }
+
     return null;
   };
 


### PR DESCRIPTION
This is Angular free so there is no need to use a watcher or `ng-show` anymore. Check if you like this implementation @argelius @anatoo 

Also, with the pointer to page's back-button added in Navigator page objects we can do something to modify back-button's popPage on demand. Something like `navigator.getCurrentPage().addOptionsToBackButton(object)`, so it could have `onTransitionEnd`, `refresh`, etc.