### PR TITLE
fix(ons-page): fix status bar fill for iOS and ons-bottom-toolbar

### DIFF
--- a/core/css/common.css
+++ b/core/css/common.css
@@ -60,7 +60,8 @@ input, textarea {
   background: transparent !important;
 }
 
-.page__status-bar-fill + .page__background + .page__content {
+.page__status-bar-fill + .page__background + .page__content,
+.page__status-bar-fill + .page__bottom-bar-fill + .page__background + .page__content {
   padding-top: 20px;
 }
 
@@ -73,33 +74,37 @@ ons-toolbar + .page__background + .page__content {
   top: 56px;
 }
 
-.page__status-bar-fill + ons-toolbar {
+.page__status-bar-fill + ons-toolbar,
+.page__status-bar-fill + .page__bottom-bar-fill + ons-toolbar {
   height: 64px;
 }
 
-.page__status-bar-fill + ons-toolbar[modifier~="material"] {
+.page__status-bar-fill ~ ons-toolbar[modifier~="material"] {
   height: 76px;
 }
 
 .page__status-bar-fill + ons-toolbar > .center,
 .page__status-bar-fill + ons-toolbar > .left,
-.page__status-bar-fill + ons-toolbar > .right {
+.page__status-bar-fill + ons-toolbar > .right,
+.page__status-bar-fill + .page__bottom-bar-fill + ons-toolbar > .center,
+.page__status-bar-fill + .page__bottom-bar-fill + ons-toolbar > .left,
+.page__status-bar-fill + .page__bottom-bar-fill + ons-toolbar > .right {
   padding-top: 20px;
 }
 
-.page__status-bar-fill + ons-toolbar[modifier~="material"] > .center,
-.page__status-bar-fill + ons-toolbar[modifier~="material"] > .left,
-.page__status-bar-fill + ons-toolbar[modifier~="material"] > .right {
+.page__status-bar-fill ~ ons-toolbar[modifier~="material"] > .center,
+.page__status-bar-fill ~ ons-toolbar[modifier~="material"] > .left,
+.page__status-bar-fill ~ ons-toolbar[modifier~="material"] > .right {
   height: 76px;
 }
 
-
-.page__status-bar-fill + ons-toolbar + .page__background + .page__content {
+.page__status-bar-fill + ons-toolbar + .page__background + .page__content,
+.page__status-bar-fill + .page__bottom-bar-fill + ons-toolbar + .page__background + .page__content {
   top: 64px;
   padding-top: 0px;
 }
 
-.page__status-bar-fill + ons-toolbar[modifier~="material"] + .page__background + .page__content {
+.page__status-bar-fill ~ ons-toolbar[modifier~="material"] + .page__background + .page__content {
   top: 76px;
 }
 
@@ -126,7 +131,7 @@ ons-toolbar + .page__background + .page__content {
   padding-top: 22px;
 }
 
-ons-tabbar[position="top"] .page__status-bar-fill + .page__background + .page__content {
+ons-tabbar[position="top"] .page__status-bar-fill ~ .page__background + .page__content {
   padding-top: 0px;
 }
 


### PR DESCRIPTION
The fix added for [iOS9](https://github.com/OnsenUI/OnsenUI/commit/eec03eeb6624f995ada9e949659c06f1b553b3d1)
causes an issue if an `ons-bottom-toolbar` is being used (either with an
`ons-toolbar` or stand alone).

When an `ons-bottom-toolbar` is being used the CSS selectors for
adjusting the page header to account for the iOS status bar are no
longer applied because an extra `<div />` is added to the DOM.

Fixes #1047.