### PR TITLE
feat(ons-tab) allow ons-tab-inactive and ons-tab-active to be used as tags

### DIFF
--- a/core/src/elements/ons-tab.js
+++ b/core/src/elements/ons-tab.js
@@ -249,9 +249,9 @@ class TabElement extends BaseElement {
     radio.checked = true;
     this.classList.add('active');
 
-    util.arrayFrom(this.querySelectorAll('[ons-tab-inactive]'))
+    util.arrayFrom(this.querySelectorAll('[ons-tab-inactive], ons-tab-inactive'))
       .forEach(element => element.style.display = 'none');
-    util.arrayFrom(this.querySelectorAll('[ons-tab-active]'))
+    util.arrayFrom(this.querySelectorAll('[ons-tab-active], ons-tab-active'))
       .forEach(element => element.style.display = 'inherit');
   }
 
@@ -260,9 +260,9 @@ class TabElement extends BaseElement {
     radio.checked = false;
     this.classList.remove('active');
 
-    util.arrayFrom(this.querySelectorAll('[ons-tab-inactive]'))
+    util.arrayFrom(this.querySelectorAll('[ons-tab-inactive], ons-tab-inactive'))
       .forEach(element => element.style.display = 'inherit');
-    util.arrayFrom(this.querySelectorAll('[ons-tab-active]'))
+    util.arrayFrom(this.querySelectorAll('[ons-tab-active], ons-tab-active'))
       .forEach(element => element.style.display = 'none');
   }
 


### PR DESCRIPTION
The framework react does not support custom attributes for non-custom elements, see https://github.com/facebook/react/issues/140. This is a problem for ons-tab-inactive and ons-tab-active,  since we use div like these:
`<div ons-tab-active></div> <div ons-tab-inactive></div>`

To solve this issue, in this pull request we allow to also use `<ons-tab-active></ons-tab-active>` and <ons-tab-inactive></ons-tab-inactive>`.