### PR TITLE
fix(tests): make tests more stable and update selinium

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -409,16 +409,16 @@ gulp.task('webdriver-download', function() {
   }
 
   if (platform === 'linux') {
-    chromeDriverUrl = 'http://chromedriver.storage.googleapis.com/2.12/chromedriver_linux64.zip';
+    chromeDriverUrl = 'http://chromedriver.storage.googleapis.com/2.19/chromedriver_linux64.zip';
   }
   else if (platform === 'darwin') {
-    chromeDriverUrl = 'http://chromedriver.storage.googleapis.com/2.14/chromedriver_mac32.zip';
+    chromeDriverUrl = 'http://chromedriver.storage.googleapis.com/2.21/chromedriver_mac32.zip';
   }
   else {
     chromeDriverUrl = 'http://chromedriver.storage.googleapis.com/2.14/chromedriver_win32.zip';
   }
 
-  var selenium = $.download('https://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar')
+  var selenium = $.download('https://selenium-release.storage.googleapis.com/2.51/selenium-server-standalone-2.51.0.jar')
     .pipe(gulp.dest(destDir));
 
   var chromedriver = $.download(chromeDriverUrl)
@@ -452,14 +452,14 @@ gulp.task('e2e-test', ['webdriver-download', 'prepare'], function() {
     configFile: './test/e2e/protractor.conf.js',
     args: [
       '--baseUrl', 'http://127.0.0.1:' + port,
-      '--seleniumServerJar', path.join(__dirname, '.selenium/selenium-server-standalone-2.45.0.jar'),
+      '--seleniumServerJar', path.join(__dirname, '.selenium/selenium-server-standalone-2.51.0.jar'),
       '--chromeDriver', path.join(__dirname, '.selenium/chromedriver')
     ]
   };
 
   var specs = argv.specs ?
     argv.specs.split(',').map(function(s) { return s.trim(); }) :
-    ['test/e2e/**/*.js'];
+    ['test/e2e/**/*js'];
 
   return gulp.src(specs)
     .pipe($.protractor.protractor(conf))

--- a/test/e2e/alertDialog/scenarios.js
+++ b/test/e2e/alertDialog/scenarios.js
@@ -22,18 +22,20 @@
       it('should trigger events', function() {
         browser.get(path);
 
-        var alertDialog = element(by.css('ons-alert-dialog')),
-          isVisible = element(by.id('alert-dialog-visible')).isDisplayed;
+        var alertDialog = element(by.css('ons-alert-dialog'));
+        browser.wait(EC.presenceOf(alertDialog));
+        var helpElement = element(by.id('alert-dialog-visible'));
+        browser.wait(EC.presenceOf(helpElement));
 
-        expect(isVisible()).not.toBeTruthy();
+        expect(helpElement.isDisplayed()).not.toBeTruthy();
 
         element(by.id('show-alert-dialog')).click();
         browser.wait(EC.visibilityOf(alertDialog));
-        expect(isVisible()).toBeTruthy();
+        expect(helpElement.isDisplayed()).toBeTruthy();
 
         element(by.css('button.alert-dialog-button')).click();
         browser.wait(EC.invisibilityOf(alertDialog));
-        expect(isVisible()).not.toBeTruthy();
+        expect(helpElement.isDisplayed()).not.toBeTruthy();
       });
     });
   });

--- a/test/e2e/backButton/scenarios.js
+++ b/test/e2e/backButton/scenarios.js
@@ -13,7 +13,11 @@
       browser.wait(EC.presenceOf(button));
 
       button.click();
-      expect(element(by.css('ons-back-button')).isDisplayed()).toBeTruthy();
+
+      var backbutton = element(by.css('ons-back-button'));
+      browser.wait(EC.presenceOf(backbutton));
+
+      expect(backbutton.isDisplayed()).toBeTruthy();
     });
 
     it('should switch page when a button is clicked', function() {

--- a/test/e2e/composition/navigator+dialog.html
+++ b/test/e2e/composition/navigator+dialog.html
@@ -34,7 +34,7 @@
     </ons-template>
 
     <ons-template id="dialog.html">
-      <ons-dialog var="dialog">
+      <ons-dialog var="dialog" animation="none">
         <p style="text-align: center;">
           <ons-button id='hide-dialog' ng-click="dialog.hide()">Hide</ons-button>
         </p>

--- a/test/e2e/composition/scenarios.js
+++ b/test/e2e/composition/scenarios.js
@@ -42,19 +42,25 @@
         popPage = element(by.id('pop-page')),
         hideDialog = element(by.id('hide-dialog'));
 
+      browser.wait(EC.visibilityOf(pushPage));
       pushPage.click();
+
       browser.wait(EC.visibilityOf(hideDialog));
       expect(hideDialog.isDisplayed()).toBeTruthy();
-
       hideDialog.click();
+
       browser.wait(EC.invisibilityOf(hideDialog));
       expect(hideDialog.isDisplayed()).not.toBeTruthy();
 
+
+      browser.wait(EC.visibilityOf(popPage));
       popPage.click();
       browser.wait(EC.stalenessOf(popPage));
       expect(popPage.isPresent()).not.toBeTruthy();
 
+      browser.wait(EC.visibilityOf(pushPage));
       pushPage.click();
+
       browser.wait(EC.visibilityOf(hideDialog));
       expect(hideDialog.isDisplayed()).toBeTruthy();
     });

--- a/test/e2e/dialog/scenarios.js
+++ b/test/e2e/dialog/scenarios.js
@@ -34,7 +34,10 @@
       browser.wait(EC.invisibilityOf(button));
       expect(button.isDisplayed()).not.toBeTruthy();
 
-      element(by.id('close-dialog')).click();
+      var closeDialog = element(by.id('close-dialog'))
+      browser.wait(EC.visibilityOf(closeDialog));
+      closeDialog.click();
+
       browser.wait(EC.visibilityOf(button));
       expect(button.isDisplayed()).toBeTruthy();
     });

--- a/test/e2e/navigator/scenarios.js
+++ b/test/e2e/navigator/scenarios.js
@@ -187,10 +187,18 @@
       var pops = element(by.id('pops')),
         pushes = element(by.id('pushes'));
 
+      var page1 = element(by.id('page1'));
+      var page2 = element(by.id('page2'));
+
       expect(pops.getText()).toBe('0');
       expect(pushes.getText()).toBe('1');
 
+      browser.wait(EC.visibilityOf(element(by.id('btn1'))));
       element(by.id('btn1')).click();
+
+      browser.wait(EC.visibilityOf(page2));
+      browser.wait(EC.invisibilityOf(page1));
+
       browser.wait(EC.visibilityOf(element(by.id('btn2'))));
       element(by.id('btn2')).click();
       browser.wait(EC.textToBePresentInElement(pops, '1'));

--- a/test/e2e/slidingMenu/events.html
+++ b/test/e2e/slidingMenu/events.html
@@ -14,7 +14,7 @@
   </head>
   <body>
 
-    <ons-sliding-menu ng-init="open = false" ons-preopen="open = true" ons-preclose="open = false" max-slide-distance="200px" main-page="page1.html" menu-page="menu.html" side="right" var="menu"></ons-sliding-menu>
+    <ons-sliding-menu ng-init="showClose = open = false" ons-preopen="open = true" ons-postopen="showClose = true"	 ons-preclose="open = false" max-slide-distance="200px" main-page="page1.html" menu-page="menu.html" side="right" var="menu"></ons-sliding-menu>
 
     <script type="text/ons-template" id="page1.html">
       <ons-page>
@@ -26,7 +26,7 @@
 
     <script type="text/ons-template" id="menu.html">
       <ons-page>
-        <ons-button id="close-menu" ng-click="menu.closeMenu()">Close menu</ons-button>
+        <ons-button ng-show="showClose" id="close-menu" ng-click="menu.closeMenu()">Close menu</ons-button>
       </ons-page>
     </script>
 


### PR DESCRIPTION
@argelius when updating node modules on my react_binding, the selinium tests are failing. Sometimes they are failing, because often we try to click an element that is not there yet. This commit fixes a lot of these issues and also updates the drivers for mac and linux.