### PR TITLE
Notification promises

### DIFF
--- a/core/src/ons/notification.js
+++ b/core/src/ons/notification.js
@@ -56,7 +56,7 @@ import util from './util';
 const notification = {};
 
 notification._createAlertDialog = function(title, message,
-  buttonLabels, primaryButtonIndex, modifier, animation, callback,
+  buttonLabels, primaryButtonIndex, modifier, animation, id, callback,
   messageIsHTML, cancelable, promptDialog, autofocus, placeholder,
   defaultValue, submitOnEnter, compile) {
 
@@ -72,10 +72,19 @@ notification._createAlertDialog = function(title, message,
     <div class="alert-dialog-footer"></div>
   </ons-alert-dialog>`);
 
+  if (id) {
+    dialogElement.setAttribute('id', id);
+  }
+
   let titleElement = dialogElement.querySelector('.alert-dialog-title');
   let messageElement = dialogElement.querySelector('.alert-dialog-content');
   let footerElement = dialogElement.querySelector('.alert-dialog-footer');
-  let inputElement;
+  let inputElement, result = {};
+
+  result.promise = new Promise((resolve, reject) => {
+    result.resolve = resolve;
+    result.reject = reject;
+  });
 
   if (typeof title === 'string') {
     titleElement.textContent = title;
@@ -111,6 +120,7 @@ notification._createAlertDialog = function(title, message,
           dialogElement.hide({
             callback: function() {
               callback(inputElement.value);
+              result.resolve(inputElement.value);
               dialogElement.destroy();
               dialogElement = null;
             }
@@ -147,8 +157,10 @@ notification._createAlertDialog = function(title, message,
         callback: function() {
           if (promptDialog) {
             callback(inputElement.value);
+            result.resolve(inputElement.value);
           } else {
             callback(i);
+            result.resolve(i);
           }
           dialogElement.destroy();
           dialogElement = inputElement = buttonElement = null;
@@ -169,8 +181,10 @@ notification._createAlertDialog = function(title, message,
     dialogElement.addEventListener('cancel', function() {
       if (promptDialog) {
         callback(null);
+        result.reject(null);
       } else {
         callback(-1);
+        result.reject(-1);
       }
       setTimeout(function() {
         dialogElement.destroy();
@@ -194,7 +208,7 @@ notification._createAlertDialog = function(title, message,
     dialogElement.setAttribute('modifier', modifier);
   }
 
-  return Promise.resolve(dialogElement);
+  return result.promise;
 };
 
 notification._alertOriginal = function(options) {
@@ -217,6 +231,7 @@ notification._alertOriginal = function(options) {
     0,
     options.modifier,
     options.animation,
+    options.id,
     options.callback,
     !options.message ? true : false,
     false, false, false, '', '', false,
@@ -241,6 +256,9 @@ notification._alertOriginal = function(options) {
  * @param {String} [options.animation]
  *   [en]Animation name. Available animations are "none", "fade" and "slide".[/en]
  *   [ja]アラートダイアログを表示する際のアニメーション名を指定します。"none", "fade", "slide"のいずれかを指定できます。[/ja]
+ * @param {String} [options.id]
+ *   [en]ons-alert-dialog element's ID.[/en]
+ *   [ja]ons-alert-dialog要素のID。[/ja]
  * @param {String} [options.title]
  *   [en]Dialog title. Default is "Alert".[/en]
  *   [ja]アラートダイアログの上部に表示するタイトルを指定します。"Alert"がデフォルトです。[/ja]
@@ -287,6 +305,7 @@ notification._confirmOriginal = function(options) {
     options.primaryButtonIndex,
     options.modifier,
     options.animation,
+    options.id,
     options.callback,
     !options.message ? true : false,
     options.cancelable,
@@ -318,6 +337,9 @@ notification._confirmOriginal = function(options) {
  * @param {String} [options.animation]
  *   [en]Animation name. Available animations are "none", "fade" and "slide".[/en]
  *   [ja]アニメーション名を指定します。"none", "fade", "slide"のいずれかを指定します。[/ja]
+ * @param {String} [options.id]
+ *   [en]ons-alert-dialog element's ID.[/en]
+ *   [ja]ons-alert-dialog要素のID。[/ja]
  * @param {String} [options.title]
  *   [en]Dialog title. Default is "Confirm".[/en]
  *   [ja]ダイアログのタイトルを指定します。"Confirm"がデフォルトです。[/ja]
@@ -373,6 +395,7 @@ notification._promptOriginal = function(options) {
     0,
     options.modifier,
     options.animation,
+    options.id,
     options.callback,
     !options.message ? true : false,
     options.cancelable,
@@ -410,6 +433,9 @@ notification._promptOriginal = function(options) {
  * @param {String} [options.animation]
  *   [en]Animation name. Available animations are "none", "fade" and "slide".[/en]
  *   [ja]アニメーション名を指定します。"none", "fade", "slide"のいずれかを指定します。[/ja]
+ * @param {String} [options.id]
+ *   [en]ons-alert-dialog element's ID.[/en]
+ *   [ja]ons-alert-dialog要素のID。[/ja]
  * @param {String} [options.title]
  *   [en]Dialog title. Default is "Alert".[/en]
  *   [ja]ダイアログのタイトルを指定します。デフォルトは "Alert" です。[/ja]

--- a/core/src/ons/notification.spec.js
+++ b/core/src/ons/notification.spec.js
@@ -7,16 +7,12 @@ describe('ons.notification', () => {
 
   describe('#alert()', () => {
     let dialog,
+      resolvePromise,
       callback = chai.spy();
 
-    beforeEach((done) => {
-      ons.notification.alert({message: 'hoge', modifier: 'fuga', cancelable: true, callback: callback})
-        .then(
-          (dlg) => {
-            dialog = dlg;
-            done();
-          }
-        );
+    beforeEach(() => {
+      resolvePromise = ons.notification.alert({message: 'hoge', modifier: 'fuga', cancelable: true, callback: callback});
+      dialog = document.body.querySelector('ons-alert-dialog');
     });
 
     afterEach(() => {
@@ -30,14 +26,12 @@ describe('ons.notification', () => {
       expect(() => ons.notification.alert()).to.throw(Error);
     });
 
-    it('accepts a \'messageHTML\' parameter', (done) => {
+    it('accepts a \'messageHTML\' parameter', () => {
       let message = '<strong>hoge</strong>';
-      ons.notification.alert({messageHTML: message})
-        .then((dialog) => {
-          expect(dialog.innerHTML.indexOf(message)).to.be.above(-1);
-          dialog.destroy();
-          done();
-        });
+      ons.notification.alert({messageHTML: message, id: 'test'});
+      let dialog = document.getElementById('test');
+      expect(dialog.innerHTML.indexOf(message)).to.be.above(-1);
+      dialog.destroy();
     });
 
     it('displays an alert dialog', () => {
@@ -56,14 +50,24 @@ describe('ons.notification', () => {
       button.dispatchEvent(event);
       expect(spy).to.have.been.called.once;
     });
+
+    it('resolves to the pressed button index', (done) => {
+      resolvePromise.then(index => {
+        expect(index).to.equal(0);
+        done();
+      });
+
+      dialog.querySelector('button').click();
+    });
   });
 
   describe('#confirm()', () => {
     let dialog,
+      resolvePromise,
       callback = chai.spy();
 
     beforeEach(() => {
-      ons.notification.confirm({message: 'hoge', modifier: 'fuga', cancelable: true, callback: callback});
+      resolvePromise = ons.notification.confirm({message: 'hoge', modifier: 'fuga', cancelable: true, callback: callback});
       dialog = document.body.querySelector('ons-alert-dialog');
     });
 
@@ -78,14 +82,12 @@ describe('ons.notification', () => {
       expect(() => ons.notification.confirm()).to.throw(Error);
     });
 
-    it('accepts a \'messageHTML\' parameter', (done) => {
+    it('accepts a \'messageHTML\' parameter', () => {
       let message = '<strong>hoge</strong>';
-      ons.notification.confirm({messageHTML: message})
-        .then((dialog) => {
-          expect(dialog.innerHTML.indexOf(message)).to.be.above(-1);
-          dialog.destroy();
-          done();
-        });
+      ons.notification.confirm({messageHTML: message, id: 'test'});
+      let dialog = document.getElementById('test');
+      expect(dialog.innerHTML.indexOf(message)).to.be.above(-1);
+      dialog.destroy();
     });
 
     it('displays an alert dialog', () => {
@@ -110,14 +112,24 @@ describe('ons.notification', () => {
       dialog.dispatchEvent(event);
       expect(callback).to.have.been.called.with(-1);
     });
+
+    it('resolves to the pressed button index', (done) => {
+      resolvePromise.then(index => {
+        expect(index).to.equal(0);
+        done();
+      });
+
+      dialog.querySelector('button').click();
+    });
   });
 
   describe('#prompt()', () => {
     let dialog,
+      resolvePromise,
       callback = chai.spy();
 
     beforeEach(() => {
-      ons.notification.prompt({message: 'hoge', modifier: 'fuga', submitOnEnter: true, cancelable: true, callback: callback});
+      resolvePromise = ons.notification.prompt({message: 'hoge', modifier: 'fuga', submitOnEnter: true, cancelable: true, callback: callback});
       dialog = document.body.querySelector('ons-alert-dialog');
     });
 
@@ -132,14 +144,12 @@ describe('ons.notification', () => {
       expect(() => ons.notification.prompt()).to.throw(Error);
     });
 
-    it('accepts a \'messageHTML\' parameter', (done) => {
+    it('accepts a \'messageHTML\' parameter', () => {
       let message = '<strong>hoge</strong>';
-      ons.notification.prompt({messageHTML: message})
-        .then((dialog) => {
-          expect(dialog.innerHTML.indexOf(message)).to.be.above(-1);
-          dialog.destroy();
-          done();
-        });
+      ons.notification.prompt({messageHTML: message, id: 'test'});
+      let dialog = document.getElementById('test');
+      expect(dialog.innerHTML.indexOf(message)).to.be.above(-1);
+      dialog.destroy();
     });
 
     it('displays an alert dialog', () => {
@@ -174,6 +184,16 @@ describe('ons.notification', () => {
       let event = new CustomEvent('cancel');
       dialog.dispatchEvent(event);
       expect(callback).to.have.been.called.with(null);
+    });
+
+    it('resolves to the input value', (done) => {
+      resolvePromise.then(value => {
+        expect(value).to.equal('42');
+        done();
+      });
+
+      dialog.querySelector('input').value = 42;
+      dialog.querySelector('button').click();
     });
   });
 });


### PR DESCRIPTION
@argelius This is done. Notifications resolve when the buttons are clicked to the `buttonIndex` or the `inputValue` in case of prompt.
It also adds a `options.id` parameter that will set the id for the new `ons-alert-dialog`.