### PR TITLE
fix(ons-alert-dialog): Stop compiling twice.

### DIFF
--- a/core/src/elements/ons-alert-dialog/index.js
+++ b/core/src/elements/ons-alert-dialog/index.js
@@ -215,9 +215,9 @@ class AlertDialogElement extends BaseElement {
   }
 
   createdCallback() {
-    contentReady(this, () => {
-      this._compile();
-    });
+    if (!this.hasAttribute('_compiled')) {
+      contentReady(this, () => this._compile());
+    }
 
     this._visible = false;
     this._doorLock = new DoorLock();
@@ -513,7 +513,9 @@ class AlertDialogElement extends BaseElement {
     this._deviceBackButtonHandler = deviceBackButtonDispatcher.createHandler(this, this._onDeviceBackButton.bind(this));
 
     contentReady(this, () => {
-      this._compile();
+      if (!this.hasAttribute('_compiled')) {
+        this._compile();
+      }
       this._mask.addEventListener('click', this._boundCancel, false);
     });
   }

--- a/core/src/elements/ons-alert-dialog/index.spec.js
+++ b/core/src/elements/ons-alert-dialog/index.spec.js
@@ -239,9 +239,16 @@ describe('OnsAlertDialogElement', () => {
     it('does not compile twice', () => {
       let div1 = document.createElement('div');
       let div2 = document.createElement('div');
-      div1.innerHTML = '<ons-alert-dialog></ons-alert-dialog>';
+      div1.innerHTML = '<ons-alert-dialog>text</ons-alert-dialog>';
       div2.innerHTML = div1.innerHTML;
       expect(div1.isEqualNode(div2)).to.be.true;
+    });
+
+    it('does not compile when _compiled attribute exists', () => {
+      const spy = chai.spy.on(OnsAlertDialogElement.prototype, '_compile');
+      let div1 = document.createElement('div');
+      div1.innerHTML = '<ons-alert-dialog _compiled>text</ons-alert-dialog>';
+      expect(spy).to.have.been.called.exactly(0);
     });
   });
 });


### PR DESCRIPTION
Currently the code tries to compile twice. @argelius - I saw that you made lots of changing adding and removing one of the compiles. I've added the _compiled attribute once again and forced it to compile only once. Recompiling was causing some issues because the second compile was being called after the dialog is shown, hiding it.