### PR TITLE
fix(autostyle): Avoid conflicts when changing modifiers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 CHANGELOG
 ====
 
+v2.0.0-beta.8
+----
+ * core: Small fix for Autostyling.
+
 v2.0.0-beta.7
 ----
  * core: Automatic Styling feature depending on current platform.

--- a/core/src/ons/autostyle.js
+++ b/core/src/ons/autostyle.js
@@ -42,7 +42,6 @@ platforms.android = element => {
     !/material/.test(element.getAttribute('modifier'))) {
 
     const oldModifier = element.getAttribute('modifier') || '';
-    element.setAttribute('modifier', '');
 
     let newModifier = oldModifier.trim().split(/\s+/).map(e => modifiersMap.hasOwnProperty(e) ? modifiersMap[e] : e);
     newModifier.unshift('material');


### PR DESCRIPTION
@argelius Autostyle changes modifiers in the compile function and calls `modifierInit`, but those modifications also trigger `attributeChangedCallback` asynchronously. In that callback we check again the modifers and there could be problems in some cases. For example, `ons-list-item` is not applying modifiers like `nodivider` correctly in MD. This PR should fix that since now the attributeChangedCallback will be called always with the same modifier value.

It would be better to avoid triggering `attributeChangedCallback` within compile function, but the only way  I've found is to set `_compile` attribute asynchronously (setImmediate(() => this.setAttribute('_compile', ''));` and trigger modifierChanged only if the element is already compiled. That way the events will be handled before `_compile` is set... but I don't like this solution too much. What do you think?