### PR TITLE
Expose fastclick instance

### DIFF
--- a/core/src/setup.js
+++ b/core/src/setup.js
@@ -41,7 +41,9 @@ import './elements/ons-toolbar';
 import './elements/ons-range';
 
 // fastclick
-window.addEventListener('load', () => FastClick.attach(document.body), false);
+window.addEventListener('load', () => {
+    ons.fastClick = FastClick.attach(document.body);
+}, false);
 
 // ons._defaultDeviceBackButtonHandler
 window.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
As you might now, there are some libraries that don't play ball very well with FastClick. I am using two of them, unfortunately, but the most important one is [Google Map Places Autocomplete](https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete). The problem is that FastClick "swallows" the click/tap on the autocomplete list and on mobile it's impossible to select an item just by tapping on it.

There are some approaches to solve this problem ([see this](https://github.com/ftlabs/fastclick/pull/347/files), for example) but in the case of OnsenUI, which uses its own FastClick instance, I didn't find a good way to easily fix it.

FastClick uses the `needsclick` class to signal itself that an element should be left alone, but Google Places doesn't give you a way to know when its popup list is open (so that you could add that class).

So, my solution is very very minimal (for Onsen) and just give you access to the FastClick instance that OnseUI has attached by the way of a `ons.fastClick` property. Once I have it, I can do the following (and I am happy again):

```javascript
ons.fastClick.needsClick = function (target) {

    var needsClick = FastClick.prototype.needsClick.apply(this, [target]);

    if (needsClick) {
        return true;
    }

    return (target.classList.contains('pac-item') ||
            (target.parentNode && target.parentNode.classList.contains('pac-item')));
}
```

