### PR TITLE
fix(css-components): Refined default theme colors on tabbar.

### DIFF
--- a/css-components/www/theme.js
+++ b/css-components/www/theme.js
@@ -15,13 +15,13 @@
         'sub-text-color': '#999',
         'highlight-color': 'rgba(24,103,194,0.81)',
         'second-highlight-color': '#25a6d9',
-        'border-color': '#ddd',
+        'border-color': '#ccc',
 
         // Toolbar
         'toolbar-background-color': '#fff',
         'toolbar-button-color': 'rgba(38,100,171,0.81)',
         'toolbar-text-color': '#1f1f21',
-        'toolbar-border-color': '#ddd',
+        'toolbar-border-color': '#bbb',
 
         // Button Bar
         'buttonbar-color': 'rgba(18,114,224,0.77)',
@@ -33,10 +33,10 @@
         'list-tap-active-background-color': '#d9d9d9',
 
         // Tabbar
-        'tabbar-background-color': '#222',
+        'tabbar-background-color': '#fff',
         'tabbar-text-color': '#999',
-        'tabbar-highlight-text-color': '#7abfff',
-        'tabbar-border-color': transparent,
+        'tabbar-highlight-text-color': 'rgba(24,103,194,0.81)',
+        'tabbar-border-color': '#ccc',
 
         // Switch
         'switch-highlight-color': '#5198db',


### PR DESCRIPTION
@argelius Please merge this changes.

NEW:
![image](https://cloud.githubusercontent.com/assets/59784/12776633/fc916b5a-ca9a-11e5-8cf4-f9055a2bed90.png)

OLD:
![image](https://cloud.githubusercontent.com/assets/59784/12776641/0fbb1c8a-ca9b-11e5-9fa0-39bbb6fce48c.png)
