### PR TITLE
fix(ons-fab): Fix #1192 - fab disappearing before animation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 v2.0.0-beta.7
 ----
  * core: Fixed [#1181](https://github.com/OnsenUI/OnsenUI/issues/1181).
+ * ons-fab: Fixed [#1192](https://github.com/OnsenUI/OnsenUI/issues/1192).
 
 v2.0.0-beta.6
 ----
@@ -322,7 +323,7 @@ v1.2.0
  * ons-navigator: Fixed [#228](https://github.com/OnsenUI/OnsenUI/issues/228).
  * ons-switch: Fixed [#252](https://github.com/OnsenUI/OnsenUI/issues/252). Model change is now bound correctly when using ngModel.
  * css-components: Fixed [#177](https://github.com/OnsenUI/OnsenUI/issues/177). Checkboxes and radio buttons are now clickable on iOS.
- * ons-button: Added several methods to the component. 
+ * ons-button: Added several methods to the component.
 
 v1.1.4
 ----

--- a/css-components/components-src/stylus/components/page.styl
+++ b/css-components/components-src/stylus/components/page.styl
@@ -16,6 +16,7 @@ var-page-material-background-color = $material-background-color
   font-size var-font-size
   color var-text-color
   -ms-overflow-style none
+  transform translate3d(0,0,0)
 
 .page::-webkit-scrollbar
   display none


### PR DESCRIPTION
Also probably fixes the scenario in which #1184 was not fixed.

The live version fabs also have collisions with `ons-toolbar` if they are in a corner which has a toolbar - they overlap (even without any animations).

During the page transitions the `transform: translate3d(0,0,0)` style which enables hardware acceleration makes the `ons-page` behave as a container element for the fabs, making them blink before the animations.

With this change it's activated by default, so they don't overlap with the toolbars and stops them from blinking and disappearing at the start of the animation.