### PR TITLE
fix(ons-tabbar): Reset style for persistent tabs. Fixes #1132

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 CHANGELOG
 ====
 
+v2.0.0-beta.4
+----
+ * ons-tabbar: Fixed [#1132](https://github.com/OnsenUI/OnsenUI/issues/1132).
+
 v2.0.0-beta.3
 ----
  * core: Fixed animationOptions parsing.

--- a/core/src/elements/ons-tabbar/index.es6
+++ b/core/src/elements/ons-tabbar/index.es6
@@ -385,6 +385,8 @@ class TabbarElement extends BaseElement {
     if (!util.isAttached(element)) {
       this._contentElement.appendChild(element);
     }
+
+    element.removeAttribute('style');
     this._switchPage(element, options);
   }
 


### PR DESCRIPTION
@argelius Persistent tabs maintain transform/opacity changes depending on the animation. Removing `style` attribute works well but do you think it would be a problem for anything else?

It's also possible to just reset the necessary properties:

`element.style.transform = element.style.transition = element.style.display = element.style.opacity = '';`
