### PR TITLE
fix(ons-splitter-side): Fix splitter side scrolling issue #1222

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ v2.0.0-beta.7
  * core: Async methods return promises. Closes [#1054](https://github.com/OnsenUI/OnsenUI/issues/1054).
  * ons-ripple: Improve ripple effect. Closes [#1193](https://github.com/OnsenUI/OnsenUI/issues/1193).
  * ons-switch: Switch is now draggable.
+ * ons-splitter-side: Fixed [#1222](https://github.com/OnsenUI/OnsenUI/issues/1222).
 
 v2.0.0-beta.6
 ----

--- a/core/src/elements/ons-splitter-side.js
+++ b/core/src/elements/ons-splitter-side.js
@@ -255,7 +255,7 @@ class CollapseMode extends BaseMode {
   }
 
   _onDragStart(event) {
-    this._ignoreDrag = false;
+    this._ignoreDrag = ['left', 'right'].indexOf(event.gesture.direction) === -1;
 
     if (!this.isOpen() && this._isOpenOtherSideMenu()) {
       this._ignoreDrag = true;

--- a/core/src/elements/ons-splitter-side.spec.js
+++ b/core/src/elements/ons-splitter-side.spec.js
@@ -107,5 +107,17 @@ describe('OnsSplitterSideElement', () => {
       expect(right.getCurrentMode()).to.be.equal('split');
     });
   });
+
+  describe('#handleGesture()', () => {
+    it('should ignore scrolling', () => {
+      let mode = right._getModeStrategy();
+      mode.handleGesture({type: 'dragstart', gesture: {direction: 'up'}});
+      expect(mode._ignoreDrag).to.be.true;
+      mode.handleGesture({type: 'dragstart', gesture: {direction: 'left'}});
+      expect(mode._ignoreDrag).to.be.false;
+      mode.handleGesture({type: 'dragstart', gesture: {direction: 'down'}});
+      expect(mode._ignoreDrag).to.be.true;
+    });
+  });
 });
 


### PR DESCRIPTION
Currently scrolling inside ons-splitter-side on a mobile device closes the side menu after the user has finished scrolling.