### PR TITLE
Add ISSUE_TEMPLATE.md

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,12 @@
+[](Github issues should be used only for bugs and feature requests. For questions please visit stackoverflow.com/tags/onsen-ui or community.onsen.io. For bugs please use the following template.)
+
+__Environment__
+Onsen beta 6
+Angular 1.5.2
+iOS 9.2
+
+__Encountered problem__
+
+
+__How to reproduce__
+


### PR DESCRIPTION
Closes [#1235](https://github.com/OnsenUI/OnsenUI/issues/1235).
We should at least have something even if it's not perfect. 

I feel like what our users need is guidelines more than a template. However most users wouldn't click the `please read the guidelines` and even if they do they will find the guidelines for pull requests rather than bug reports. 

I sort of cheated the system by using an empty link as a comment, but that's all I could think of. Adding more content in the template is not nice imo as it's just annoying to delete.