### PR TITLE
bugfix(navigator) Fixing resetToPage method to not execute always in the callback "onTransitionEnd"

### DIFF
--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -664,13 +664,14 @@ class NavigatorElement extends BaseElement {
     const onTransitionEnd = options.onTransitionEnd || function() {};
 
     options.onTransitionEnd = () => {
-      while (this._pages.length > 1) {
-        this._pages.shift().destroy();
-      }
-      this._pages[0].updateBackButton();
+      
       onTransitionEnd();
     };
-
+    while (this._pages.length > 1) {
+        this._pages.shift().destroy();
+    }
+    this._pages[0].updateBackButton();
+      
     if (!options.pageHTML && (options.page === undefined || page === '')) {
       if (this.hasAttribute('page')) {
         options.page = this.getAttribute('page');

--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -660,16 +660,23 @@ class NavigatorElement extends BaseElement {
     if (!options.animator && !options.animation) {
       options.animation = 'none';
     }
-
+    var self = this;
     const onTransitionEnd = options.onTransitionEnd || function() {};
-
+    const destroyPages = function(){
+       if(typeof(self._pages) !== "undefined" ){
+         while (self._pages.length > 1) {
+           self._pages.shift().destroy();
+         }    
+       }
+   }
+   var needToDestroyPages = true;
     options.onTransitionEnd = () => {
-      
+      if(needToDestroyPages === true){
+         destroyPages();
+         needToDestroyPages  = false;
+      }
       onTransitionEnd();
     };
-    while (this._pages.length > 1) {
-        this._pages.shift().destroy();
-    }
     this._pages[0].updateBackButton();
       
     if (!options.pageHTML && (options.page === undefined || page === '')) {


### PR DESCRIPTION
When the "resetToPage" method is then executed the "callback" "onTransitionEnd" is changed to reset all pages stacked on the navigator and thereby the unstacking of pages is always running even when other methods are invoked such as pushPage that causes an error state in the application, especially if you are working with "back button"

So I created a local variable, "needToDestroyPages", indicating whether the method for unstacking pages should or should not be performed on the "callback" "onTransitionEnd"