### PR TITLE
Auto refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v2.0.0-beta.10
  * ons-navigator: Removed small delay after Lift animators.
  * css-components: Fixed issue with list item using both "chevron" and "longdivider" modifiers.
  * core: Fixed an issue preventing users from selecting text in inputs and textareas.
+ * ons-carousel: Added `auto-refresh` attribute.
 
 v2.0.0-beta.9
 ----

--- a/bindings/angular1/directives/carousel.js
+++ b/bindings/angular1/directives/carousel.js
@@ -138,20 +138,6 @@
             element = null;
           });
 
-          if (element[0].hasAttribute('auto-refresh')) {
-            // Refresh carousel when items are added or removed.
-            scope.$watch(
-              function () {
-                return element[0].childNodes.length;
-              },
-              function () {
-                setImmediate(function() {
-                  carousel.refresh();
-                });
-              }
-            );
-          }
-
           setImmediate(function() {
             carousel.refresh();
           });

--- a/core/src/elements/ons-carousel.js
+++ b/core/src/elements/ons-carousel.js
@@ -550,18 +550,11 @@ class CarouselElement extends BaseElement {
   }
 
   _prepareEventListeners() {
-    this._gestureDetector = new GestureDetector(this, {
-      dragMinDistance: 1
-    });
+    this._gestureDetector = new GestureDetector(this, {dragMinDistance: 1});
+    this._mutationObserver = new MutationObserver(() => this.refresh());
 
     this._updateSwipeable();
-
-    this._mutationObserver = new MutationObserver(() => {
-      if (this.hasAttribute('auto-refresh')) {
-        this.refresh();
-      }
-    });
-    this._mutationObserver.observe(this, {childList: true});
+    this._updateAutoRefresh();
 
     window.addEventListener('resize', this._boundOnResize, true);
   }
@@ -571,6 +564,7 @@ class CarouselElement extends BaseElement {
     this._gestureDetector = null;
 
     this._mutationObserver.disconnect();
+    this._mutationObserver = null;
 
     window.removeEventListener('resize', this._boundOnResize, true);
   }
@@ -583,6 +577,16 @@ class CarouselElement extends BaseElement {
       } else {
         this._gestureDetector.off('drag dragleft dragright dragup dragdown swipe swipeleft swiperight swipeup swipedown', this._boundOnDrag);
         this._gestureDetector.off('dragend', this._boundOnDragEnd);
+      }
+    }
+  }
+
+  _updateAutoRefresh() {
+    if (this._mutationObserver) {
+      if (this.hasAttribute('auto-refresh')) {
+        this._mutationObserver.observe(this, {childList: true});
+      } else {
+        this._mutationObserver.disconnect();
       }
     }
   }
@@ -926,6 +930,9 @@ class CarouselElement extends BaseElement {
     switch (name) {
       case 'swipeable':
         this._updateSwipeable();
+        break;
+      case 'auto-refresh':
+        this._updateAutoRefresh();
         break;
       case 'direction':
         this._onDirectionChange();

--- a/core/src/elements/ons-carousel.js
+++ b/core/src/elements/ons-carousel.js
@@ -556,12 +556,21 @@ class CarouselElement extends BaseElement {
 
     this._updateSwipeable();
 
+    this._mutationObserver = new MutationObserver(() => {
+      if (this.hasAttribute('auto-refresh')) {
+        this.refresh();
+      }
+    });
+    this._mutationObserver.observe(this, {childList: true});
+
     window.addEventListener('resize', this._boundOnResize, true);
   }
 
   _removeEventListeners() {
     this._gestureDetector.dispose();
     this._gestureDetector = null;
+
+    this._mutationObserver.disconnect();
 
     window.removeEventListener('resize', this._boundOnResize, true);
   }

--- a/core/src/elements/ons-carousel.spec.js
+++ b/core/src/elements/ons-carousel.spec.js
@@ -25,7 +25,7 @@ describe('OnsCarouselElement', () => {
 
   describe('#_updateSwipeable()', () => {
     it('attaches and removes listeners', () => {
-      let spyOn = chai.spy.on(carousel._gestureDetector, 'on'),
+      const spyOn = chai.spy.on(carousel._gestureDetector, 'on'),
         spyOff = chai.spy.on(carousel._gestureDetector, 'off');
 
       carousel.setAttribute('swipeable', '');
@@ -36,9 +36,38 @@ describe('OnsCarouselElement', () => {
     });
   });
 
+  describe('#_updateAutoRefresh()', () => {
+    it('starts and stops observing', () => {
+      const spyOn = chai.spy.on(carousel._mutationObserver, 'observe'),
+        spyOff = chai.spy.on(carousel._mutationObserver, 'disconnect');
+
+      carousel.setAttribute('auto-scroll', '');
+      expect(spyOn).to.have.been.called.at.least.once;
+
+      carousel.removeAttribute('auto-scroll');
+      expect(spyOff).to.have.been.called.at.least.once;
+    });
+  });
+
+  describe('auto-refresh', () => {
+    it('calls refresh on appendChild', () => {
+      const spy = chai.spy.on(carousel, 'refresh');
+      carousel.setAttribute('auto-scroll', '');
+      carousel.appendChild(ons._util.createElement('<ons-carousel-item>Item X</ons-carousel-item>'));
+      expect(spy).to.have.been.called.at.least.once;
+    });
+
+    it('calls refresh on innerHTML change', () => {
+      const spy = chai.spy.on(carousel, 'refresh');
+      carousel.setAttribute('auto-scroll', '');
+      carousel.innerHTML += '<ons-carousel-item>Item X</ons-carousel-item>';
+      expect(spy).to.have.been.called.at.least.once;
+    });
+  });
+
   describe('#_onResize()', () => {
     it('fires \'refresh\' event', () => {
-      var promise = new Promise((resolve) =>
+      const promise = new Promise((resolve) =>
         carousel.addEventListener('refresh', resolve)
       );
 
@@ -49,7 +78,7 @@ describe('OnsCarouselElement', () => {
 
   describe('#_onDirectionChange()', () => {
     it('is fired when the \'direction\' attribute is changed', () => {
-      let spy = chai.spy.on(carousel, '_onDirectionChange');
+      const spy = chai.spy.on(carousel, '_onDirectionChange');
       carousel.setAttribute('direction', 'vertical');
       carousel.setAttribute('direction', 'horizontal');
       expect(spy).to.have.been.called.twice;
@@ -139,7 +168,7 @@ describe('OnsCarouselElement', () => {
     });
 
     it('should fire \'postchange\' event', () => {
-      var promise = new Promise((resolve) =>
+      const promise = new Promise((resolve) =>
         carousel.addEventListener('postchange', resolve)
       );
 
@@ -204,7 +233,7 @@ describe('OnsCarouselElement', () => {
     });
 
     it('renders dynamically added items', () => {
-      var item = ons._util.createElement(`
+      const item = ons._util.createElement(`
         <ons-carousel-item>Item 4</ons-carousel-item>
       `);
 


### PR DESCRIPTION
@IliaSky I noticed that `auto-refresh` attribute was only implemented for AngularJS bindings. I think it makes sense to have it in the core.

This will trigger `carousel.refresh()` when the number of children changes and the `auto-refresh` attribute is defined.

Please merge if there are no problems.