### PR TITLE
fix(ons-ready): Inner components might not be ready on page init.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ v2.0.0-beta.9
  * ons-page: Fixed [#1315](https://github.com/OnsenUI/OnsenUI/issues/1315).
  * ons-icon: Accepts two icon values at once for Auto Styling.
  * ons-tab: Fix glitch where content was removed during `<ons-navigator>` slide animation.
+ * ons-page: Fixed an issue where inner components might not be ready on page init.
 
 v2.0.0-beta.8
 ----

--- a/core/src/elements/ons-back-button.spec.js
+++ b/core/src/elements/ons-back-button.spec.js
@@ -107,7 +107,7 @@ describe('OnsBackButtonElement', () => {
 
     it('takes \'refresh\' attribute', () => {
       let promise = new Promise((resolve) => {
-        nav.addEventListener('init', event => {
+        nav.addEventListener('destroy', event => {
           if (event.detail.page.id === 'p1') {
             return resolve();
           }

--- a/core/src/elements/ons-page.js
+++ b/core/src/elements/ons-page.js
@@ -157,7 +157,7 @@ class PageElement extends BaseElement {
       if (this._skipInit) {
         this.removeAttribute('_skipinit');
       } else {
-        util.triggerElementEvent(this, 'init', this.eventDetail);
+        setImmediate(() => util.triggerElementEvent(this, 'init', this.eventDetail));
       }
     }
 


### PR DESCRIPTION
@argelius @IliaSky We still have `ons.ready` after `init` events in some situations but maybe it's not a big problem.