### PR TITLE
feat(ons-splitter) support collapse='true' on ons-splitter-side

### DIFF
--- a/core/src/elements/ons-splitter-side.js
+++ b/core/src/elements/ons-splitter-side.js
@@ -775,7 +775,7 @@ class SplitterSideElement extends BaseElement {
 
     const collapse = ('' + this.getAttribute('collapse')).trim();
 
-    if (collapse === '') {
+    if (collapse === '' || collapse === 'true') {
       this._updateCollapseStrategy(new StaticCollapseDetection());
     } else if (collapse === 'portrait' || collapse === 'landscape') {
       this._updateCollapseStrategy(new OrientationCollapseDetection(collapse));


### PR DESCRIPTION
Currently we support thinks like `<ons-splitter-side collapse />`, but it would be nice to also support `<ons-splitter-side collapse='true' />`, since framework like react convert this directly. 