### PR TITLE
fix(DeviceBackButtonDispatcher): createTree() threw an error if element was not an HTMLElement

### DIFF
--- a/core/src/ons/device-back-button-dispatcher.js
+++ b/core/src/ons/device-back-button-dispatcher.js
@@ -103,6 +103,10 @@ const HandlerRepository = {
   },
 
   has: function(element) {
+    if (!element.dataset) {
+      return false;
+    }
+
     const id = element.dataset.deviceBackButtonHandlerId;
 
     return !!this._store[id];


### PR DESCRIPTION
So i have an SVG in my OnsenUI app which apparently broke the `backbutton` handler because he was searching for the "deviceBackButtonHandlerId" inside the `dataset`. But the `dataset` property belongs only to [HTMLElements](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset).

So when checking the `<svg>` childrens for it, the `backbutton` dispatcher threw an error.

I also thought about checking if the element is an HTMLElement, but just checking if the `dataset` property exists seemed simpler and more future proof.