### PR TITLE
Splitter fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ v2.0.0-beta.7
  * ons-switch: Switch is now draggable.
  * core: Use a global gesture detector to improve performance.
  * ons-splitter-side: Fixed [#1222](https://github.com/OnsenUI/OnsenUI/issues/1222).
+ * ons-splitter: Improved performance and fixed minor bugs.
 
 v2.0.0-beta.6
 ----

--- a/core/src/elements/ons-splitter-content.js
+++ b/core/src/elements/ons-splitter-content.js
@@ -99,19 +99,12 @@ class SplitterContentElement extends BaseElement {
     return internal.getPageHTMLAsync(page).then((html) => {
       return new Promise(resolve => {
         rewritables.link(this, util.createFragment(html), options, (fragment) => {
-          while (this.childNodes[0]) {
-            if (this.childNodes[0]._hide instanceof Function) {
-              this.childNodes[0]._hide();
-            }
-            this.removeChild(this.childNodes[0]);
-          }
+          util.propagateAction(this, '_hide');
+          this.innerHTML = '';
 
           this.appendChild(fragment);
-          util.arrayFrom(fragment.children).forEach(child => {
-            if (child._show instanceof Function) {
-              child._show();
-            }
-          });
+
+          util.propagateAction(this, '_show');
 
           options.callback();
           resolve(this.firstChild);
@@ -132,27 +125,15 @@ class SplitterContentElement extends BaseElement {
   }
 
   _show() {
-    util.arrayFrom(this.children).forEach(child => {
-      if (child._show instanceof Function) {
-        child._show();
-      }
-    });
+    util.propagateAction(this, '_show');
   }
 
   _hide() {
-    util.arrayFrom(this.children).forEach(child => {
-      if (child._hide instanceof Function) {
-        child._hide();
-      }
-    });
+    util.propagateAction(this, '_hide');
   }
 
   _destroy() {
-    util.arrayFrom(this.children).forEach(child => {
-      if (child._destroy instanceof Function) {
-        child._destroy();
-      }
-    });
+    util.propagateAction(this, '_destroy');
     this.remove();
   }
 

--- a/core/src/elements/ons-splitter-mask.js
+++ b/core/src/elements/ons-splitter-mask.js
@@ -26,8 +26,8 @@ class SplitterMaskElement extends BaseElement {
   _onClick(event) {
     if (this.parentElement && this.parentElement.nodeName.toLowerCase() === 'ons-splitter') {
       // close side menus
-      this.parentElement.closeRight();
-      this.parentElement.closeLeft();
+      this.parentElement.closeRight().catch(() => {});
+      this.parentElement.closeLeft().catch(() => {});
     }
     event.stopPropagation();
   }

--- a/core/src/elements/ons-splitter-side.js
+++ b/core/src/elements/ons-splitter-side.js
@@ -631,7 +631,7 @@ class SplitterSideElement extends BaseElement {
    * @attribute side
    * @type {String}
    * @description
-   *   [en]Specify which side of the screen the ons-splitter-side element is located on. Possible values are "left" and "right".[/en]
+   *   [en]Specify which side of the screen the ons-splitter-side element is located on. Possible values are "left" (default) and "right".[/en]
    *   [ja]この要素が左か右かを指定します。指定できる値は"left"か"right"のみです。[/ja]
    */
 
@@ -692,6 +692,11 @@ class SplitterSideElement extends BaseElement {
     this._mode = null;
     this._page = null;
     this._isAttached = false;
+
+    if (!this.hasAttribute('side')) {
+      this.setAttribute('side', 'left');
+    }
+
     this._collapseStrategy = new CollapseDetection();
     this._animatorFactory = new AnimatorFactory({
       animators: window.OnsSplitterElement._animatorDict,
@@ -983,19 +988,12 @@ class SplitterSideElement extends BaseElement {
     return internal.getPageHTMLAsync(page).then((html) => {
       return new Promise(resolve => {
         rewritables.link(this, util.createFragment(html), options, (fragment) => {
-          while (this.childNodes[0]) {
-            if (this.childNodes[0]._hide instanceof Function) {
-              this.childNodes[0]._hide();
-            }
-            this.removeChild(this.childNodes[0]);
-          }
+          util.propagateAction(this, '_hide');
+          this.innerHTML = '';
 
           this.appendChild(fragment);
-          util.arrayFrom(fragment.childNodes).forEach(node => {
-            if (node._show instanceof Function) {
-              node._show();
-            }
-          });
+
+          util.propagateAction(this, '_show');
 
           options.callback();
           resolve(this.firstChild);
@@ -1088,27 +1086,15 @@ class SplitterSideElement extends BaseElement {
   }
 
   _show() {
-    util.arrayFrom(this.children).forEach(child => {
-      if (child._show instanceof Function) {
-        child._show();
-      }
-    });
+    util.propagateAction(this, '_show');
   }
 
   _hide() {
-    util.arrayFrom(this.children).forEach(child => {
-      if (child._hide instanceof Function) {
-        child._hide();
-      }
-    });
+    util.propagateAction(this, '_hide');
   }
 
   _destroy() {
-    util.arrayFrom(this.children).forEach(child => {
-      if (child._destroy instanceof Function) {
-        child._destroy();
-      }
-    });
+    util.propagateAction(this, '_destroy');
     this.remove();
   }
 

--- a/core/src/elements/ons-splitter/index.js
+++ b/core/src/elements/ons-splitter/index.js
@@ -156,11 +156,7 @@ class SplitterElement extends BaseElement {
   _open(side, options = {}) {
     const menu = this._getSideElement(side);
 
-    if (menu) {
-      return menu.open(options);
-    } else {
-      throw new Error('child "ons-splitter-side" element is not found in this element.');
-    }
+    return menu ? menu.open(options) : Promise.reject('child "ons-splitter-side" element is not found in this element.');
   }
 
   /**
@@ -211,11 +207,7 @@ class SplitterElement extends BaseElement {
   _close(side, options = {}) {
     const menu = this._getSideElement(side);
 
-    if (menu) {
-      return menu.close(options);
-    } else {
-      throw new Error('child "ons-splitter-side" element is not found in this element.');
-    }
+    return menu ? menu.close(options) : Promise.reject('child "ons-splitter-side" element is not found in this element.');
   }
 
   /**
@@ -242,11 +234,7 @@ class SplitterElement extends BaseElement {
   _toggle(side, options = {}) {
     const menu = this._getSideElement(side);
 
-    if (menu) {
-      return menu.toggle(options);
-    } else {
-      throw new Error('child "ons-splitter-side" element is not found in this element.');
-    }
+    return menu ? menu.toggle(options) : Promise.reject('child "ons-splitter-side" element is not found in this element.');
   }
 
   /**
@@ -304,11 +292,7 @@ class SplitterElement extends BaseElement {
   loadContentPage(page, options = {}) {
     const content = this._getContentElement();
 
-    if (content) {
-      return content.load(page, options);
-    } else {
-      throw new Error('child "ons-splitter-content" element is not found in this element.');
-    }
+    return content ? content.load(page, options) : Promise.reject('child "ons-splitter-content" element is not found in this element.');
   }
 
   _onDeviceBackButton(handler) {

--- a/core/src/elements/ons-tab.js
+++ b/core/src/elements/ons-tab.js
@@ -143,20 +143,6 @@ class TabElement extends BaseElement {
    *   [ja]このタブアイテムをアクティブ状態にするかどうかを指定します。trueもしくはfalseを指定できます。[/ja]
    */
 
-  /**
-   * @attribute persistent
-   * @description
-   *   [en]
-   *     Set to make the tab content persistent.
-   *     If this attribute it set the DOM will not be destroyed when navigating to another tab.
-   *   [/en]
-   *   [ja]
-   *     このタブで読み込んだページを永続化します。
-   *     この属性があるとき、別のタブのページに切り替えても、
-   *     読み込んだページのDOM要素は破棄されずに単に非表示になります。
-   *   [/ja]
-   */
-
   createdCallback() {
     if (!this.hasAttribute('_compiled')) {
       this._compile();
@@ -332,19 +318,19 @@ class TabElement extends BaseElement {
       const tabIndex = this._findTabIndex();
 
       OnsTabbarElement.rewritables.ready(tabbar, () => {
-        tabbar.setActiveTab(tabIndex, {animation: 'none'});
+        setImmediate(() => tabbar.setActiveTab(tabIndex, {animation: 'none'}));
       });
     } else {
       OnsTabbarElement.rewritables.ready(tabbar, () => {
-        if (!this._pageElement) {
+        setImmediate(() =>
           this._createPageElement(this.getAttribute('page'), pageElement => {
             OnsTabbarElement.rewritables.link(tabbar, pageElement, {}, pageElement => {
               this._pageElement = pageElement;
               this._pageElement.style.display = 'none';
               tabbar._contentElement.appendChild(this._pageElement);
             });
-          });
-        }
+          })
+        );
       });
     }
 

--- a/core/src/ons/util.js
+++ b/core/src/ons/util.js
@@ -128,7 +128,7 @@ util.hasAnyComponentAsParent = (element) => {
 util.propagateAction = (element, action) => {
   for (let i = 0; i < element.childNodes.length; i++) {
     let child = element.childNodes[i];
-    if (child[action]) {
+    if (child[action] instanceof Function) {
       child[action]();
     } else {
       util.propagateAction(child, action);


### PR DESCRIPTION
@argelius I started a small sample app this weekend and had some troubles with the version in master branch. This PR fixes few bugs in `ons-splitter`:

* `util.arrayFrom(fragment.children)` is empty so there were no `show` events.
* I think `this.innerHTML = ''` should be more efficient than `this.removeChild(this.childNodes[0])` in a loop.
* If the side is not specified it appears on the left but loses some functionality. Set `left` as the default side.
* In `ons-splitter-mask` we try to close rightMenu and leftMenu, but if any of those is missing it will throw an error. I've changed that error to be a rejected promise (it should have been like this since the beginning) and ignore the error with `.catch(() => {})`.

The second commit fixes some console error with tabs.