### PR TITLE
fix(ons-carousel): Support for ng-repeat. Closes #1168

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 CHANGELOG
 ====
 
+v2.0.0-rc.7
+ * ons-carousel: Support ng-repeat in Angular1 bindings.
+ * ons-carousel: Fix [#1168](https://github.com/OnsenUI/OnsenUI/issues/1168).
+
 v2.0.0-rc.6
 ----
  * ons-splitter: 'load' methods return promises in Angular1 bindings.

--- a/bindings/angular1/directives/carousel.js
+++ b/bindings/angular1/directives/carousel.js
@@ -152,7 +152,7 @@
         CustomElements.upgrade(element[0]);
         return function(scope, element, attrs) {
           CustomElements.upgrade(element[0]);
-          if (scope.$last){
+          if (scope.$last) {
             element[0].parentElement._setup();
             element[0].parentElement._setupInitialIndex();
             element[0].parentElement._saveLastState();

--- a/bindings/angular1/directives/carousel.js
+++ b/bindings/angular1/directives/carousel.js
@@ -152,6 +152,11 @@
         CustomElements.upgrade(element[0]);
         return function(scope, element, attrs) {
           CustomElements.upgrade(element[0]);
+          if (scope.$last){
+            element[0].parentElement._setup();
+            element[0].parentElement._setupInitialIndex();
+            element[0].parentElement._saveLastState();
+          }
         };
       }
     };

--- a/core/src/elements/ons-carousel.js
+++ b/core/src/elements/ons-carousel.js
@@ -323,11 +323,6 @@ class CarouselElement extends BaseElement {
     this._boundOnResize = this._onResize.bind(this);
 
     this._mixin(this._isVertical() ? VerticalModeTrait : HorizontalModeTrait);
-
-    this._setup();
-    this._setupInitialIndex();
-
-    this._saveLastState();
   }
 
   _onResize() {


### PR DESCRIPTION
@argelius Carousel was not working at all with `ng-repeat` because the setup was called before Angular compiled all the `ons-carousel-item`. Same for `initial-index` attribute. This is the most painless fix I could think about.

It's also possible to call `refresh()` but it throws events and do some unnecessary stuff so I preferred to call `_setup` and `_saveLastState`. We need to call `_setupInitialIndex` either way.

I removed some duplicated calls from `createdCallback` since we already do the same in `attachedCallback`.