### PR TITLE
Fixing ios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ v2.0.0-beta.8
  * core: Small fix for Autostyling.
  * ons-list-item: Fix "tappable" attribute.
  * ons-navigator: Added default `options` poperty.
+ * ons-navigator: Fixed flickering in Lift animation for iOS.
+ * ons-page: Does not remove 'style' attribute anymore.
+ * ons.notification: Fixed an issue in iOS related to CustomElements.
 
 v2.0.0-beta.7
 ----

--- a/core/src/elements/ons-navigator/lift-animator.js
+++ b/core/src/elements/ons-navigator/lift-animator.js
@@ -34,7 +34,7 @@ export default class LiftNavigatorTransitionAnimator extends NavigatorTransition
 
     this.backgroundMask = util.createElement(`
       <div style="position: absolute; width: 100%; height: 100%;
-        background-color: black;"></div>
+        background: linear-gradient(black, white);"></div>
     `);
   }
 

--- a/core/src/elements/ons-page.js
+++ b/core/src/elements/ons-page.js
@@ -303,11 +303,6 @@ class PageElement extends BaseElement {
       content.appendChild(this.childNodes[0]);
     }
 
-    if (this.hasAttribute('style')) {
-      background.setAttribute('style', this.getAttribute('style'));
-      this.removeAttribute('style', null);
-    }
-
     const fragment = document.createDocumentFragment();
     fragment.appendChild(background);
     fragment.appendChild(content);

--- a/core/src/elements/ons-page.spec.js
+++ b/core/src/elements/ons-page.spec.js
@@ -206,16 +206,6 @@ describe('OnsPageElement', () => {
       div2.innerHTML = div1.innerHTML;
       expect(div1.isEqualNode(div2)).to.be.true;
     });
-
-    it('uses style attribute', () => {
-      while (element.lastChild) {
-        element.removeChild(element.lastChild);
-      }
-      element.setAttribute('style', 'hoge');
-      element._compile();
-      expect(element.hasAttribute('style')).to.be.false;
-      expect(element.firstChild.hasAttribute('style')).to.be.true;
-    });
   });
 
   describe('autoStyling', () => {

--- a/core/src/ons/notification.js
+++ b/core/src/ons/notification.js
@@ -72,6 +72,8 @@ notification._createAlertDialog = function(title, message,
     <div class="alert-dialog-footer"></div>
   </ons-alert-dialog>`);
 
+  CustomElements.upgrade(dialogElement);
+
   if (id) {
     dialogElement.setAttribute('id', id);
   }


### PR DESCRIPTION
@argelius Please check this small fixes:

* Lift animation translates the leavePage 10% to the top and adds a black mask behind. On iOS the translation of leavePage happens before the translation of enterPage so it's possible to see the black mask for a moment. Adding a delay slightly modifies the animation in every platform so I think this fix is maybe better.

* ons.notification was crashing on iOS when trying call `dialogElement.show` internally because it was not a function yet.

* Since non active tabs are now loaded since the beginning it's necessary to add `display: none` to the element. I think this could be fixed also with `CustomElements.upgrade`, but I guess it's enough with this fix.