### PR TITLE
fix(ons-splitter): Fix angular bindings memory leak.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 
 v2.0.0-beta.9
 ----
+ * ons-splitter: Fixed memory leak.
 
 v2.0.0-beta.8
 ----

--- a/bindings/angular1/views/splitter-content.js
+++ b/bindings/angular1/views/splitter-content.js
@@ -26,46 +26,28 @@ limitations under the License.
         this._scope = scope;
         this._attrs = attrs;
 
-        this._clearDerivingMethods = $onsen.deriveMethods(this, this._element[0], [
-          'load'
-        ]);
-
+        this.load = (...args) => {
+          this._pageScope && this._pageScope.$destroy();
+          this._element[0].load(...args);
+        };
         scope.$on('$destroy', this._destroy.bind(this));
       },
 
       _link: function(fragment, done) {
-        var link = $compile(fragment);
-        var pageScope = this._createPageScope();
-        link(pageScope);
+        this._pageScope = this._scope.$new();
+        $compile(fragment)(this._pageScope);
 
-        pageScope.$evalAsync(function() {
-          done(fragment);
-        });
-      },
-
-      _createPageScope: function() {
-         return this._scope.$new();
+        this._pageScope.$evalAsync(() => done(fragment));
       },
 
       _destroy: function() {
         this.emit('destroy');
-
-        this._clearDerivingMethods();
-
-        this._element = this._scope = this._attrs = null;
+        this._element = this._scope = this._attrs = this.load = this._pageScope = null;
       }
     });
 
     MicroEvent.mixin(SplitterContent);
-
-    Object.defineProperty(SplitterContent.prototype, 'page', {
-      get: function () {
-        return this._element[0].page;
-      },
-      set: function() {
-        throw new Error();
-      }
-    });
+    $onsen.derivePropertiesFromElement(SplitterContent, ['page']);
 
     return SplitterContent;
   });

--- a/bindings/angular1/views/splitter-side.js
+++ b/bindings/angular1/views/splitter-side.js
@@ -27,33 +27,27 @@ limitations under the License.
         this._attrs = attrs;
 
         this._clearDerivingMethods = $onsen.deriveMethods(this, this._element[0], [
-          'isOpen', 'open', 'close', 'toggle', 'load'
+          'isOpen', 'open', 'close', 'toggle'
         ]);
+
+        this.load = (...args) => {
+          this._pageScope && this._pageScope.$destroy();
+          this._element[0].load(...args);
+        };
 
         this._clearDerivingEvents = $onsen.deriveEvents(this, element[0], [
           'modechange', 'preopen', 'preclose', 'postopen', 'postclose'
-        ], function(detail) {
-          if (detail.side) {
-            detail.side = this;
-          }
-          return detail;
-        }.bind(this));
+        ], detail => detail.side ? angular.extend(detail, {side: this}) : detail);
 
         scope.$on('$destroy', this._destroy.bind(this));
       },
 
       _link: function(fragment, done) {
         var link = $compile(fragment);
-        var pageScope = this._createPageScope();
-        link(pageScope);
+        this._pageScope = this._scope.$new();
+        link(this._pageScope);
 
-        pageScope.$evalAsync(function() {
-          done(fragment);
-        });
-      },
-
-      _createPageScope: function() {
-         return this._scope.$new();
+        this._pageScope.$evalAsync(() => done(fragment));
       },
 
       _destroy: function() {
@@ -62,7 +56,7 @@ limitations under the License.
         this._clearDerivingMethods();
         this._clearDerivingEvents();
 
-        this._element = this._scope = this._attrs = null;
+        this._element = this._scope = this._attrs = this.load = this._pageScope = null;
       }
     });
 

--- a/bindings/angular1/views/splitter.js
+++ b/bindings/angular1/views/splitter.js
@@ -20,7 +20,6 @@ limitations under the License.
   angular.module('onsen').factory('Splitter', function($onsen) {
 
     var Splitter = Class.extend({
-
       init: function(scope, element, attrs) {
         this._element = element;
         this._scope = scope;
@@ -35,9 +34,16 @@ limitations under the License.
     });
 
     MicroEvent.mixin(Splitter);
-    $onsen.derivePropertiesFromElement(Splitter, [
-      'left', 'right', 'content', 'mask', 'backButtonHandler'
-    ]);
+    $onsen.derivePropertiesFromElement(Splitter, ['backButtonHandler']);
+
+    ['left', 'right', 'content', 'mask'].forEach((prop, i) => {
+      Object.defineProperty(Splitter.prototype, prop, {
+        get: function () {
+          var tagName = `ons-splitter-${i < 2 ? 'side' : prop}`;
+          return angular.element(this._element[0][prop]).data(tagName);
+        }
+      });
+    });
 
     return Splitter;
   });


### PR DESCRIPTION
When a new page is loaded in either the content or side element the `scope.$destroy` wasn't being called, which resulted in a memory leak. 

Apparently @frankdiox fixed the same issue in `sliding-menu`, but the `splitter` element was made after that fix and the same problem occurred. Now it's also fixed in the splitter.

This pull request also changes the `left`, `right`, `content`, `mask` properties to point to their respective angular views instead of the raw DOM elements, which is how it should be I guess.