### PR TITLE
fix(ons-navigator): fix the cancelIfRunning functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ v2.0.0-beta.6
  * css-components: Fixed [#1162](https://github.com/OnsenUI/OnsenUI/issues/1162).
  * ons-input: Add "ons-input" component and remove "ons-material-input" component.
  * ons-range: Add "ons-range" component.
+ * ons-navigator: Fixed [#1175](https://github.com/OnsenUI/OnsenUI/issues/1175).
 
 v2.0.0-beta.5
 ----

--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -403,7 +403,9 @@ class NavigatorElement extends BaseElement {
     if (this._emitPrePushEvent()) {
       return;
     }
-
+    
+    this._isPushing = true;
+    
     this._doorLock.waitUnlock(() => this._pushPage(page, options));
   }
 


### PR DESCRIPTION
Currently if a user manages to click twice on a menu element even with  `{ cancelIfRunning : true }` he will have the same page pushed twice (Issue #1175).
The reason for that is that _isPushing is being set in a callback function, meaning that the second execution of the click handler can start before the flag is set to true. This flag isn't used in many places so side effects from this should not exist. Both `core-test` and `e2e-test` show no errors after this change.
The original assignment of _isPushing to true is left unchanged due to the function _pushPageDOM being called in bringPageTop.
Replication of the bug is hard to achieve by hand so it can be done with [this codepen](http://codepen.io/IliaSky/pen/jWGWeg?editors=001) and [this repeater script](https://github.com/OnsenUI/OnsenUI/files/91770/click.record.txt) (.record). The codepen also shows the relative part of the fix, so it can be enabled and seen easily.