### PR TITLE
Page fix

### DIFF
--- a/core/src/elements/ons-page.js
+++ b/core/src/elements/ons-page.js
@@ -53,7 +53,7 @@ class PageElement extends BaseElement {
     }
 
     if (!util.hasAnyComponentAsParent(this)) {
-      this._show();
+      setImmediate(() => this._show());
     }
 
     this._tryToFillStatusBar();

--- a/core/src/elements/ons-page.spec.js
+++ b/core/src/elements/ons-page.spec.js
@@ -179,10 +179,11 @@ describe('OnsPageElement', () => {
 
   describe('#_show()', () => {
     it('fires \'show\' event', () => {
-      var spy = chai.spy();
-      document.addEventListener('show', spy);
+      var showPromise = new Promise(resolve => {
+        document.addEventListener('show', resolve);
+      });
       document.body.appendChild(element);
-      expect(spy).to.have.been.called.once;
+      return expect(showPromise).to.eventually.be.fulfilled;
     });
   });
 
@@ -191,6 +192,7 @@ describe('OnsPageElement', () => {
       var spy = chai.spy();
       document.addEventListener('hide', spy);
       document.body.appendChild(element);
+      element.isShown = true;
       element._hide();
       expect(spy).to.have.been.called.once;
     });


### PR DESCRIPTION
@argelius I realized that if `ons-page` is the main component, when trying to propagate `show` action its descendants are not defined. Now that `ons-fab` is hidden by default it would not be shown (check `examples/ons-fab/index.html`). This small change fixes it.