### PR TITLE
feat(components): 'var' attribute without Angular

### DIFF
--- a/core/elements/ons-alert-dialog.es6
+++ b/core/elements/ons-alert-dialog.es6
@@ -73,6 +73,10 @@ limitations under the License.
       this._visible = false;
       this._doorLock = new DoorLock();
       this._boundCancel = this._cancel.bind(this);
+
+      if (this.hasAttribute('var')) {
+        ons._defineVar(this.getAttribute('var'), this);
+      }
     }
 
     _compile() {

--- a/core/elements/ons-carousel.es6
+++ b/core/elements/ons-carousel.es6
@@ -124,6 +124,10 @@ limitations under the License.
       this._setupInitialIndex();
 
       this._saveLastState();
+
+      if (this.hasAttribute('var')) {
+        ons._defineVar(this.getAttribute('var'), this);
+      }
     }
 
     _onResize() {

--- a/core/elements/ons-dialog.es6
+++ b/core/elements/ons-dialog.es6
@@ -73,6 +73,10 @@ limitations under the License.
         baseClassName: 'DialogAnimator',
         defaultAnimation: this.getAttribute('animation')
       });
+
+      if (this.hasAttribute('var')) {
+        ons._defineVar(this.getAttribute('var'), this);
+      }
     }
 
     _compile() {

--- a/core/elements/ons-modal.es6
+++ b/core/elements/ons-modal.es6
@@ -48,6 +48,10 @@ limitations under the License.
 
       this._compile();
       ModifierUtil.initModifier(this, scheme);
+
+      if (this.hasAttribute('var')) {
+        ons._defineVar(this.getAttribute('var'), this);
+      }
     }
 
     getDeviceBackButtonHandler() {

--- a/core/elements/ons-navigator.es6
+++ b/core/elements/ons-navigator.es6
@@ -73,6 +73,10 @@ limitations under the License.
         baseClassName: 'NavigatorTransitionAnimator',
         defaultAnimation: this.getAttribute('animation')
       });
+
+      if (this.hasAttribute('var')) {
+        ons._defineVar(this.getAttribute('var'), this);
+      }
     }
 
     /**

--- a/core/elements/ons-page.es6
+++ b/core/elements/ons-page.es6
@@ -39,6 +39,10 @@ limitations under the License.
       this.eventDetail = {
         page: this
       };
+
+      if (this.hasAttribute('var')) {
+        ons._defineVar(this.getAttribute('var'), this);
+      }
     }
 
     attachedCallback() {

--- a/core/elements/ons-popover.es6
+++ b/core/elements/ons-popover.es6
@@ -80,6 +80,10 @@ limitations under the License.
 
 
       this._animatorFactory = this._createAnimatorFactory();
+
+      if (this.hasAttribute('var')) {
+        ons._defineVar(this.getAttribute('var'), this);
+      }
     }
 
     _createAnimatorFactory() {

--- a/core/elements/ons-pull-hook.es6
+++ b/core/elements/ons-pull-hook.es6
@@ -42,6 +42,10 @@ limitations under the License.
 
       this._setState(STATE_INITIAL, true);
       this._setStyle();
+
+      if (this.hasAttribute('var')) {
+        ons._defineVar(this.getAttribute('var'), this);
+      }
     }
 
     _createScrollElement() {

--- a/core/elements/ons-switch.es6
+++ b/core/elements/ons-switch.es6
@@ -101,6 +101,10 @@ limitations under the License.
 
       this._updateForCheckedAttribute();
       this._updateForDisabledAttribute();
+
+      if (this.hasAttribute('var')) {
+        ons._defineVar(this.getAttribute('var'), this);
+      }
     }
 
     _updateForCheckedAttribute() {

--- a/core/elements/ons-tabbar.es6
+++ b/core/elements/ons-tabbar.es6
@@ -87,6 +87,10 @@ limitations under the License.
       this._compile();
       this._contentElement = ons._util.findChild(this, '.tab-bar__content');
       ModifierUtil.initModifier(this, scheme);
+
+      if (this.hasAttribute('var')) {
+        ons._defineVar(this.getAttribute('var'), this);
+      }
     }
 
     _compile() {

--- a/core/elements/ons-toolbar-button.es6
+++ b/core/elements/ons-toolbar-button.es6
@@ -28,6 +28,10 @@ limitations under the License.
       this.classList.add('navigation-bar__line-height');
 
       ModifierUtil.initModifier(this, scheme);
+
+      if (this.hasAttribute('var')) {
+        ons._defineVar(this.getAttribute('var'), this);
+      }
     }
 
     attributeChangedCallback(name, last, current) {

--- a/core/elements/ons-toolbar.es6
+++ b/core/elements/ons-toolbar.es6
@@ -34,6 +34,10 @@ limitations under the License.
 
       this._tryToEnsureNodePosition();
       setImmediate(() => this._tryToEnsureNodePosition());
+
+      if (this.hasAttribute('var')) {
+        ons._defineVar(this.getAttribute('var'), this);
+      }
     }
 
     attributeChangedCallback(name, last, current) {

--- a/core/lib/ons.es6
+++ b/core/lib/ons.es6
@@ -24,6 +24,10 @@ limitations under the License.
     animationsDisabled: false
   };
 
+  // Object to attach component variables to when using the var="..." attribute.
+  // Can be set to null to avoid polluting the global scope.
+  ons.componentBase = window;
+
   waitDeviceReady();
 
   /**
@@ -52,6 +56,43 @@ limitations under the License.
       callback();
     } else {
       ons._readyLock.waitUnlock(callback);
+    }
+  };
+
+  /**
+   * Define a variable to JavaScript global scope.
+   *
+   * Util.defineVar('foo', 'foo-value');
+   * // => window.foo is now 'foo-value'
+   *
+   * Util.defineVar('foo.bar', 'foo-bar-value');
+   * // => window.foo.bar is now 'foo-bar-value'
+   *
+   * @param {String} rawName
+   * @param object
+   */
+  ons._defineVar = (name, object) => {
+    let names = name.split(/\./);
+
+    function set(container, names, object) {
+      let partName;
+      for (let i = 0; i < names.length - 1; i++) {
+        partName = names[i];
+        if (container[partName] === undefined || container[partName] === null) {
+          container[partName] = {};
+        }
+        container = container[partName];
+      }
+
+      container[names[names.length - 1]] = object;
+
+      if (container[names[names.length - 1]] !== object) {
+        throw new Error('Cannot set var="' + name + '" because it will overwrite a read-only variable.');
+      }
+    }
+
+    if (ons.componentBase) {
+      set(ons.componentBase, names, object);
     }
   };
 

--- a/framework/js/onsen.js
+++ b/framework/js/onsen.js
@@ -299,10 +299,6 @@ limitations under the License.
   function initOnsenFacade() {
     ons._onsenService = null;
 
-    // Object to attach component variables to when using the var="..." attribute.
-    // Can be set to null to avoid polluting the global scope.
-    ons.componentBase = window;
-
     /**
      * Bootstrap this document as a Onsen UI application.
      *


### PR DESCRIPTION
@argelius I guess we also need `var` attribute when using OnsenUI without Angular. I didn't remove [this code](https://github.com/OnsenUI/OnsenUI/blob/master/framework/services/onsen.js#L456) from `angular-onsenui.js` to avoid possible BC breaks so it overwrites these variables with the old stuff (it always loads after `onsenui.js`). Perhaps we should remove it and only let WebComponents to write in JavaScript global scope and Angular in its own scope?

Also, I added `var` attribute for every documented component that had it with Angular. Should we add it to `ons-fab`, `ons-progress`, etc? And is it necessary on `ons-toolbar` and `ons-toolbar-button` (they have it right now)?
