### PR TITLE
Add pageHTML option to insertPage function in ons-navigator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ v2.0.0-beta.7
  * ons-tabbar: Correctly applies animation-options.
  * ons-popover: Correctly applies animation-options.
  * ons-alert-dialog: Correctly applies animation-options.
+ * ons-navigator: ons-navigator: add "pageHTML" option to "insertPage()" method
  * ons-carousel: Accepts animation-options.
  * core: Async methods return promises. Closes [#1054](https://github.com/OnsenUI/OnsenUI/issues/1054).
 

--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -257,7 +257,7 @@ class NavigatorElement extends BaseElement {
     const tryInsertPage = () => {
       const unlock = this._doorLock.lock();
 
-      return internal.getPageHTMLAsync(page).then(templateHTML => {
+      var run = templateHTML => {
         const element = this._createPageElement(templateHTML);
         const pageObject = this._createPageObject(page, element, options);
 
@@ -275,7 +275,13 @@ class NavigatorElement extends BaseElement {
             }, 1000 / 60);
           });
         });
-      });
+      };
+
+      if (options.pageHTML) {
+        return run(options.pageHTML);
+      } else {
+        return internal.getPageHTMLAsync(page).then(run);
+      }
     };
 
     return new Promise(resolve => {


### PR DESCRIPTION
Currently the function pushPage in ons-navigator supports the pageHTML option, however, the function insertPage does not, this commit adds this functionality. 