### PR TITLE
Fix bottom toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ v2.0.0-beta.8
  * ons.ready: Waits for `WebComponentsReady` event instead of `DOMContentLoaded`.
  * ons-icon: Fixed a bug in old Android versions.
  * ons-page: Add onInfiniteScroll functionality [#1165](https://github.com/OnsenUI/OnsenUI/issues/1165).
+ * ons-bottom-toolbar: Fixed a bug making it scroll with the content in some cases.
 
 v2.0.0-beta.7
 ----

--- a/bindings/angular1/directives/bottomToolbar.js
+++ b/bindings/angular1/directives/bottomToolbar.js
@@ -10,13 +10,6 @@
           GenericView.register(scope, element, attrs, {
             viewKey: 'ons-bottomToolbar'
           });
-
-          var inline = typeof attrs.inline !== 'undefined';
-          var pageView = element.inheritedData('ons-page');
-
-          if (pageView && !inline) {
-            pageView._element[0]._registerBottomToolbar(element[0]);
-          }
         },
 
         post: function(scope, element, attrs) {

--- a/core/css/common.css
+++ b/core/css/common.css
@@ -129,7 +129,7 @@ ons-toolbar + .page__background + .page__content {
   -ms-touch-action: pan-y;
 }
 
-.page__bottom-bar-fill ~ .page__content {
+.page-with-bottom-toolbar > .page__content {
   bottom: 44px;
 }
 

--- a/core/css/common.css
+++ b/core/css/common.css
@@ -58,6 +58,21 @@ input, textarea {
   -webkit-user-select: auto;
 }
 
+ons-toolbar:not([inline]) {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  z-index: 10000;
+}
+
+ons-bottom-toolbar:not([inline]) {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
 .page,
 .page__content {
   background-color: transparent !important;

--- a/core/src/elements/ons-bottom-toolbar.js
+++ b/core/src/elements/ons-bottom-toolbar.js
@@ -58,8 +58,6 @@ class BottomToolbarElement extends BaseElement {
 
   createdCallback() {
     this.classList.add('bottom-bar');
-    // this.style.zIndex = '0';
-    this._update();
 
     ModifierUtil.initModifier(this, scheme);
   }
@@ -72,16 +70,11 @@ class BottomToolbarElement extends BaseElement {
   }
 
   attributeChangedCallback(name, last, current) {
-    if (name === 'inline') {
-      this._update();
-    } else if (name === 'modifier') {
-      return ModifierUtil.onModifierChanged(last, current, this, scheme);
+    if (name === 'modifier') {
+      ModifierUtil.onModifierChanged(last, current, this, scheme);
     }
   }
 
-  _update() {
-    this.style.position = this.hasAttribute('inline') ? 'static' : 'absolute';
-  }
 }
 
 window.OnsBottomToolbarElement = document.registerElement('ons-bottom-toolbar', {

--- a/core/src/elements/ons-bottom-toolbar.js
+++ b/core/src/elements/ons-bottom-toolbar.js
@@ -58,10 +58,17 @@ class BottomToolbarElement extends BaseElement {
 
   createdCallback() {
     this.classList.add('bottom-bar');
-    this.style.zIndex = '0';
+    // this.style.zIndex = '0';
     this._update();
 
     ModifierUtil.initModifier(this, scheme);
+  }
+
+  attachedCallback() {
+    const page = util.findParent(this, 'ons-page');
+    if (this.parentNode != page) {
+      page._registerBottomToolbar(this);
+    }
   }
 
   attributeChangedCallback(name, last, current) {
@@ -73,9 +80,7 @@ class BottomToolbarElement extends BaseElement {
   }
 
   _update() {
-    const inline = typeof this.getAttribute('inline') === 'string';
-
-    this.style.position = inline ? 'static' : 'absolute';
+    this.style.position = this.hasAttribute('inline') ? 'static' : 'absolute';
   }
 }
 

--- a/core/src/elements/ons-bottom-toolbar.spec.js
+++ b/core/src/elements/ons-bottom-toolbar.spec.js
@@ -10,13 +10,6 @@ describe('ons-bottom-toolbar', () => {
     expect(element.classList.contains('bottom-bar')).to.be.true;
   });
 
-  it('default \'position\' is \'absolute\' and default \'z-index\' is \'0\'', () => {
-    var element = new OnsBottomToolbarElement();
-    expect(element.style.zIndex).to.equal('0');
-    expect(element.style.position).to.equal('absolute');
-    expect(element.style.position).not.to.equal('relative');
-  });
-
   it('provides \'modifier\' attribute', () => {
     var element = new OnsBottomToolbarElement();
     element.setAttribute('modifier', 'hoge');
@@ -33,11 +26,16 @@ describe('ons-bottom-toolbar', () => {
     expect(element.classList.contains('bottom-bar--fuga')).to.be.true;
   });
 
-  it('provides \'inline\' attribute', () => {
-    var element = new OnsBottomToolbarElement();
-    element.setAttribute('inline', '');
-    expect(element.style.position).to.equal('static');
-    expect(element.style.position).not.to.equal('absolute');
+  it('ensures it\'s location in the page', () => {
+    var element = new OnsBottomToolbarElement(),
+      page = new OnsPageElement();
+
+    document.body.appendChild(page);
+    page.appendChild(element);
+
+    expect(element.parentNode).to.equal(page);
+
+    document.body.removeChild(page);
   });
 
   describe('#_compile()', () => {

--- a/core/src/elements/ons-page.js
+++ b/core/src/elements/ons-page.js
@@ -250,27 +250,13 @@ class PageElement extends BaseElement {
   /**
    * @return {Boolean}
    */
-  _hasToolbarElement() {
-    return !!util.findChild(this, 'ons-toolbar');
-  }
-
-  /**
-   * @return {Boolean}
-   */
   _canAnimateToolbar() {
-    const toolbar = util.findChild(this, 'ons-toolbar');
-    if (toolbar) {
+    if (util.findChild(this, 'ons-toolbar')) {
       return true;
     }
-
-    const elements = this._contentElement.children;
-    for (let i = 0; i < elements.length; i++) {
-      if (elements[i].nodeName.toLowerCase() === 'ons-toolbar' && !elements[i].hasAttribute('inline')) {
-        return true;
-      }
-    }
-
-    return false;
+    return !!util.findChild(this._contentElement, (e) => {
+      return e.nodeName.toLowerCase() === 'ons-toolbar' && !e.hasAttribute('inline');
+    });
   }
 
   /**
@@ -321,13 +307,8 @@ class PageElement extends BaseElement {
    */
   _registerBottomToolbar(element) {
     if (!util.findChild(this, '.page__bottom-bar-fill')) {
-      const fill = document.createElement('div');
-      fill.classList.add('page__bottom-bar-fill');
-      // fill.style.width = '0px';
-      // fill.style.height = '0px';
-
-      this.insertBefore(fill, this.children[0]);
-      this.insertBefore(element, null);
+      this.insertBefore(util.create('.page__bottom-bar-fill'), this.children[0]);
+      this.appendChild(element);
     }
   }
 
@@ -351,21 +332,15 @@ class PageElement extends BaseElement {
   _compile() {
     ons._autoStyle.prepare(this);
 
-    const background = document.createElement('div');
-    background.classList.add('page__background');
+    const background = util.create('.page__background');
+    const content = util.create('.page__content');
 
-    const content = document.createElement('div');
-    content.classList.add('page__content');
-
-    while (this.childNodes[0]) {
-      content.appendChild(this.childNodes[0]);
+    while (this.firstChild) {
+      content.appendChild(this.firstChild);
     }
 
-    const fragment = document.createDocumentFragment();
-    fragment.appendChild(background);
-    fragment.appendChild(content);
-
-    this.appendChild(fragment);
+    this.appendChild(background);
+    this.appendChild(content);
 
     ModifierUtil.initModifier(this, scheme);
 
@@ -375,13 +350,11 @@ class PageElement extends BaseElement {
   _registerExtraElement(element) {
     let extra = util.findChild(this, '.page__extra');
     if (!extra) {
-      extra = document.createElement('div');
-      extra.classList.add('page__extra');
-      extra.style.zIndex = '10001';
-      this.insertBefore(extra, null);
+      extra = util.create('.page__extra', {zIndex: 10001});
+      this.appendChild(extra);
     }
 
-    extra.insertBefore(element, null);
+    extra.appendChild(element);
   }
 
   _tryToFillStatusBar() {
@@ -389,28 +362,23 @@ class PageElement extends BaseElement {
       .then(() => {
         let fill = this.querySelector('.page__status-bar-fill');
 
-        if (fill instanceof HTMLElement) {
-          return fill;
-        }
+        if (!fill) {
+          fill = util.create('.page__status-bar-fill');
 
-        fill = document.createElement('div');
-        fill.classList.add('page__status-bar-fill');
+          let bottomBarFill = util.findChild(this, '.page__bottom-bar-fill');
 
-        let bottomBarFill = util.findChild(this, '.page__bottom-bar-fill');
-
-        if (bottomBarFill) {
-          this.insertBefore(fill, bottomBarFill.nextSibling);
-        } else {
-          this.insertBefore(fill, this.children[0]);
+          if (bottomBarFill) {
+            this.insertBefore(fill, bottomBarFill.nextSibling);
+          } else {
+            this.insertBefore(fill, this.children[0]);
+          }
         }
 
         return fill;
       })
       .catch(() => {
         const el = this.querySelector('.page__status-bar-fill');
-        if (el instanceof HTMLElement) {
-          el.remove();
-        }
+        el && el.remove();
       });
   }
 

--- a/core/src/elements/ons-page.js
+++ b/core/src/elements/ons-page.js
@@ -306,10 +306,8 @@ class PageElement extends BaseElement {
    * @param {HTMLElement} element
    */
   _registerBottomToolbar(element) {
-    if (!util.findChild(this, '.page__bottom-bar-fill')) {
-      this.insertBefore(util.create('.page__bottom-bar-fill'), this.children[0]);
-      this.appendChild(element);
-    }
+    this.classList.add('page-with-bottom-toolbar');
+    this.appendChild(element);
   }
 
   attributeChangedCallback(name, last, current) {
@@ -365,13 +363,7 @@ class PageElement extends BaseElement {
         if (!fill) {
           fill = util.create('.page__status-bar-fill');
 
-          let bottomBarFill = util.findChild(this, '.page__bottom-bar-fill');
-
-          if (bottomBarFill) {
-            this.insertBefore(fill, bottomBarFill.nextSibling);
-          } else {
-            this.insertBefore(fill, this.children[0]);
-          }
+          this.insertBefore(fill, this.children[0]);
         }
 
         return fill;

--- a/core/src/elements/ons-page.js
+++ b/core/src/elements/ons-page.js
@@ -320,11 +320,11 @@ class PageElement extends BaseElement {
    * @param {HTMLElement} element
    */
   _registerBottomToolbar(element) {
-    if (!util.findChild(this, '.page__status-bar-fill')) {
+    if (!util.findChild(this, '.page__bottom-bar-fill')) {
       const fill = document.createElement('div');
       fill.classList.add('page__bottom-bar-fill');
-      fill.style.width = '0px';
-      fill.style.height = '0px';
+      // fill.style.width = '0px';
+      // fill.style.height = '0px';
 
       this.insertBefore(fill, this.children[0]);
       this.insertBefore(element, null);
@@ -395,22 +395,12 @@ class PageElement extends BaseElement {
 
         fill = document.createElement('div');
         fill.classList.add('page__status-bar-fill');
-        fill.style.width = '0px';
-        fill.style.height = '0px';
 
-        let bottomBarFill;
-
-        for (let i = 0; i < this.children.length; i++) {
-          if (this.children[i].classList.contains('page__bottom-bar-fill')) {
-            bottomBarFill = this.children[i];
-            break;
-          }
-        }
+        let bottomBarFill = util.findChild(this, '.page__bottom-bar-fill');
 
         if (bottomBarFill) {
           this.insertBefore(fill, bottomBarFill.nextSibling);
-        }
-        else {
+        } else {
           this.insertBefore(fill, this.children[0]);
         }
 

--- a/core/src/elements/ons-page.spec.js
+++ b/core/src/elements/ons-page.spec.js
@@ -94,14 +94,6 @@ describe('OnsPageElement', () => {
     });
   });
 
-  describe('#_hasToolbarElement()', () => {
-    it('returns if a toolbar exists', () => {
-      expect(element._hasToolbarElement()).to.be.false;
-      element._registerToolbar(new OnsToolbarElement());
-      expect(element._hasToolbarElement()).to.be.true;
-    });
-  });
-
   describe('#_canAnimateToolbar()', () => {
     it('works with normal toolbar', () => {
       expect(element._canAnimateToolbar()).to.be.false;

--- a/core/src/elements/ons-toolbar.js
+++ b/core/src/elements/ons-toolbar.js
@@ -16,6 +16,7 @@ limitations under the License.
 */
 
 import ons from 'ons/ons';
+import util from 'ons/util';
 import ModifierUtil from 'ons/internal/modifier-util';
 import BaseElement from 'ons/base-element';
 
@@ -97,20 +98,9 @@ class ToolbarElement extends BaseElement {
     if (!this.parentNode || this.hasAttribute('inline')) {
       return;
     }
+    let page = util.findParent(this, 'ons-page');
 
-    if (this.parentNode.nodeName.toLowerCase() !== 'ons-page') {
-      var page = this;
-      for (;;) {
-        page = page.parentNode;
-
-        if (!page) {
-          return;
-        }
-
-        if (page.nodeName.toLowerCase() === 'ons-page') {
-          break;
-        }
-      }
+    if (page && page !== this.parentNode) {
       page._registerToolbar(this);
     }
   }
@@ -168,7 +158,6 @@ class ToolbarElement extends BaseElement {
   _ensureToolbarItemElements() {
 
     var hasCenterClassElementOnly = this.children.length === 1 && this.children[0].classList.contains('center');
-    var center;
 
     for (var i = 0; i < this.childNodes.length; i++) {
       // case of not element
@@ -177,10 +166,10 @@ class ToolbarElement extends BaseElement {
       }
     }
 
-    if (hasCenterClassElementOnly) {
-      center = this._ensureToolbarItemContainer('center');
-    } else {
-      center = this._ensureToolbarItemContainer('center');
+    var center = this._ensureToolbarItemContainer('center');
+    center.classList.add('navigation-bar__title');
+
+    if (!hasCenterClassElementOnly) {
       var left = this._ensureToolbarItemContainer('left');
       var right = this._ensureToolbarItemContainer('right');
 
@@ -195,26 +184,18 @@ class ToolbarElement extends BaseElement {
           this.removeChild(right);
         }
 
-        var fragment = document.createDocumentFragment();
-        fragment.appendChild(left);
-        fragment.appendChild(center);
-        fragment.appendChild(right);
-
-        this.appendChild(fragment);
+        this.appendChild(left);
+        this.appendChild(center);
+        this.appendChild(right);
       }
     }
-    center.classList.add('navigation-bar__title');
   }
 
   _ensureToolbarItemContainer(name) {
-    var container = ons._util.findChild(this, '.' + name);
-
-    if (!container) {
-      container = document.createElement('div');
-      container.classList.add(name);
-    }
+    var container = util.findChild(this, '.' + name) || util.create('.' + name);
 
     container.classList.add('navigation-bar__' + name);
+
     return container;
   }
 

--- a/core/src/elements/ons-toolbar.js
+++ b/core/src/elements/ons-toolbar.js
@@ -136,17 +136,7 @@ class ToolbarElement extends BaseElement {
   _compile() {
     ons._autoStyle.prepare(this);
 
-    var inline = this.hasAttribute('inline');
-
     this.classList.add('navigation-bar');
-
-    if (!inline) {
-      this.style.position = 'absolute';
-      this.style.zIndex = '10000';
-      this.style.left = '0px';
-      this.style.right = '0px';
-      this.style.top = '0px';
-    }
 
     this._ensureToolbarItemElements();
 
@@ -166,12 +156,12 @@ class ToolbarElement extends BaseElement {
       }
     }
 
-    var center = this._ensureToolbarItemContainer('center');
+    var center = this._ensureToolbarElement('center');
     center.classList.add('navigation-bar__title');
 
     if (!hasCenterClassElementOnly) {
-      var left = this._ensureToolbarItemContainer('left');
-      var right = this._ensureToolbarItemContainer('right');
+      var left = this._ensureToolbarElement('left');
+      var right = this._ensureToolbarElement('right');
 
       if (this.children[0] !== left || this.children[1] !== center || this.children[2] !== right) {
         if (left.parentNode) {
@@ -191,12 +181,12 @@ class ToolbarElement extends BaseElement {
     }
   }
 
-  _ensureToolbarItemContainer(name) {
-    var container = util.findChild(this, '.' + name) || util.create('.' + name);
+  _ensureToolbarElement(name) {
+    var element = util.findChild(this, '.' + name) || util.create('.' + name);
 
-    container.classList.add('navigation-bar__' + name);
+    element.classList.add('navigation-bar__' + name);
 
-    return container;
+    return element;
   }
 
 }

--- a/core/src/ons/util.js
+++ b/core/src/ons/util.js
@@ -24,11 +24,19 @@ const util = {};
  * @return {Function}
  */
 util.prepareQuery = (query) => {
-  return query instanceof Function
-    ? query
-    : query.substr(0, 1) === '.' ?
-      (node) => node.classList.contains(query.substr(1)) :
-      (node) => node.nodeName.toLowerCase() === query;
+  return query instanceof Function ? query : (element) => util.match(element, query);
+};
+
+/**
+ * @param {Element} element
+ * @param {String/Function} query dot class name or node name.
+ * @return {Boolean}
+ */
+util.match = (element, query) => {
+  if (query[0] === '.') {
+    return element.classList.contains(query.slice(1));
+  }
+  return element.nodeName.toLowerCase() === query;
 };
 
 /**
@@ -73,13 +81,11 @@ util.findChildRecursively = (element, query) => {
 
 /**
  * @param {Element} element
- * @param {String} query dot class name or node name.
+ * @param {String/Function} query dot class name or node name or matcher function.
  * @return {HTMLElement/null}
  */
 util.findParent = (element, query) => {
-  const match = query.substr(0, 1) === '.' ?
-    (node) => node.classList.contains(query.substr(1)) :
-    (node) => node.nodeName.toLowerCase() === query;
+  const match = util.prepareQuery(query);
 
   let parent = element.parentNode;
   for (;;) {
@@ -134,6 +140,25 @@ util.propagateAction = (element, action) => {
       util.propagateAction(child, action);
     }
   }
+};
+
+
+/**
+ * @param {String} selector - tag and class only
+ * @param {Object} style
+ * @param {Element}
+ */
+util.create = (selector = '', style = {}) => {
+  let classList = selector.split('.'),
+    element = document.createElement(classList.shift() || 'div');
+
+  if (classList.length) {
+    element.className = classList.join(' ');
+  }
+
+  util.extend(element.style, style);
+
+  return element;
 };
 
 /**


### PR DESCRIPTION
The bottom toolbar wasn't working properly in 2 scenarios:
1. when there is no angular
2. in some cases when there is a status-bar-fill (IOS)

This pull request fixes those and also removes the need of  the element `.page__bottom-bar-fill`. This also simplifies the logic in `tryToFIllStatusbar` in `ons-page` as it does not need to work around it.

It's probably going to be easier if we don't add a `.page__status-bar-fill` element too, as it's used only for styling the elements after it and thus can be easily replaced by putting an attribute or class to the parent instead, but since the same logic is present in `ons-tabbar` I have decided to leave this for after the changes from the react branch have been merged in order to avoid unnecessary conflicts with that branch. 