### PR TITLE
docs(ons-lazy-repeat): update ons-lazy-repeat example to make it work

### DIFF
--- a/core/src/elements/ons-lazy-repeat.js
+++ b/core/src/elements/ons-lazy-repeat.js
@@ -129,7 +129,7 @@ class InternalDelegate extends LazyRepeatDelegate {
  * </script>
  *
  * <ons-list>
- *   <ons-lazy-repeat>
+ *   <ons-lazy-repeat id="list">
  *     <ons-list-item></ons-list-item>
  *   </ons-lazy-repeat>
  * </ons-list>


### PR DESCRIPTION
@argelius in the example the id was missing, so the querySelector would be always null.