### PR TITLE
refactor(ons-splitter): Renamed some methods.

### DIFF
--- a/bindings/angular1/directives/splitter.js
+++ b/bindings/angular1/directives/splitter.js
@@ -124,23 +124,23 @@
 
 /**
  * @ngdoc method
- * @signature leftIsOpened()
+ * @signature leftIsOpen()
  * @return {Boolean}
- *   [en]Whether the left ons-splitter-side on collapse mode is opened.[/en]
+ *   [en]Whether the left ons-splitter-side on collapse mode is open.[/en]
  *   [ja]左のons-splitter-sideが開いているかどうかを返します。[/ja]
  * @description
- *   [en]Determines whether the left ons-splitter-side on collapse mode is opened.[/en]
+ *   [en]Determines whether the left ons-splitter-side on collapse mode is open.[/en]
  *   [ja]左のons-splitter-side要素が開いているかどうかを返します。[/ja]
  */
 
 /**
  * @ngdoc method
- * @signature rightIsOpened()
+ * @signature rightIsOpen()
  * @return {Boolean}
- *   [en]Whether the right ons-splitter-side on collapse mode is opened.[/en]
+ *   [en]Whether the right ons-splitter-side on collapse mode is open.[/en]
  *   [ja]右のons-splitter-sideが開いているかどうかを返します。[/ja]
  * @description
- *   [en]Determines whether the right ons-splitter-side on collapse mode is opened.[/en]
+ *   [en]Determines whether the right ons-splitter-side on collapse mode is open.[/en]
  *   [ja]右のons-splitter-side要素が開いているかどうかを返します。[/ja]
  */
 

--- a/core/src/elements/ons-splitter-side.js
+++ b/core/src/elements/ons-splitter-side.js
@@ -129,7 +129,7 @@ class MediaQueryCollapseDetection extends CollapseDetection {
 }
 
 class BaseMode {
-  isOpened() {
+  isOpen() {
     return false;
   }
   openMenu() {
@@ -150,7 +150,7 @@ class SplitMode extends BaseMode {
     this._element = element;
   }
 
-  isOpened() {
+  isOpen() {
     return false;
   }
 
@@ -190,8 +190,8 @@ class CollapseMode extends BaseMode {
     return 'closed';
   }
 
-  static get OPENED_STATE() {
-    return 'opened';
+  static get OPEN_STATE() {
+    return 'open';
   }
 
   static get CHANGING_STATE() {
@@ -215,7 +215,7 @@ class CollapseMode extends BaseMode {
     return this._lock.isLocked();
   }
 
-  isOpened() {
+  isOpen() {
     return this._state !== CollapseMode.CLOSED_STATE;
   }
 
@@ -228,7 +228,7 @@ class CollapseMode extends BaseMode {
       return;
     }
 
-    if (this._openedOtherSideMenu()) {
+    if (this._isOpenOtherSideMenu()) {
       return;
     }
 
@@ -250,7 +250,7 @@ class CollapseMode extends BaseMode {
   _onDragStart(event) {
     this._ignoreDrag = false;
 
-    if (!this.isOpened() && this._openedOtherSideMenu()) {
+    if (!this.isOpen() && this._isOpenOtherSideMenu()) {
       this._ignoreDrag = true;
     } else if (this._element._swipeTargetWidth > 0) {
       const distance = this._element._isLeftSide()
@@ -270,9 +270,9 @@ class CollapseMode extends BaseMode {
 
     const startEvent = event.gesture.startEvent;
 
-    if (!('isOpened' in startEvent)) {
-      startEvent.isOpened = this.isOpened();
-      startEvent.distance = startEvent.isOpened ? this._element._getWidthInPixel() : 0;
+    if (!('isOpen' in startEvent)) {
+      startEvent.isOpen = this.isOpen();
+      startEvent.distance = startEvent.isOpen ? this._element._getWidthInPixel() : 0;
       startEvent.width = this._element._getWidthInPixel();
     }
 
@@ -286,7 +286,7 @@ class CollapseMode extends BaseMode {
       return;
     }
 
-    const distance = startEvent.isOpened ? deltaDistance + width : deltaDistance;
+    const distance = startEvent.isOpen ? deltaDistance + width : deltaDistance;
     const normalizedDistance = Math.max(0, Math.min(width, distance));
 
     startEvent.distance = normalizedDistance;
@@ -299,7 +299,7 @@ class CollapseMode extends BaseMode {
     const deltaX = event.gesture.deltaX;
     const deltaDistance = this._element._isLeftSide() ? deltaX : -deltaX;
     const width = event.gesture.startEvent.width;
-    const distance = event.gesture.startEvent.isOpened ? deltaDistance + width : deltaDistance;
+    const distance = event.gesture.startEvent.isOpen ? deltaDistance + width : deltaDistance;
     const direction = event.gesture.interimDirection;
     const shouldOpen =
       (this._element._isLeftSide() && direction === 'right' && distance > width * this._element._getThresholdRatioIfShouldOpen()) ||
@@ -322,7 +322,7 @@ class CollapseMode extends BaseMode {
       if (this._animator.isActivated()) {
         this._animator.layoutOnClose();
       }
-    } else if (this._state === CollapseMode.OPENED_STATE) {
+    } else if (this._state === CollapseMode.OPEN_STATE) {
       if (this._animator.isActivated()) {
         this._animator.layoutOnOpen();
       }
@@ -346,11 +346,11 @@ class CollapseMode extends BaseMode {
   /**
    * @return {Boolean}
    */
-  _openedOtherSideMenu() {
+  _isOpenOtherSideMenu() {
     return util.arrayFrom(this._element.parentElement.children).filter(child => {
       return child.nodeName.toLowerCase() === 'ons-splitter-side' && this._element !== child;
     }).filter(side => {
-      return side.isOpened();
+      return side.isOpen();
     }).length > 0;
   }
 
@@ -379,7 +379,7 @@ class CollapseMode extends BaseMode {
       return false;
     }
 
-    if (this._openedOtherSideMenu()) {
+    if (this._isOpenOtherSideMenu()) {
       return false;
     }
 
@@ -397,13 +397,13 @@ class CollapseMode extends BaseMode {
     };
 
     if (options.withoutAnimation) {
-      this._state = CollapseMode.OPENED_STATE;
+      this._state = CollapseMode.OPEN_STATE;
       this.layout();
       done();
     } else {
       this._state = CollapseMode.CHANGING_STATE;
       this._animator.open(() => {
-        this._state = CollapseMode.OPENED_STATE;
+        this._state = CollapseMode.OPEN_STATE;
         this.layout();
         done();
       });
@@ -417,7 +417,7 @@ class CollapseMode extends BaseMode {
    * @return {Boolean}
    */
   closeMenu(options = {}) {
-    if (this._state !== CollapseMode.OPENED_STATE) {
+    if (this._state !== CollapseMode.OPEN_STATE) {
       return false;
     }
 
@@ -717,8 +717,8 @@ class SplitterSideElement extends BaseElement {
   /**
    * @return {Boolean}
    */
-  isOpened() {
-    return this._getModeStrategy().isOpened();
+  isOpen() {
+    return this._getModeStrategy().isOpen();
   }
 
   /**
@@ -771,7 +771,7 @@ class SplitterSideElement extends BaseElement {
    * @param {Object} [options]
    */
   toggle(options = {}) {
-    return this.isOpened() ? this.close(options) : this.open(options);
+    return this.isOpen() ? this.close(options) : this.open(options);
   }
 
   attributeChangedCallback(name, last, current) {

--- a/core/src/elements/ons-splitter-side.spec.js
+++ b/core/src/elements/ons-splitter-side.spec.js
@@ -49,12 +49,12 @@ describe('OnsSplitterSideElement', () => {
     });
   });
 
-  describe('#isOpened()', () => {
+  describe('#isOpen()', () => {
     it('should return boolean', (done) => {
-      expect(right.isOpened()).to.be.false;
-      expect(left.isOpened()).to.be.false;
+      expect(right.isOpen()).to.be.false;
+      expect(left.isOpen()).to.be.false;
       right.open({callback: () => {
-        expect(right.isOpened()).to.be.true;
+        expect(right.isOpen()).to.be.true;
         done();
       }});
     });
@@ -62,9 +62,9 @@ describe('OnsSplitterSideElement', () => {
 
   describe('#toggle()', () => {
     it('toggle open or close state', (done) => {
-      expect(right.isOpened()).to.be.false;
+      expect(right.isOpen()).to.be.false;
       right.toggle({callback: () => {
-        expect(right.isOpened()).to.be.true;
+        expect(right.isOpen()).to.be.true;
         done();
       }});
     });

--- a/core/src/elements/ons-splitter/index.js
+++ b/core/src/elements/ons-splitter/index.js
@@ -165,26 +165,26 @@ class SplitterElement extends BaseElement {
   /**
    * @return {Boolean}
    */
-  leftIsOpened() {
-    return this._isOpened('left');
+  leftIsOpen() {
+    return this._isOpen('left');
   }
 
   /**
    * @return {Boolean}
    */
-  rightIsOpened() {
-    return this._isOpened('right');
+  rightIsOpen() {
+    return this._isOpen('right');
   }
 
   /**
    * @param {String} side
    * @return {Boolean}
    */
-  _isOpened(side) {
+  _isOpen(side) {
     const menu = this._getSideElement(side);
 
     if (menu) {
-      return menu.isOpened();
+      return menu.isOpen();
     }
 
     return false;
@@ -208,12 +208,12 @@ class SplitterElement extends BaseElement {
     const left = this._getSideElement('left');
     const right = this._getSideElement('right');
 
-    if (left.isOpened()) {
+    if (left.isOpen()) {
       left.close();
       return;
     }
 
-    if (right.isOpened()) {
+    if (right.isOpen()) {
       right.close();
       return;
     }

--- a/core/src/elements/ons-splitter/index.spec.js
+++ b/core/src/elements/ons-splitter/index.spec.js
@@ -68,7 +68,7 @@ describe('OnsSplitterElement', () => {
     it('should open right ons-splitter-side', () => {
       expect(splitter.openRight()).to.be.true;
       expect(splitter.openLeft()).to.be.false;
-      expect(splitter.rightIsOpened()).to.be.true;
+      expect(splitter.rightIsOpen()).to.be.true;
     });
   });
 
@@ -80,12 +80,12 @@ describe('OnsSplitterElement', () => {
 
   describe('#closeRight()', () => {
     it('should close right ons-splitter-side', (done) => {
-      expect(splitter.rightIsOpened()).to.be.false;
+      expect(splitter.rightIsOpen()).to.be.false;
 
       expect(splitter.openRight({callback: () => {
-        expect(splitter.rightIsOpened()).to.be.true;
+        expect(splitter.rightIsOpen()).to.be.true;
         expect(splitter.closeRight({callback: () => {
-          expect(splitter.rightIsOpened()).to.be.false;
+          expect(splitter.rightIsOpen()).to.be.false;
           done();
         }})).to.be.true;
       }})).to.be.true;


### PR DESCRIPTION
@argelius I think this is better. Sliding menu still has a `isOpened` method but I guess we should not change since it's a BC.