### PR TITLE
fix(css-components): Material list item paddings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 CHANGELOG
 ====
 
+v2.0.0-rc.5
+----
+ * css-components: Fix material list item paddings.
+
 v2.0.0-rc.4
 ----
  * ons-input: Fix to `input-id` attribute.

--- a/css-components/components-src/stylus/components/list.styl
+++ b/css-components/components-src/stylus/components/list.styl
@@ -695,18 +695,21 @@ list__item()
   padding 16px 0px 16px 0px
   min-width 56px
   line-height 1
+  box-sizing border-box
 
 .list__item--material__left:empty
 
 .list__item--material__center
   padding 16px 0
   border-color #eee
+  box-sizing border-box
   retina-list-item-border(#eee)
 
 .list__item--material__right
   padding 16px 16px 16px 0px
   line-height 1
   border-color #eee
+  box-sizing border-box
   retina-list-item-border(#eee)
 
 .list__item--material.list__item--longdivider


### PR DESCRIPTION
@IliaSky Do you think this could break anything else? I haven't seen any problem. This fixes some padding issue on MD list items.