### PR TITLE
fix(slidingMenu): Fix slidingMenu currentPageUrl bug

### DIFF
--- a/framework/views/slidingMenu.js
+++ b/framework/views/slidingMenu.js
@@ -447,7 +447,7 @@ limitations under the License.
           options.callback();
         }.bind(this);
 
-        if (this.currentPageUrl === pageUrl) {
+        if (this._currentPageUrl === pageUrl) {
           done();
           return;
         }


### PR DESCRIPTION
I guess slidingMenu's current page is stored in _currentPageUrl, not in currentPageUrl.