### PR TITLE
feat(ons-lazy-repeat): Add delegate render to ons-lazy-repeat

### DIFF
--- a/core/src/elements/ons-lazy-repeat.js
+++ b/core/src/elements/ons-lazy-repeat.js
@@ -45,6 +45,14 @@ class InternalDelegate extends LazyRepeatDelegate {
     });
   }
 
+  hasRenderFunction() {
+    return this._userDelegate._render !== undefined;
+  }
+
+  render(items, height) {
+    this._userDelegate._render(items, height);
+  }
+
   countItems() {
     const count = this._userDelegate.countItems();
 

--- a/core/src/ons/internal/lazy-repeat.js
+++ b/core/src/ons/internal/lazy-repeat.js
@@ -139,6 +139,12 @@ export class LazyRepeatProvider {
 
   _render() {
     const items = this._getItemsInView();
+
+    if (this._delegate.hasRenderFunction && this._delegate.hasRenderFunction()) {
+      this._delegate.render(items, this._calculateListHeight(items));
+      return;
+    }
+
     const keep = {};
 
     for (let i = 0, l = items.length; i < l; i++) {
@@ -153,11 +159,11 @@ export class LazyRepeatProvider {
       }
     }
 
-    this._wrapperElement.style.height = this._calculateListHeight() + 'px';
+    this._wrapperElement.style.height = this._calculateListHeight(items) + 'px';
   }
 
-  _calculateListHeight() {
-    let indices = Object.keys(this._renderedItems).map((n) => parseInt(n));
+  _calculateListHeight(items) {
+    let indices = items.map((item) => parseInt(item.index));
     return this._itemHeightSum[indices.pop()] || 0;
   }
 


### PR DESCRIPTION
@argelius this will add a delegate render, that can be used to redo the rendering of the items. I am thinking, probably a delegate is not the right way, because i only want to use this in the react binding, what do you think, maybe its better to use a rewritable?