### PR TITLE
feat(ons-popover): add cancel event

### DIFF
--- a/core/src/elements/ons-popover/index.js
+++ b/core/src/elements/ons-popover/index.js
@@ -645,7 +645,11 @@ class PopoverElement extends BaseElement {
 
   _cancel() {
     if (this.isCancelable()) {
-      this.hide();
+      this.hide({
+        callback: () => {
+          util.triggerElementEvent(this, 'cancel');
+        }
+      });
     }
   }
 }


### PR DESCRIPTION
Currently ons-dialog and ons-alert-dialog throw an 'cancel' event if the user clicks outside of the box. But for ons-popover this is not the case. This fix just makes it more consistent by also adding this event to ons-popover.