### PR TITLE
fix(ons-pull-hook): fix compability with react

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ CHANGELOG
 
 v2.0.0-rc.8
 ----
-* core: Fixed [#845](https://github.com/OnsenUI/OnsenUI/issues/845) (again).
+ * core: Fixed [#845](https://github.com/OnsenUI/OnsenUI/issues/845).
+ * ons-pull-hook: Add React compatibility.
 
 v2.0.0-rc.7
 ----

--- a/core/src/elements/ons-pull-hook.js
+++ b/core/src/elements/ons-pull-hook.js
@@ -132,7 +132,7 @@ class PullHookElement extends BaseElement {
   }
 
   _ensureScrollElement() {
-    if (!this._scrollElement) {
+    if (this.parentElement && !this._scrollElement) {
       this._scrollElement = this._createScrollElement();
     }
   }


### PR DESCRIPTION
@argelius This should fix the problem with react:

Another fix could be that we delete the  `this._ensureScrollElement` in the createdCallback. The issue you referenced in the commit was the wrong one, so i am not sure whats better. 

https://github.com/OnsenUI/OnsenUI/commit/9c9f2593d28764f89ab8a9c0564ba444b41c0af6#diff-f96d6a24e6d6c2c79a80b239b7a738d5R110