### PR TITLE
fix(ons): ons.ready waits for WebComponentsReady event.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v2.0.0-beta.8
  * ons-navigator: Fixed flickering in Lift animation for iOS.
  * ons-page: Does not remove 'style' attribute anymore.
  * ons.notification: Fixed an issue in iOS related to CustomElements.
+ * ons.ready: Waits for `WebComponentsReady` event instead of `DOMContentLoaded`.
 
 v2.0.0-beta.7
 ----

--- a/core/src/ons/ons.js
+++ b/core/src/ons/ons.js
@@ -415,7 +415,7 @@ ons._resolveLoadingPlaceholder = function(element, page, link) {
 
 function waitDeviceReady() {
   const unlockDeviceReady = ons._readyLock.lock();
-  window.addEventListener('DOMContentLoaded', () => {
+  window.addEventListener('WebComponentsReady', () => {
     if (ons.isWebView()) {
       window.document.addEventListener('deviceready', unlockDeviceReady, false);
     } else {


### PR DESCRIPTION
@argelius I think this does not break anything.