### PR TITLE
Avoid compiling twice.

### DIFF
--- a/core/src/elements/ons-alert-dialog/index.js
+++ b/core/src/elements/ons-alert-dialog/index.js
@@ -84,10 +84,16 @@ class AlertDialogElement extends BaseElement {
   }
 
   createdCallback() {
-    this._compile();
-    //this._mask = this._createMask(this.getAttribute('mask-color'));
+    if (!this.hasAttribute('_compiled')) {
+      this._compile();
+      ModifierUtil.initModifier(this, scheme);
 
-    ModifierUtil.initModifier(this, scheme);
+      this.setAttribute('_compiled', '');
+    }
+
+    this._visible = false;
+    this._doorLock = new DoorLock();
+    this._boundCancel = this._cancel.bind(this);
 
     this._animatorFactory = new AnimatorFactory({
       animators: _animatorDict,
@@ -95,10 +101,6 @@ class AlertDialogElement extends BaseElement {
       baseClassName: 'AlertDialogAnimator',
       defaultAnimation: this.getAttribute('animation')
     });
-
-    this._visible = false;
-    this._doorLock = new DoorLock();
-    this._boundCancel = this._cancel.bind(this);
   }
 
   _compile() {

--- a/core/src/elements/ons-alert-dialog/index.spec.js
+++ b/core/src/elements/ons-alert-dialog/index.spec.js
@@ -254,4 +254,14 @@ describe('OnsAlertDialogElement', () => {
       window.OnsAlertDialogElement.registerAnimator('hoge', MyAnimator);
     });
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-alert-dialog></ons-alert-dialog>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });

--- a/core/src/elements/ons-back-button.js
+++ b/core/src/elements/ons-back-button.js
@@ -28,10 +28,15 @@ var scheme = {
 class BackButtonElement extends BaseElement {
 
   createdCallback() {
+    if (!this.hasAttribute('_compiled')) {
+      this._compile();
+      ModifierUtil.initModifier(this, scheme);
+
+      this.setAttribute('_compiled', '');
+    }
+
     this._options = {};
-    this._compile();
     this._boundOnClick = this._onClick.bind(this);
-    ModifierUtil.initModifier(this, scheme);
   }
 
   _compile() {

--- a/core/src/elements/ons-back-button.spec.js
+++ b/core/src/elements/ons-back-button.spec.js
@@ -141,4 +141,14 @@ describe('OnsBackButtonElement', () => {
       });
     });
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-back-button>Back</ons-back-button>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });

--- a/core/src/elements/ons-bottom-toolbar.spec.js
+++ b/core/src/elements/ons-bottom-toolbar.spec.js
@@ -39,4 +39,14 @@ describe('ons-bottom-toolbar', () => {
     expect(element.style.position).to.equal('static');
     expect(element.style.position).not.to.equal('absolute');
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-bottom-toolbar></ons-bottom-toolbar>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });

--- a/core/src/elements/ons-button.spec.js
+++ b/core/src/elements/ons-button.spec.js
@@ -20,5 +20,15 @@ describe('ons-button', () => {
     expect(element.classList.contains('button--piyo')).to.be.true;
     expect(element.classList.contains('button--fuga')).to.be.true;
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-button>Button</ons-button>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });
 

--- a/core/src/elements/ons-carousel-item.spec.js
+++ b/core/src/elements/ons-carousel-item.spec.js
@@ -21,5 +21,15 @@ describe('OnsCarouselItemElement', () => {
     expect(carouselItem.classList.contains('carousel-item--piyo')).to.be.true;
     expect(carouselItem.classList.contains('carousel-item--fuga')).to.be.true;
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-carousel-item>Content</ons-carousel-item>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });
 

--- a/core/src/elements/ons-carousel.spec.js
+++ b/core/src/elements/ons-carousel.spec.js
@@ -451,5 +451,21 @@ describe('OnsCarouselElement', () => {
       expect(carousel.getActiveCarouselItemIndex()).to.equal(2);
     });
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = `
+        <ons-carousel>
+        <ons-carousel-item>Item 1</ons-carousel-item>
+        <ons-carousel-item>Item 2</ons-carousel-item>
+        <ons-carousel-item>Item 3</ons-carousel-item>
+        </ons-carosel>
+      `;
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });
 

--- a/core/src/elements/ons-col.spec.js
+++ b/core/src/elements/ons-col.spec.js
@@ -45,5 +45,15 @@ describe('OnsColElement', () => {
       expect(element.style.maxWidth ).to.equal('100px');
     });
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-col width="50px"></ons-col>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });
 

--- a/core/src/elements/ons-dialog/index.js
+++ b/core/src/elements/ons-dialog/index.js
@@ -63,8 +63,12 @@ class DialogElement extends BaseElement {
   }
 
   createdCallback() {
-    this._compile();
-    ModifierUtil.initModifier(this, scheme);
+    if (!this.hasAttribute('_compiled')) {
+      this._compile();
+      ModifierUtil.initModifier(this, scheme);
+
+      this.setAttribute('_compiled', '');
+    }
 
     this._visible = false;
     this._doorLock = new DoorLock();
@@ -79,10 +83,6 @@ class DialogElement extends BaseElement {
   }
 
   _compile() {
-    if (util.findChild(this, '.dialog') && util.findChild(this, '.dialog-mask')) {
-      return;
-    }
-
     const style = this.getAttribute('style');
 
     this.style.display = 'none';

--- a/core/src/elements/ons-dialog/index.spec.js
+++ b/core/src/elements/ons-dialog/index.spec.js
@@ -56,6 +56,14 @@ describe('OnsDialogElement', () => {
       let dialog = ons._util.createElement('<ons-dialog style="background-color: red"></ons-dialog>');
       expect(dialog._dialog.style.backgroundColor).to.equal('red');
     });
+
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-dialog></ons-dialog>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
   });
 
   describe('#getDeviceBackButtonHandler()', () => {

--- a/core/src/elements/ons-fab.js
+++ b/core/src/elements/ons-fab.js
@@ -22,8 +22,13 @@ const scheme = {
 class FabElement extends BaseElement {
 
   createdCallback() {
-    this._compile();
-    ModifierUtil.initModifier(this, scheme);
+    if (!this.hasAttribute('_compiled')) {
+      this._compile();
+      ModifierUtil.initModifier(this, scheme);
+
+      this.setAttribute('_compiled', '');
+    }
+
     this.classList.add('fab');
     this._updatePosition();
     this.hide();

--- a/core/src/elements/ons-fab.spec.js
+++ b/core/src/elements/ons-fab.spec.js
@@ -206,4 +206,14 @@ describe('OnsFabElement', () => {
       expect(spy).to.have.been.called.once;
     });
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-fab></ons-fab>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });

--- a/core/src/elements/ons-gesture-detector.spec.js
+++ b/core/src/elements/ons-gesture-detector.spec.js
@@ -8,4 +8,14 @@ describe('OnsGestureDetectorElement', () => {
   it('is correctly created', () => {
     expect(new OnsGestureDetectorElement()).to.be.ok;
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-gesture-detector></ons-gesture-detector>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });

--- a/core/src/elements/ons-icon.spec.js
+++ b/core/src/elements/ons-icon.spec.js
@@ -49,4 +49,14 @@ describe('OnsIconElement', () => {
     expect(element.classList.contains('fa-6x')).not.to.be.true;
     expect(element.classList.contains('fa-5x')).not.to.be.true;
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-icon icon="fa-twitter" size="10px"></ons-icon>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });

--- a/core/src/elements/ons-input.js
+++ b/core/src/elements/ons-input.js
@@ -44,8 +44,13 @@ const INPUT_ATTRIBUTES = [
 class MaterialInputElement extends BaseElement {
 
   createdCallback() {
-    this._compile();
-    ModifierUtil.initModifier(this, scheme);
+    if (!this.hasAttribute('_compiled')) {
+      this._compile();
+      ModifierUtil.initModifier(this, scheme);
+
+      this.setAttribute('_compiled', '');
+    }
+
     this._updateLabel();
     this._updateLabelColor();
     this._updateBoundAttributes();
@@ -58,10 +63,6 @@ class MaterialInputElement extends BaseElement {
   }
 
   _compile() {
-    if (this._input) {
-      return;
-    }
-
     this.appendChild(document.createElement('input'));
     this._input.classList.add('text-input');
     this.appendChild(document.createElement('span'));

--- a/core/src/elements/ons-list-header.spec.js
+++ b/core/src/elements/ons-list-header.spec.js
@@ -25,4 +25,14 @@ describe('ons-list-header', () => {
     expect(element.classList.contains('list__header--piyo')).to.be.true;
     expect(element.classList.contains('list__header--fuga')).to.be.true;
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-list-header>Content</ons-list-header>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });

--- a/core/src/elements/ons-list-item.spec.js
+++ b/core/src/elements/ons-list-item.spec.js
@@ -83,4 +83,14 @@ describe('OnsListItemElement', () => {
       expect(listItem.style.backgroundColor).to.equal(origColor);
     });
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-list-item>Content</ons-list-item>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });

--- a/core/src/elements/ons-list.spec.js
+++ b/core/src/elements/ons-list.spec.js
@@ -25,4 +25,20 @@ describe('ons-list', () => {
     expect(element.classList.contains('list--piyo')).to.be.true;
     expect(element.classList.contains('list--fuga')).to.be.true;
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = `
+        <ons-list>
+          <ons-list-header>Content</ons-list-header>
+          <ons-list-item>Content</ons-list-item>
+          <ons-list-item>Content</ons-list-item>
+        </ons-list>
+      `;
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });

--- a/core/src/elements/ons-modal/index.js
+++ b/core/src/elements/ons-modal/index.js
@@ -39,16 +39,21 @@ const _animatorDict = {
 class ModalElement extends BaseElement {
 
   createdCallback() {
+    if (!this.hasAttribute('_compiled')) {
+      this._compile();
+      ModifierUtil.initModifier(this, scheme);
+
+      this.setAttribute('_compiled', '');
+    }
+
     this._doorLock = new DoorLock();
+
     this._animatorFactory = new AnimatorFactory({
       animators: _animatorDict,
       baseClass: ModalAnimator,
       baseClassName: 'ModalAnimator',
       defaultAnimation: this.getAttribute('animation')
     });
-
-    this._compile();
-    ModifierUtil.initModifier(this, scheme);
   }
 
   getDeviceBackButtonHandler() {

--- a/core/src/elements/ons-modal/index.spec.js
+++ b/core/src/elements/ons-modal/index.spec.js
@@ -36,6 +36,14 @@ describe('OnsModalElement', () => {
       element.appendChild(wrapper);
       expect(element.children[0].classList.contains('modal__content')).to.be.true;
     });
+
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-modal></ons-modal>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
   });
 
   describe('#show()', () => {

--- a/core/src/elements/ons-navigator/index.spec.js
+++ b/core/src/elements/ons-navigator/index.spec.js
@@ -545,4 +545,14 @@ describe('OnsNavigatorElement', () => {
       window.OnsNavigatorElement.registerAnimator('hoge', MyAnimator);
     });
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-navigator></ons-navigator>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });

--- a/core/src/elements/ons-page.js
+++ b/core/src/elements/ons-page.js
@@ -33,8 +33,14 @@ class PageElement extends BaseElement {
 
   createdCallback() {
     this.classList.add('page');
-    this._compile();
-    ModifierUtil.initModifier(this, scheme);
+
+    if (!this.hasAttribute('_compiled')) {
+      this._compile();
+      ModifierUtil.initModifier(this, scheme);
+
+      this.setAttribute('_compiled', '');
+    }
+
     this._isShown = false;
     this._isMuted = this.hasAttribute('_muted');
     this._skipInit = this.hasAttribute('_skipinit');
@@ -197,10 +203,6 @@ class PageElement extends BaseElement {
   }
 
   _compile() {
-    if (util.findChild(this, '.page__background') && util.findChild(this, '.page__content')) {
-      return;
-    }
-
     const background = document.createElement('div');
     background.classList.add('page__background');
 

--- a/core/src/elements/ons-page.spec.js
+++ b/core/src/elements/ons-page.spec.js
@@ -198,9 +198,11 @@ describe('OnsPageElement', () => {
 
   describe('#_compile()', () => {
     it('does not compile twice', () => {
-      var formerLastChild = element.lastChild;
-      element._compile();
-      expect(element.lastChild).to.equal(formerLastChild);
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-page></ons-page>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
     });
 
     it('uses style attribute', () => {

--- a/core/src/elements/ons-popover/index.js
+++ b/core/src/elements/ons-popover/index.js
@@ -65,15 +65,11 @@ class PopoverElement extends BaseElement {
   }
 
   createdCallback() {
-    this._compile();
-    this.style.display = 'none';
-    ModifierUtil.initModifier(this, scheme);
+    if (!this.hasAttribute('_compiled')) {
+      this._compile();
+      ModifierUtil.initModifier(this, scheme);
 
-    this._mask.style.zIndex = '20000';
-    this._popover.style.zIndex = '20001';
-
-    if (this.hasAttribute('mask-color')) {
-      this._mask.style.backgroundColor = this.getAttribute('mask-color');
+      this.setAttribute('_compiled', '');
     }
 
     this._visible = false;
@@ -252,6 +248,15 @@ class PopoverElement extends BaseElement {
 
     if (style) {
       this._popover.setAttribute('style', style);
+    }
+
+    this.style.display = 'none';
+
+    this._mask.style.zIndex = '20000';
+    this._popover.style.zIndex = '20001';
+
+    if (this.hasAttribute('mask-color')) {
+      this._mask.style.backgroundColor = this.getAttribute('mask-color');
     }
   }
 

--- a/core/src/elements/ons-popover/index.spec.js
+++ b/core/src/elements/ons-popover/index.spec.js
@@ -358,5 +358,15 @@ describe('OnsPopoverElement', () => {
       window.OnsPopoverElement.registerAnimator('hoge', MyAnimator);
     });
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-popover></ons-popover>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });
 

--- a/core/src/elements/ons-progress-bar.js
+++ b/core/src/elements/ons-progress-bar.js
@@ -34,9 +34,12 @@ const template = util.createElement(`
 
 class ProgressBarElement extends BaseElement {
   createdCallback() {
-    this._compile();
+    if (!this.hasAttribute('_compiled')) {
+      this._compile();
+      ModifierUtil.initModifier(this, scheme);
 
-    ModifierUtil.initModifier(this, scheme);
+      this.setAttribute('_compiled', '');
+    }
   }
 
   attributeChangedCallback(name, last, current) {

--- a/core/src/elements/ons-progress-bar.spec.js
+++ b/core/src/elements/ons-progress-bar.spec.js
@@ -67,5 +67,13 @@ describe('OnsProgressBarElement', () => {
 
       expect(spy).to.have.been.called.once;
     });
+
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-progress-bar></ons-progress-bar>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
   });
 });

--- a/core/src/elements/ons-progress-circular.js
+++ b/core/src/elements/ons-progress-circular.js
@@ -34,9 +34,12 @@ const template = util.createElement(`
 
 class ProgressCircularElement extends BaseElement {
   createdCallback() {
-    this._compile();
+    if (!this.hasAttribute('_compiled')) {
+      this._compile();
+      ModifierUtil.initModifier(this, scheme);
 
-    ModifierUtil.initModifier(this, scheme);
+      this.setAttribute('_compiled', '');
+    }
   }
 
   attributeChangedCallback(name, last, current) {

--- a/core/src/elements/ons-progress-circular.spec.js
+++ b/core/src/elements/ons-progress-circular.spec.js
@@ -67,5 +67,13 @@ describe('OnsProgressCircularElement', () => {
 
       expect(spy).to.have.been.called.once;
     });
+
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-progress-circular></ons-progress-circular>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
   });
 });

--- a/core/src/elements/ons-pull-hook.js
+++ b/core/src/elements/ons-pull-hook.js
@@ -27,7 +27,15 @@ const STATE_ACTION = 'action';
 class PullHookElement extends BaseElement {
 
   createdCallback() {
-    this._scrollElement = this._createScrollElement();
+    if (!this.hasAttribute('_compiled')) {
+      this._scrollElement = this._createScrollElement();
+      this.setAttribute('_compiled', '');
+    } else {
+      this._scrollElement = this.parentElement;
+    }
+
+    this._scrollElement = this.hasAttribute('_compiled') ? this.parentElement : this._createScrollElement();
+
     this._pageElement = this._scrollElement.parentElement;
 
     if (!this._pageElement.classList.contains('page__content') && !this._pageElement.classList.contains('ons-scroller__content')) {

--- a/core/src/elements/ons-pull-hook.spec.js
+++ b/core/src/elements/ons-pull-hook.spec.js
@@ -51,12 +51,6 @@ describe('OnsPullHookElement', () => {
     page = pullHook = null;
   });
 
-  describe('#createdCallback()', () => {
-    it('throws an error if is not a descendant of ons-page or ons-scroller', () => {
-      expect(() => pullHook.createdCallback()).to.throw(Error);
-    });
-  });
-
   describe('#_createScrollElement()', () => {
     it('creates a scroll element', () => {
       let scrollElement = pullHook._createScrollElement();
@@ -341,6 +335,16 @@ describe('OnsPullHookElement', () => {
   describe('#_getMinimumScroll()', () => {
     it('returns an integer', () => {
       expect(pullHook._getMinimumScroll()).to.be.a('number');
+    });
+  });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-page><ons-pull-hook></ons-pull-hook></ons-page>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
     });
   });
 });

--- a/core/src/elements/ons-range.js
+++ b/core/src/elements/ons-range.js
@@ -37,8 +37,13 @@ const INPUT_ATTRIBUTES = [
 class MaterialInputElement extends BaseElement {
 
   createdCallback() {
-    this._compile();
-    ModifierUtil.initModifier(this, scheme);
+    if (!this.hasAttribute('_compiled')) {
+      this._compile();
+      ModifierUtil.initModifier(this, scheme);
+
+      this.setAttribute('_compiled', '');
+    }
+
     this._updateBoundAttributes();
     this._onChange();
   }

--- a/core/src/elements/ons-range.spec.js
+++ b/core/src/elements/ons-range.spec.js
@@ -37,4 +37,14 @@ describe('OnsRangeElement', () => {
     expect(input.classList.contains('range--piyo')).to.be.true;
     expect(input.classList.contains('range--fuga')).to.be.true;
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-range></ons-range>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });

--- a/core/src/elements/ons-ripple.js
+++ b/core/src/elements/ons-ripple.js
@@ -27,17 +27,19 @@ class RippleElement extends BaseElement {
       this.setAttribute('_compiled', '');
     }
 
+    this._wave = util.findChild(this, '.ripple__wave');
     this._boundOnClick = this._onMouseDown.bind(this);
   }
 
   _compile() {
     this.classList.add('ripple');
-    this._wave = document.createElement('span');
-    this._wave.classList.add('ripple__wave');
-    this.insertBefore(this._wave, this.children[0]);
+
+    const wave = document.createElement('span');
+    wave.classList.add('ripple__wave');
+    this.insertBefore(wave, this.children[0]);
 
     if (this.hasAttribute('color')) {
-      this._wave.style.background = this.getAttribute('color');
+      wave.style.background = this.getAttribute('color');
     }
   }
 

--- a/core/src/elements/ons-ripple.js
+++ b/core/src/elements/ons-ripple.js
@@ -21,13 +21,17 @@ import BaseElement from 'ons/base-element';
 class RippleElement extends BaseElement {
 
   createdCallback() {
-    this.classList.add('ripple');
-    this._compile();
+    if (!this.hasAttribute('_compiled')) {
+      this._compile();
+
+      this.setAttribute('_compiled', '');
+    }
 
     this._boundOnClick = this._onMouseDown.bind(this);
   }
 
   _compile() {
+    this.classList.add('ripple');
     this._wave = document.createElement('span');
     this._wave.classList.add('ripple__wave');
     this.insertBefore(this._wave, this.children[0]);

--- a/core/src/elements/ons-ripple.spec.js
+++ b/core/src/elements/ons-ripple.spec.js
@@ -117,4 +117,14 @@ describe('OnsRippleElement', () => {
       expect(ripple.isDisabled()).to.be.false;
     });
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-ripple></ons-ripple>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });

--- a/core/src/elements/ons-row.spec.js
+++ b/core/src/elements/ons-row.spec.js
@@ -4,4 +4,14 @@ describe('OnsRowElement', () => {
   it('should exist', () => {
     expect(window.OnsRowElement).to.be.ok;
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-row></ons-row>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });

--- a/core/src/elements/ons-scroller.spec.js
+++ b/core/src/elements/ons-scroller.spec.js
@@ -4,4 +4,14 @@ describe('ons-scroller', () => {
   it('provides \'OnsRowElement\' global variable', () => {
     expect(window.OnsScrollerElement).to.be.ok;
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-scroller></ons-scroller>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });

--- a/core/src/elements/ons-speed-dial-item.spec.js
+++ b/core/src/elements/ons-speed-dial-item.spec.js
@@ -42,3 +42,13 @@ describe('OnsSpeedDialItemElement', () => {
     });
   });
 });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-speed-dial-item>Content</ons-speed-dial-item>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });

--- a/core/src/elements/ons-speed-dial.js
+++ b/core/src/elements/ons-speed-dial.js
@@ -49,7 +49,13 @@ class SpeedDialElement extends BaseElement {
   _compile() {
     let content = document.createElement('ons-fab');
 
-    const children = util.arrayFrom(this.childNodes).forEach(element => (element.nodeName.toLowerCase() !== 'ons-speed-dial-item') ? content.firstChild.appendChild(element) : true);
+    util.arrayFrom(this.childNodes).forEach(node => {
+      if (node.nodeType == 8  || (node.nodeType === 3 && !/\S/.test(node.nodeValue))) {
+        node.remove();
+      } else if (node.nodeName.toLowerCase() !== 'ons-speed-dial-item') {
+        content.firstChild.appendChild(node);
+      }
+    });
 
     this.insertBefore(content, this.firstChild);
   }

--- a/core/src/elements/ons-speed-dial.js
+++ b/core/src/elements/ons-speed-dial.js
@@ -26,24 +26,24 @@ class SpeedDialElement extends BaseElement {
       this._compile();
       ModifierUtil.initModifier(this, scheme);
 
+      this.classList.add('speed__dial');
+
+      if (this.hasAttribute('direction')) {
+        this._updateDirection(this.getAttribute('direction'));
+      } else {
+        this._updateDirection('up');
+      }
+      this._updatePosition();
+
+      if (this.hasAttribute('disabled')) {
+        this.setDisabled(true);
+      }
       this.setAttribute('_compiled', '');
     }
 
     this._shown = true;
     this._itemShown = false;
     this._boundOnClick = this._onClick.bind(this);
-    this.classList.add('speed__dial');
-
-    if (this.hasAttribute('direction')) {
-      this._updateDirection(this.getAttribute('direction'));
-    } else {
-      this._updateDirection('up');
-    }
-    this._updatePosition();
-
-    if (this.hasAttribute('disabled')) {
-      this.setDisabled(true);
-    }
   }
 
   _compile() {

--- a/core/src/elements/ons-speed-dial.js
+++ b/core/src/elements/ons-speed-dial.js
@@ -22,10 +22,15 @@ const scheme = {
 class SpeedDialElement extends BaseElement {
 
   createdCallback() {
-    this._compile();
+    if (!this.hasAttribute('_compiled')) {
+      this._compile();
+      ModifierUtil.initModifier(this, scheme);
+
+      this.setAttribute('_compiled', '');
+    }
+
     this._shown = true;
     this._itemShown = false;
-    ModifierUtil.initModifier(this, scheme);
     this._boundOnClick = this._onClick.bind(this);
     this.classList.add('speed__dial');
 

--- a/core/src/elements/ons-speed-dial.spec.js
+++ b/core/src/elements/ons-speed-dial.spec.js
@@ -321,4 +321,20 @@ describe('OnsSpeedDialElement', () => {
       expect(spy).to.have.been.called.once;
     });
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = `
+        <ons-speed-dial>
+          <ons-speed-dial-item>Item 1</ons-speed-dial-item>
+          <ons-speed-dial-item>Item 2</ons-speed-dial-item>
+          <ons-speed-dial-item>Item 3</ons-speed-dial-item>
+        </ons-speed-dial>
+      `;
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.innerHTML === div2.innerHTML).to.be.true;
+    });
+  });
 });

--- a/core/src/elements/ons-speed-dial.spec.js
+++ b/core/src/elements/ons-speed-dial.spec.js
@@ -334,7 +334,7 @@ describe('OnsSpeedDialElement', () => {
         </ons-speed-dial>
       `;
       div2.innerHTML = div1.innerHTML;
-      expect(div1.innerHTML === div2.innerHTML).to.be.true;
+      expect(div1.isEqualNode(div2)).to.be.true;
     });
   });
 });

--- a/core/src/elements/ons-splitter/index.spec.js
+++ b/core/src/elements/ons-splitter/index.spec.js
@@ -103,4 +103,20 @@ describe('OnsSplitterElement', () => {
       expect(splitter.getDeviceBackButtonHandler()).to.be.an('object');
     });
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = `
+        <ons-splitter>
+          <ons-splitter-side side="left">Left</ons-splitter-side>
+          <ons-splitter-side side="right" collapse>Right</ons-splitter-side>
+          <ons-splitter-content>Content</ons-splitter-content>
+        </ons-splitter>
+      `;
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });

--- a/core/src/elements/ons-switch.js
+++ b/core/src/elements/ons-switch.js
@@ -96,8 +96,12 @@ class SwitchElement extends ExtendableLabelElement {
   }
 
   createdCallback() {
-    this._compile();
-    ModifierUtil.initModifier(this, scheme);
+    if (!this.hasAttribute('_compiled')) {
+      this._compile();
+      ModifierUtil.initModifier(this, scheme);
+
+      this.setAttribute('_compiled', '');
+    }
 
     this._updateForCheckedAttribute();
     this._updateForDisabledAttribute();

--- a/core/src/elements/ons-switch.spec.js
+++ b/core/src/elements/ons-switch.spec.js
@@ -135,4 +135,14 @@ describe('OnsSwitchElement', () => {
       expect(element.checked).to.be.false;
     });
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-switch></ons-switch>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });

--- a/core/src/elements/ons-tab.js
+++ b/core/src/elements/ons-tab.js
@@ -43,10 +43,14 @@ const defaultInnerTemplateSource = util.createElement(`
 class TabElement extends BaseElement {
 
   createdCallback() {
-    this._compile();
-    this._boundOnClick = this._onClick.bind(this);
+    if (!this.hasAttribute('_compiled')) {
+      this._compile();
+      ModifierUtil.initModifier(this, scheme);
 
-    ModifierUtil.initModifier(this, scheme);
+      this.setAttribute('_compiled', '');
+    }
+
+    this._boundOnClick = this._onClick.bind(this);
   }
 
   _compile() {

--- a/core/src/elements/ons-tab.spec.js
+++ b/core/src/elements/ons-tab.spec.js
@@ -275,4 +275,14 @@ describe('OnsTabElement', () => {
       document.body.removeChild(template2);
     });
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-tab></ons-tab>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });

--- a/core/src/elements/ons-tabbar/index.js
+++ b/core/src/elements/ons-tabbar/index.js
@@ -73,16 +73,21 @@ class TabbarElement extends BaseElement {
   createdCallback() {
     this._tabbarId = generateId();
 
+    if (!this.hasAttribute('_compiled')) {
+      this._compile();
+      ModifierUtil.initModifier(this, scheme);
+
+      this.setAttribute('_compiled', '');
+    }
+
+    this._contentElement = util.findChild(this, '.tab-bar__content');
+
     this._animatorFactory = new AnimatorFactory({
       animators: _animatorDict,
       baseClass: TabbarAnimator,
       baseClassName: 'TabbarAnimator',
       defaultAnimation: this.getAttribute('animation')
     });
-
-    this._compile();
-    this._contentElement = util.findChild(this, '.tab-bar__content');
-    ModifierUtil.initModifier(this, scheme);
   }
 
   _compile() {

--- a/core/src/elements/ons-tabbar/index.spec.js
+++ b/core/src/elements/ons-tabbar/index.spec.js
@@ -422,6 +422,19 @@ describe('OnsTabbarElement', () => {
         done();
       }, 1000);
     });
+
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = `
+        <ons-tabbar>
+          <ons-tab page="hoge">hoge</ons-tab>
+          <ons-tab page="fuga">fuga</ons-tab>
+        </ons-tabbar>
+      `;
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
   });
 
   describe('#registerAnimator()', () => {

--- a/core/src/elements/ons-template.spec.js
+++ b/core/src/elements/ons-template.spec.js
@@ -25,5 +25,15 @@ describe('ons-template', () => {
       expect(element.firstChild).not.to.be.ok;
       done();
     });
+
+    describe('#_compile()', () => {
+      it('does not compile twice', () => {
+        let div1 = document.createElement('div');
+        let div2 = document.createElement('div');
+        div1.innerHTML = '<ons-template><ons-page>Content</ons-page></ons-template>';
+        div2.innerHTML = div1.innerHTML;
+        expect(div1.isEqualNode(div2)).to.be.true;
+      });
+    });
   });
 });

--- a/core/src/elements/ons-template.spec.js
+++ b/core/src/elements/ons-template.spec.js
@@ -25,15 +25,15 @@ describe('ons-template', () => {
       expect(element.firstChild).not.to.be.ok;
       done();
     });
+  });
 
-    describe('#_compile()', () => {
-      it('does not compile twice', () => {
-        let div1 = document.createElement('div');
-        let div2 = document.createElement('div');
-        div1.innerHTML = '<ons-template><ons-page>Content</ons-page></ons-template>';
-        div2.innerHTML = div1.innerHTML;
-        expect(div1.isEqualNode(div2)).to.be.true;
-      });
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-template><ons-page>Content</ons-page></ons-template>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
     });
   });
 });

--- a/core/src/elements/ons-toolbar-button.spec.js
+++ b/core/src/elements/ons-toolbar-button.spec.js
@@ -20,5 +20,15 @@ describe('ons-toolbar-button', () => {
     expect(element.classList.contains('toolbar-button--piyo')).to.be.true;
     expect(element.classList.contains('toolbar-button--fuga')).to.be.true;
   });
+
+  describe('#_compile()', () => {
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-toolbar-button>Back</ons-toolbar-button>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
+  });
 });
 

--- a/core/src/elements/ons-toolbar.js
+++ b/core/src/elements/ons-toolbar.js
@@ -30,8 +30,12 @@ const scheme = {
 class ToolbarElement extends BaseElement {
 
   createdCallback() {
-    this._compile();
-    ModifierUtil.initModifier(this, scheme);
+    if (!this.hasAttribute('_compiled')) {
+      this._compile();
+      ModifierUtil.initModifier(this, scheme);
+
+      this.setAttribute('_compiled', '');
+    }
 
     this._tryToEnsureNodePosition();
     setImmediate(() => this._tryToEnsureNodePosition());

--- a/core/src/elements/ons-toolbar.spec.js
+++ b/core/src/elements/ons-toolbar.spec.js
@@ -99,5 +99,13 @@ describe('OnsToolbarElement', () => {
       expect(element.children[1].classList.contains('navigation-bar__center')).to.be.true;
       expect(element.children[2].classList.contains('navigation-bar__right')).to.be.true;
     });
+
+    it('does not compile twice', () => {
+      let div1 = document.createElement('div');
+      let div2 = document.createElement('div');
+      div1.innerHTML = '<ons-toolbar><div class="center">Title</div></ons-toolbar>';
+      div2.innerHTML = div1.innerHTML;
+      expect(div1.isEqualNode(div2)).to.be.true;
+    });
   });
 });


### PR DESCRIPTION
@argelius This maintains the same DOM structure and attributes when an element is copied using `innerHTML`. I added tests to every element, even to those that don't have a real `_compile` method just to be sure the DOM stays the same. 

As mentioned in #1187, internal variables would be a problem. I can make some modifications to minimize the problems.

There is currently a problem with `ons-template` since it removes its content on createdCallback, so the copy and the original one will be empty (thus passing the test).