### PR TITLE
fix(ons-list-item): Adds 'center' class.

### DIFF
--- a/core/src/elements/ons-list-item.js
+++ b/core/src/elements/ons-list-item.js
@@ -136,6 +136,7 @@ class ListItemElement extends BaseElement {
       this.insertBefore(center, right || null);
     }
 
+    center.classList.add('center');
     center.classList.add('list__item__center');
 
     if (this.hasAttribute('ripple')) {


### PR DESCRIPTION
@argelius . If the user specifies a center element it will have `.center` class so I think we should add it as well when they don't specify it. It could be useful for selectors.