### PR TITLE
chore(gulpfile): Enabled "serve" task to continue when "core" task occur compile errors.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,6 +58,10 @@ gulp.task('browser-sync', function() {
 ////////////////////////////////////////
 gulp.task('core', function() {
   return gulp.src(['core/src/setup.js'], {read: false})
+    .pipe($.plumber(function(error) {
+      $.util.log(error.message);
+      this.emit('end');
+    }))
     .pipe($.rollup({
       sourceMap: 'inline',
       plugins: [


### PR DESCRIPTION
Enabled "serve" task to continue when "core" task occur compile errors. 
@argelius Please merge this changes.