### PR TITLE
fix(ons-popover): fix buggy ios animation

### DIFF
--- a/core/src/elements/ons-popover/index.js
+++ b/core/src/elements/ons-popover/index.js
@@ -254,14 +254,14 @@ class PopoverElement extends BaseElement {
     this._popover.classList.add('popover--' + primary);
 
     const offset = cover ? 0 : (vertical ? pos.height : pos.width) + (isMD ? 0 : 14);
-    this.style[primary] = Math.max(0, distance[primary] + offset) + margin + 'px';
-    el.style[primary] = 0;
+    this._popover.style[primary] = Math.max(0, distance[primary] + offset) + margin + 'px';
 
     const l = vertical ? 'width' : 'height';
     const diff = parseInt(window.getComputedStyle(el).getPropertyValue(l)) - pos[l];
 
-    el.style[secondary] = Math.max(0, distance[secondary] - diff / 2) + 'px';
-    this._arrow.style[secondary] = Math.max(radius, distance[secondary] + pos[l] / 2) + 'px';
+    const secPos = Math.max(0, distance[secondary] - diff / 2);
+    this._popover.style[secondary] = secPos + 'px';
+    this._arrow.style[secondary] = Math.max(radius, distance[secondary] + pos[l] / 2 - secPos) + 'px';
 
     // Prevent animit from restoring the style.
     el.removeAttribute('data-animit-orig-style');
@@ -284,7 +284,7 @@ class PopoverElement extends BaseElement {
 
   _clearStyles() {
     ['top', 'bottom', 'left', 'right'].forEach(e => {
-      this._arrow.style[e] = this._content.style[e] = this.style[e] = '';
+      this._arrow.style[e] = this._popover.style[e] = this.style[e] = '';
       this._popover.classList.remove(`popover--${e}`);
     });
   }

--- a/css-components/components-src/stylus/components/popover.styl
+++ b/css-components/components-src/stylus/components/popover.styl
@@ -59,15 +59,14 @@ var-popover-margin-material = 4px
   position fixed
 
 .popover__container
-  width 100%
-  height 100%
+  position absolute
 
 .popover__content
   reset-box-model()
   reset-base()
   reset-cursor()
   reset-font()
-  position absolute
+  position relative
   display block
   width 220px
   overflow auto
@@ -166,7 +165,7 @@ var-popover-margin-material = 4px
   // position absolute
   display inline-block
   max-height 100%
-  overflow auto
+  overflow visible
   /*border-bottom 4px solid transparent*/
 
 .popover__content--material


### PR DESCRIPTION
@IliaSky I made some changes to the popover since the animation was broken.
I'm not sure if I broke something so please take a look :)

The problem before was that the `popover__container` was very large and since we ran the transitions on it, the origin of the transforms was not inside the popover.