### PR TITLE
fix(ons-icon): Fixed a bug in old Android versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ v2.0.0-beta.8
  * ons-page: Does not remove 'style' attribute anymore.
  * ons.notification: Fixed an issue in iOS related to CustomElements.
  * ons.ready: Waits for `WebComponentsReady` event instead of `DOMContentLoaded`.
+ * ons-icon: Fixed a bug in old Android versions.
 
 v2.0.0-beta.7
 ----

--- a/core/src/elements/ons-icon.js
+++ b/core/src/elements/ons-icon.js
@@ -119,16 +119,12 @@ class IconElement extends BaseElement {
    * Remove unneeded class value.
    */
   _cleanClassAttribute() {
-    const classList = this.classList;
+    util.arrayFrom(this.classList)
+      .filter(className => /^(fa$|fa-|ion-|zmdi-)/.test(className))
+      .forEach(className => this.classList.remove(className));
 
-    Array.apply(null, this.classList).filter(klass => {
-      return klass === 'fa' || klass.indexOf('fa-') === 0 || klass.indexOf('ion-') === 0 || klass.indexOf('zmdi-') === 0;
-    }).forEach(className => {
-      classList.remove(className);
-    });
-
-    classList.remove('zmdi');
-    classList.remove('ons-icon--ion');
+    this.classList.remove('zmdi');
+    this.classList.remove('ons-icon--ion');
   }
 
   _buildClassAndStyle() {


### PR DESCRIPTION
@argelius The To-Do app [was crashing](https://github.com/frankdiox/OnsenUI-Todo-App/issues/1) in Android 4.0.4. This fixes it.