### PR TITLE
fix(ons-page): Toolbar animation works with nested components.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 v2.0.0-rc.5
 ----
  * css-components: Fix material list item paddings.
+ * ons-page: Toolbar animation works with nested components.
 
 v2.0.0-rc.4
 ----

--- a/core/src/elements/ons-page.js
+++ b/core/src/elements/ons-page.js
@@ -273,12 +273,8 @@ class PageElement extends BaseElement {
    * @return {Boolean}
    */
   _canAnimateToolbar() {
-    if (util.findChild(this, 'ons-toolbar')) {
-      return true;
-    }
-    return !!util.findChild(this._contentElement, el => {
-      return util.match(el, 'ons-toolbar') && !el.hasAttribute('inline');
-    });
+    var toolbar = this.querySelector('ons-toolbar');
+    return !!toolbar && !toolbar.hasAttribute('inline');
   }
 
   /**
@@ -296,7 +292,7 @@ class PageElement extends BaseElement {
    * @return {HTMLElement}
    */
   _getBottomToolbarElement() {
-    return util.findChild(this, 'ons-bottom-toolbar') || internal.nullElement;
+    return this.querySelector('ons-bottom-toolbar') || internal.nullElement;
   }
 
 
@@ -304,7 +300,7 @@ class PageElement extends BaseElement {
    * @return {HTMLElement}
    */
   _getToolbarElement() {
-    return util.findChild(this, 'ons-toolbar') || nullToolbarElement;
+    return this.querySelector('ons-toolbar') || nullToolbarElement;
   }
 
   /**


### PR DESCRIPTION
@argelius This is why sometimes the toolbar was not animated on ios-slide. It happened because there were nested components and it couldn't find the toolbar :sweat_smile: Do you think this fix is fine?