### PR TITLE
Fix scrolling issue on Android browser

### DIFF
--- a/core/css/input.css
+++ b/core/css/input.css
@@ -23,8 +23,8 @@ ons-input .text-input__label:not(.text-input--material__label) {
 }
 
 ons-input .text-input__label--active {
-  transform: translate3d(0, -75%, 0) scale(0.75);
-  -webkit-transform: translate3d(0, -75%, 0) scale(0.75);
+  transform: translate(0, -75%) scale(0.75);
+  -webkit-transform: translate(0, -75%) scale(0.75);
   transform-origin: left top;
   -webkit-transform-origin: left top;
   transition: transform 0.1s ease-in, color 0.1s ease-in;

--- a/css-components/www/patterns/lib/onsen/stylus/components/button.styl
+++ b/css-components/www/patterns/lib/onsen/stylus/components/button.styl
@@ -332,7 +332,6 @@ button--material()
   transition box-shadow 0.2s ease
   text-align center
   font-size 14px
-  transform: translate3d(0, 0, 0);
   text-transform uppercase
   background-color var-material-button-background-color
   color var-material-button-color

--- a/css-components/www/patterns/lib/onsen/stylus/components/text-input.styl
+++ b/css-components/www/patterns/lib/onsen/stylus/components/text-input.styl
@@ -188,7 +188,7 @@ text-input-underbar-disabled()
   padding-bottom 2px
   border-radius 0
   height 24px
-  -webkit-transform translate3d(0, 0, 0) // prevent ios flicker
+  -webkit-transform translate(0, 0) // prevent ios flicker
 
 .text-input--material__label
   color var-material-text-input-active-color


### PR DESCRIPTION
Replaces translate3d with translate for small elements due to buggy results when scrolling...

Scrolling hardware accelerated elements results in overlapping with other elements on some Android devices in their default Android browser. Buggy scrolling has been confirmed in [4.0, 4.4]. Fixes #1227