### PR TITLE
add example how to use ons-navigator replacePage

### DIFF
--- a/examples/navigator_replace/index.html
+++ b/examples/navigator_replace/index.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en" ng-app="myApp">
+<head>
+  <meta charset="utf-8">
+  <title>Navigator Replace | Onsen UI</title>
+  <link rel="stylesheet" href="../styles/app.css"/>
+  <link rel="stylesheet" href="../../build/css/onsenui.css">
+  <link rel="stylesheet" href="../../build/css/onsen-css-components.css">
+
+  <script src="../../build/js/onsenui.js"></script>
+  <script src="../../build/js/angular/angular.js"></script>
+  <script src="../../build/js/angular-onsenui.js"></script>
+  <script src="../app.js"></script>
+
+</head>
+
+<body>
+  <ons-navigator var="myNavigator">
+    <ons-page>
+      <ons-toolbar>
+        <div class="left"><ons-back-button ng-show="myNavigator.pages.length > 1">Back</ons-back-button></div>
+        <div class="center">Navigator</div>
+      </ons-toolbar>
+
+      <div style="text-align: center">
+        <br>
+        <ons-button ng-click="myNavigator.pushPage('page1.html')">
+          Push
+        </ons-button>
+      </div>
+    </ons-page>
+  </ons-navigator>
+
+  <ons-template id="page1.html">
+    <ons-page>
+      <ons-toolbar>
+        <div class="left"><ons-back-button ng-show="myNavigator.pages.length > 1">Back</ons-back-button></div>
+        <div class="center">Pushed Page</div>
+      </ons-toolbar>
+
+      <div style="text-align: center">
+        <br>
+        <ons-button ng-click="myNavigator.pushPage('page1.html', {hoge: 'hoge'})">
+          Push 
+        </ons-button>
+        <ons-button ng-click="myNavigator.popPage({animation: 'slide'})">
+          Pop
+        </ons-button>
+        <ons-button ng-click="myNavigator.replacePage('page2.html', {animation: 'none'})">
+          Replace
+        </ons-button>
+      </div>
+    </ons-page>
+  </ons-template>
+
+  <ons-template id="page2.html">
+    <ons-page>
+      <ons-toolbar>
+        <div class="left"><ons-back-button ng-show="myNavigator.pages.length > 1">Back</ons-back-button></div>
+        <div class="center">Replaced Page</div>
+      </ons-toolbar>
+
+      <div style="text-align: center">
+        <br>
+        <ons-button ng-click="myNavigator.pushPage('page1.html', {hoge: 'hoge'})">
+          Push 
+        </ons-button>
+        <ons-button ng-click="myNavigator.popPage({animation: 'slide'})">
+          Pop
+        </ons-button>
+      </div>
+    </ons-page>
+  </ons-template>
+
+</body>
+</html>


### PR DESCRIPTION
This adds an example of how to use ons-navigator replacePage function. It is done via angular and has 1 start template, a second page type and a third page type. On the second page type you can replace this page by the third page type. You can push and pop on the second and third type page and only push on the first type page.