### PR TITLE
Page html parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ v2.0.0-beta.7
  * ons-tabbar: Correctly applies animation-options.
  * ons-popover: Correctly applies animation-options.
  * ons-alert-dialog: Correctly applies animation-options.
- * ons-navigator: ons-navigator: add "pageHTML" option to "insertPage()" method
+ * ons-navigator: Closes [#1208](https://github.com/OnsenUI/OnsenUI/issues/1208).
  * ons-carousel: Accepts animation-options.
  * core: Async methods return promises. Closes [#1054](https://github.com/OnsenUI/OnsenUI/issues/1054).
  * ons-ripple: Improve ripple effect. Closes [#1193](https://github.com/OnsenUI/OnsenUI/issues/1193).

--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -232,12 +232,18 @@ class NavigatorElement extends BaseElement {
   /**
    * @method replacePage
    * @signature replacePage(pageUrl, [options])
-   * @param {String} pageUrl
+   * @param {String} [pageUrl]
    *   [en]Page URL. Can be either a HTML document or an <code>&lt;ons-template&gt;</code>.[/en]
    *   [ja]pageのURLか、もしくはons-templateで宣言したテンプレートのid属性の値を指定できます。[/ja]
    * @param {Object} [options]
    *   [en]Parameter object.[/en]
    *   [ja]オプションを指定するオブジェクト。[/ja]
+   * @param {String} [options.page]
+   *   [en]PageURL. Only necssary if `page` parameter is omitted.[/en]
+   *   [ja][/ja]
+   * @param {String} [options.pageHTML]
+   *   [en]HTML code that will be computed as a new page. Overwrites `page` parameter.[/en]
+   *   [ja][/ja]
    * @param {String} [options.animation]
    *   [en]Animation name. Available animations are "slide", "simpleslide", "lift", "fade" and "none".[/en]
    *   [ja]アニメーション名を指定できます。"slide", "simpleslide", "lift", "fade", "none"のいずれかを指定できます。[/ja]
@@ -260,6 +266,12 @@ class NavigatorElement extends BaseElement {
    */
   replacePage(page, options = {}) {
 
+    if (typeof page === 'object' && page !== null) {
+      options = page;
+    } else {
+      options.page = page;
+    }
+
     if (options && typeof options != 'object') {
       throw new Error('options must be an object. You supplied ' + options);
     }
@@ -277,7 +289,7 @@ class NavigatorElement extends BaseElement {
       onTransitionEnd();
     };
 
-    return this.pushPage(page, options);
+    return this.pushPage(options.page, options);
   }
 
   /**
@@ -452,6 +464,12 @@ class NavigatorElement extends BaseElement {
    */
   insertPage(index, page, options = {}) {
 
+    if (typeof page === 'object' && page !== null) {
+      options = page;
+    } else {
+      options.page = page;
+    }
+
     if (options && typeof options != 'object') {
       throw new Error('options must be an object. You supplied ' + options);
     }
@@ -558,12 +576,18 @@ class NavigatorElement extends BaseElement {
   /**
    * @method resetTopage
    * @signature resetToPage(pageUrl, [options])
-   * @param {String/undefined} pageUrl
+   * @param {String/undefined} [pageUrl]
    *   [en]Page URL. Can be either a HTML document or an <code>&lt;ons-template&gt;</code>. If the value is undefined or '', the navigator will be reset to the page that was first displayed.[/en]
    *   [ja]pageのURLか、もしくはons-templateで宣言したテンプレートのid属性の値を指定できます。undefinedや''を指定すると、ons-navigatorが最初に表示したページを指定したことになります。[/ja]
    * @param {Object} [options]
    *   [en]Parameter object.[/en]
    *   [ja]オプションを指定するオブジェクト。[/ja]
+   * @param {String} [options.page]
+   *   [en]PageURL. Only necssary if `page` parameter is omitted.[/en]
+   *   [ja][/ja]
+   * @param {String} [options.pageHTML]
+   *   [en]HTML code that will be computed as a new page. Overwrites `page` parameter.[/en]
+   *   [ja][/ja]
    * @param {String} [options.animation]
    *   [en]Animation name. Available animations are "slide", "simpleslide", "lift", "fade" and "none".[/en]
    *   [ja]アニメーション名を指定できます。"slide", "simpleslide", "lift", "fade", "none"のいずれかを指定できます。[/ja]
@@ -588,6 +612,12 @@ class NavigatorElement extends BaseElement {
    */
   resetToPage(page, options = {}) {
 
+    if (typeof page === 'object' && page !== null) {
+      options = page;
+    } else {
+      options.page = page;
+    }
+
     if (options && typeof options != 'object') {
       throw new Error('options must be an object. You supplied ' + options);
     }
@@ -606,15 +636,16 @@ class NavigatorElement extends BaseElement {
       onTransitionEnd();
     };
 
-    if (options.pageHTML == undefined && (page === undefined || page === '')) {
+    if (!options.pageHTML && (options.page === undefined || page === '')) {
       if (this.hasAttribute('page')) {
-        page = this.getAttribute('page');
+        options.page = this.getAttribute('page');
       } else {
         options.pageHTML = this._initialHTML;
-        page = '';
+        options.page = '';
       }
     }
-    return this.pushPage(page, options);
+
+    return this.pushPage(options.page, options);
   }
 
   attributeChangedCallback(name, last, current) {
@@ -644,12 +675,18 @@ class NavigatorElement extends BaseElement {
   /**
    * @method pushPage
    * @signature pushPage(page, [options])
-   * @param {String} page
+   * @param {String} [page]
    *   [en]Page URL. Can be either a HTML document or a <code>&lt;ons-template&gt;</code>.[/en]
    *   [ja]pageのURLか、もしくはons-templateで宣言したテンプレートのid属性の値を指定できます。[/ja]
    * @param {Object} [options]
    *   [en]Parameter object.[/en]
    *   [ja]オプションを指定するオブジェクト。[/ja]
+   * @param {String} [options.page]
+   *   [en]PageURL. Only necssary if `page` parameter is omitted.[/en]
+   *   [ja][/ja]
+   * @param {String} [options.pageHTML]
+   *   [en]HTML code that will be computed as a new page. Overwrites `page` parameter.[/en]
+   *   [ja][/ja]
    * @param {String} [options.animation]
    *   [en]Animation name. Available animations are "slide", "simpleslide", "lift", "fade" and "none".[/en]
    *   [ja]アニメーション名を指定します。"slide", "simpleslide", "lift", "fade", "none"のいずれかを指定できます。[/ja]
@@ -679,6 +716,12 @@ class NavigatorElement extends BaseElement {
    */
   pushPage(page, options = {}) {
 
+    if (typeof page === 'object' && page !== null) {
+      options = page;
+    } else {
+      options.page = page;
+    }
+
     if (options && typeof options != 'object') {
       throw new Error('options must be an object. You supplied ' + options);
     }
@@ -699,11 +742,11 @@ class NavigatorElement extends BaseElement {
     this._isPushing = true;
 
     return new Promise(resolve => {
-      this._doorLock.waitUnlock(() => resolve(this._pushPage(page, options)));
+      this._doorLock.waitUnlock(() => resolve(this._pushPage(options)));
     });
   }
 
-  _pushPage(page, options) {
+  _pushPage(options) {
     const unlock = this._doorLock.lock();
     const done = function() {
       unlock();
@@ -711,13 +754,13 @@ class NavigatorElement extends BaseElement {
 
     const run = templateHTML => {
       const element = this._createPageElement(templateHTML);
-      return this._pushPageDOM(this._createPageObject(page, element, options), done);
+      return this._pushPageDOM(this._createPageObject(options.page, element, options), done);
     };
 
     if (options.pageHTML) {
       return run(options.pageHTML);
     } else {
-      return internal.getPageHTMLAsync(page).then(run);
+      return internal.getPageHTMLAsync(options.page).then(run);
     }
   }
 
@@ -835,16 +878,16 @@ class NavigatorElement extends BaseElement {
     }
 
 
-    let index, page;
+    let index;
     if (typeof item === 'string') {
-      page = item;
-      index = this._lastIndexOfPage(page);
+      options.page = item;
+      index = this._lastIndexOfPage(options.page);
     } else if (typeof item === 'number') {
       index = this._normalizeIndex(item);
       if (item >= this._pages.length) {
         throw new Error('The provided index does not match an existing page.');
       }
-      page = this._pages[index].page;
+      options.page = this._pages[index].page;
     } else {
       throw new Error('First argument must be a page name or the index of an existing page. You supplied ' + item);
     }
@@ -853,7 +896,7 @@ class NavigatorElement extends BaseElement {
     if (index < 0) {
       // Fallback pushPage
       return new Promise(resolve => {
-        this._doorLock.waitUnlock(() => resolve(this._pushPage(page, options)));
+        this._doorLock.waitUnlock(() => resolve(this._pushPage(options)));
       });
     } else if (index === this._pages.length - 1) {
       // Page is already the top

--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -483,7 +483,7 @@ class NavigatorElement extends BaseElement {
     const tryInsertPage = () => {
       const unlock = this._doorLock.lock();
 
-      var run = templateHTML => {
+      const run = templateHTML => {
         const element = this._createPageElement(templateHTML);
         const pageObject = this._createPageObject(page, element, options);
 

--- a/core/src/elements/ons-navigator/index.spec.js
+++ b/core/src/elements/ons-navigator/index.spec.js
@@ -64,6 +64,18 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
+    it('adds a new page to the top of the page stack using options.pageHTML', (done) => {
+      nav.pushPage({
+        pageHTML: '<ons-page>hoge</ons-page>',
+        onTransitionEnd: () => {
+          let content = nav.getCurrentPage().element._getContentElement();
+          expect(nav.pages.length).to.equal(2);
+          expect(content.innerHTML).to.equal('hoge');
+          done();
+        }
+      });
+    });
+
     it('only accepts object options', () => {
       expect(() => nav.pushPage('hoge', 'string')).to.throw(Error);
     });
@@ -249,6 +261,22 @@ describe('OnsNavigatorElement', () => {
       nav.pushPage('hoge', {
         onTransitionEnd: () => {
           nav.insertPage(0, 'fuga');
+          setImmediate(() => {
+            expect(nav.pages.length).to.equal(3);
+
+            let content = nav.pages[0].element._getContentElement();
+            expect(content.innerHTML).to.equal('fuga');
+
+            done();
+          });
+        }
+      });
+    });
+
+    it('inserts a new page on a given index using `options.pageHTML`', (done) => {
+      nav.pushPage('hoge', {
+        onTransitionEnd: () => {
+          nav.insertPage(0, {pageHTML: '<ons-page>fuga</ons-page>'});
           setImmediate(() => {
             expect(nav.pages.length).to.equal(3);
 

--- a/examples/navigator_replace/index.html
+++ b/examples/navigator_replace/index.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en" ng-app="myApp">
+<head>
+  <meta charset="utf-8">
+  <title>Navigator Replace | Onsen UI</title>
+  <link rel="stylesheet" href="../styles/app.css"/>
+  <link rel="stylesheet" href="../../build/css/onsenui.css">
+  <link rel="stylesheet" href="../../build/css/onsen-css-components.css">
+
+  <script src="../../build/js/onsenui.js"></script>
+  <script src="../../build/js/angular/angular.js"></script>
+  <script src="../../build/js/angular-onsenui.js"></script>
+  <script src="../app.js"></script>
+
+</head>
+
+<body>
+  <ons-navigator var="myNavigator">
+    <ons-page>
+      <ons-toolbar>
+        <div class="left"><ons-back-button ng-show="myNavigator.pages.length > 1">Back</ons-back-button></div>
+        <div class="center">Navigator</div>
+      </ons-toolbar>
+
+      <div style="text-align: center">
+        <br>
+        <ons-button ng-click="myNavigator.pushPage('page1.html')">
+          Push
+        </ons-button>
+      </div>
+    </ons-page>
+  </ons-navigator>
+
+  <ons-template id="page1.html">
+    <ons-page>
+      <ons-toolbar>
+        <div class="left"><ons-back-button ng-show="myNavigator.pages.length > 1">Back</ons-back-button></div>
+        <div class="center">Pushed Page</div>
+      </ons-toolbar>
+
+      <div style="text-align: center">
+        <br>
+        <ons-button ng-click="myNavigator.pushPage('page1.html', {hoge: 'hoge'})">
+          Push 
+        </ons-button>
+        <ons-button ng-click="myNavigator.popPage({animation: 'slide'})">
+          Pop
+        </ons-button>
+        <ons-button ng-click="myNavigator.replacePage('page2.html', {animation: 'none'})">
+          Replace
+        </ons-button>
+      </div>
+    </ons-page>
+  </ons-template>
+
+  <ons-template id="page2.html">
+    <ons-page>
+      <ons-toolbar>
+        <div class="left"><ons-back-button ng-show="myNavigator.pages.length > 1">Back</ons-back-button></div>
+        <div class="center">Replaced Page</div>
+      </ons-toolbar>
+
+      <div style="text-align: center">
+        <br>
+        <ons-button ng-click="myNavigator.pushPage('page1.html', {hoge: 'hoge'})">
+          Push 
+        </ons-button>
+        <ons-button ng-click="myNavigator.popPage({animation: 'slide'})">
+          Pop
+        </ons-button>
+      </div>
+    </ons-page>
+  </ons-template>
+
+</body>
+</html>


### PR DESCRIPTION
@argelius This is done. Closes #1208 . It adds `options.pageHTML` parameter for every method of `ons-navigator`. It also makes `page` parameter optional (and adds `options.page` as well). Could you check the Japanese docs? I don't know either how to specify in the docs that both `page` and `options` are optional but at least one of them should be specified. Is possible to have two `@signature`?