### PR TITLE
Remove `status-bar-fill` element and fix #1315

### DIFF
--- a/core/css/common.css
+++ b/core/css/common.css
@@ -54,19 +54,12 @@ input, textarea {
   -webkit-user-select: auto;
 }
 
-ons-toolbar:not([inline]) {
+ons-toolbar:not([inline]), ons-bottom-toolbar:not([inline]) {
   position: absolute;
   left: 0;
   right: 0;
   top: 0;
   z-index: 10000;
-}
-
-ons-bottom-toolbar:not([inline]) {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
 }
 
 .scroller {
@@ -78,53 +71,9 @@ ons-bottom-toolbar:not([inline]) {
   -ms-scroll-snap-type: mandatory;
 }
 
-.page,
-.page__content {
+.page, .page__content {
   background-color: transparent !important;
   background: transparent !important;
-}
-
-.page__status-bar-fill + .page__background + .page__content {
-  padding-top: 20px;
-}
-
-ons-toolbar + .page__background + .page__content {
-  margin-top: -1px;
-  top: 44px;
-}
-
-.navigation-bar--material + .page__background + .page__content {
-  top: 56px;
-}
-
-.page__status-bar-fill + ons-toolbar {
-  height: 64px;
-}
-
-.page__status-bar-fill + ons-toolbar[modifier~="material"] {
-  height: 76px;
-}
-
-.page__status-bar-fill + ons-toolbar > .center,
-.page__status-bar-fill + ons-toolbar > .left,
-.page__status-bar-fill + ons-toolbar > .right {
-  padding-top: 20px;
-}
-
-.page__status-bar-fill + ons-toolbar[modifier~="material"] > .center,
-.page__status-bar-fill + ons-toolbar[modifier~="material"] > .left,
-.page__status-bar-fill + ons-toolbar[modifier~="material"] > .right {
-  height: 76px;
-}
-
-
-.page__status-bar-fill + ons-toolbar + .page__background + .page__content {
-  top: 64px;
-  padding-top: 0px;
-}
-
-.page__status-bar-fill + ons-toolbar[modifier~="material"] + .page__background + .page__content {
-  top: 76px;
 }
 
 .page__content {
@@ -134,28 +83,54 @@ ons-toolbar + .page__background + .page__content {
   -ms-touch-action: pan-y;
 }
 
-.page-with-bottom-toolbar > .page__content {
-  bottom: 44px;
+.navigation-bar + .page__background + .page__content {
+  margin-top: -1px;
+  top: 44px;
 }
 
-.tab-bar__status-bar-fill + .tab-bar--top__content {
+.navigation-bar--material + .page__background + .page__content {
+  top: 56px;
+}
+
+.page[status-bar-fill] > .page__content {
+  top: 20px;
+}
+
+.page[status-bar-fill] > .navigation-bar {
+  padding-top: 20px;
+  box-sizing: content-box;
+}
+
+.page[status-bar-fill] > .navigation-bar + .page__background + .page__content {
+  top: 64px;
+}
+
+.page[status-bar-fill] > .navigation-bar--material + .page__background + .page__content {
+  top: 76px;
+}
+
+ons-tabbar[status-bar-fill] > .tab-bar--top__content {
   top: 71px;
 }
 
-.tab-bar__status-bar-fill + .tab-bar--top__content + .tab-bar--top {
+ons-tabbar[status-bar-fill] > .tab-bar--top {
   padding-top: 22px;
 }
 
-ons-tabbar[position="top"] .page__status-bar-fill + .page__background + .page__content {
-  padding-top: 0px;
+ons-tabbar[position="top"] .page[status-bar-fill] > .page__content {
+  top: 0px;
 }
 
-ons-toolbar + .page__background + .page__content ons-tabbar > .tab-bar__status-bar-fill + .tab-bar--top__content {
+.navigation-bar + .page__background + .page__content ons-tabbar[status-bar-fill] > .tab-bar--top {
+  top: 0px;
+}
+
+.navigation-bar + .page__background + .page__content ons-tabbar[status-bar-fill] > .tab-bar--top__content {
   top: 49px;
 }
 
-ons-toolbar + .page__background + .page__content ons-tabbar > .tab-bar__status-bar-fill + .tab-bar--top__content + .tab-bar--top {
-  padding-top: 0px;
+.page-with-bottom-toolbar > .page__content {
+  bottom: 44px;
 }
 
 ons-dialog[disabled] > .dialog,

--- a/core/src/elements/ons-page.js
+++ b/core/src/elements/ons-page.js
@@ -170,6 +170,13 @@ class PageElement extends BaseElement {
     this.attributeChangedCallback('oninfinitescroll', null, infiniteScroll);
   }
 
+  _tryToFillStatusBar(){
+    return internal.shouldFillStatusBar(this).then(
+      () => this.setAttribute('status-bar-fill', ''),
+      () => this.removeAttribute('status-bar-fill')
+    );
+  }
+
   /**
    * @return {boolean}
    */
@@ -254,8 +261,8 @@ class PageElement extends BaseElement {
     if (util.findChild(this, 'ons-toolbar')) {
       return true;
     }
-    return !!util.findChild(this._contentElement, (e) => {
-      return e.nodeName.toLowerCase() === 'ons-toolbar' && !e.hasAttribute('inline');
+    return !!util.findChild(this._contentElement, el => {
+      return util.match(el, 'ons-toolbar') && !el.hasAttribute('inline');
     });
   }
 
@@ -292,12 +299,7 @@ class PageElement extends BaseElement {
    */
   _registerToolbar(element) {
     this._contentElement.setAttribute('no-status-bar-fill', '');
-
-    if (util.findChild(this, '.page__status-bar-fill')) {
-      this.insertBefore(element, this.children[1]);
-    } else {
-      this.insertBefore(element, this.children[0]);
-    }
+    this.insertBefore(element, this.children[0]);
   }
 
   /**
@@ -356,25 +358,6 @@ class PageElement extends BaseElement {
     }
 
     extra.appendChild(element);
-  }
-
-  _tryToFillStatusBar() {
-    return internal.shouldFillStatusBar(this)
-      .then(() => {
-        let fill = this.querySelector('.page__status-bar-fill');
-
-        if (!fill) {
-          fill = util.create('.page__status-bar-fill');
-
-          this.insertBefore(fill, this.children[0]);
-        }
-
-        return fill;
-      })
-      .catch(() => {
-        const el = this.querySelector('.page__status-bar-fill');
-        el && el.remove();
-      });
   }
 
   _show() {

--- a/core/src/elements/ons-page.spec.js
+++ b/core/src/elements/ons-page.spec.js
@@ -38,6 +38,18 @@ describe('OnsPageElement', () => {
     });
   });
 
+  describe('#_tryToFillStatusBar()', (done) => {
+    it('fills status bar', () => {
+      var tmp = ons._internal.shouldFillStatusBar;
+      ons._internal.shouldFillStatusBar = () => { return Promise.resolve(); };
+      element._tryToFillStatusBar().then(() => {
+        expect(element.hasAttribute('status-bar-fill')).to.be.true;
+        done();
+      });
+      ons._internal.shouldFillStatusBar = tmp;
+    });
+  });
+
   describe('#detachedCallback', () => {
     it('fires \'destroy\' event', () => {
       var spy = chai.spy();
@@ -146,18 +158,6 @@ describe('OnsPageElement', () => {
       expect(element.lastChild.className).to.equal('page__content');
       element._registerExtraElement(document.createElement('div'));
       expect(element.lastChild.className).to.equal('page__extra');
-    });
-  });
-
-  describe('#_tryToFillStatusBar()', (done) => {
-    it('fills status bar', () => {
-      var tmp = ons._internal.shouldFillStatusBar;
-      ons._internal.shouldFillStatusBar = () => { return Promise.resolve(); };
-      element._tryToFillStatusBar().then(() => {
-        expect(element.firstChild.className).to.equal('page__status-bar-fill');
-        done();
-      });
-      ons._internal.shouldFillStatusBar = tmp;
     });
   });
 

--- a/core/src/elements/ons-tabbar/index.js
+++ b/core/src/elements/ons-tabbar/index.js
@@ -274,34 +274,14 @@ class TabbarElement extends BaseElement {
     if (page) {
       this.style.top = window.getComputedStyle(page._getContentElement(), null).getPropertyValue('padding-top');
 
-      if (page.firstChild.tagName.toLowerCase() === 'ons-toolbar') {
+      if (util.match(page.firstChild, 'ons-toolbar')) {
         util.addModifier(page.firstChild, 'noshadow');
       }
     }
-
-    internal.shouldFillStatusBar(this)
-      .then(() => {
-        let fill = this.querySelector('.tab-bar__status-bar-fill');
-
-        if (fill instanceof HTMLElement) {
-          return fill;
-        }
-
-        fill = document.createElement('div');
-        fill.classList.add('tab-bar__status-bar-fill');
-        fill.style.width = '0px';
-        fill.style.height = '0px';
-
-        this.insertBefore(fill, this.children[0]);
-
-        return fill;
-      })
-      .catch(() => {
-        const el = this.querySelector('.tab-bar__status-bar-fill');
-        if (el instanceof HTMLElement) {
-          el.remove();
-        }
-      });
+    internal.shouldFillStatusBar(this).then(
+      () => this.setAttribute('status-bar-fill', ''),
+      () => this.removeAttribute('status-bar-fill')
+    );
   }
 
   _getTabbarElement() {

--- a/core/src/elements/ons-tabbar/index.spec.js
+++ b/core/src/elements/ons-tabbar/index.spec.js
@@ -425,7 +425,7 @@ describe('OnsTabbarElement', () => {
 
       setTimeout(() => {
         expect(element._hasTopTabbar()).to.be.true;
-        expect(element.firstChild.className).to.equal('tab-bar__status-bar-fill');
+        expect(element.hasAttribute('status-bar-fill')).to.be.true;
         done();
       }, 1000);
     });


### PR DESCRIPTION
Currently we're adding this element to the `page` and `tabbar` - it adds unnecessary code and complicates a lot of css selectors. Here it's removed and instead an attribute on the parent is used. We could also use a class, but I think an attribute looks better. If anyone disagrees we can easily change that to a class.

The fix for #1315 is a very small part - currently even without an `ons-splitter` tag the same issue would be also occur in even a simple page without a title and lots of content as an application - it's not related to the splitter it seems.