### PR TITLE
fix(ons-splitter): setImmediate for layout after creation

### DIFF
--- a/core/src/elements/ons-splitter/index.js
+++ b/core/src/elements/ons-splitter/index.js
@@ -154,7 +154,7 @@ class SplitterElement extends BaseElement {
 
     contentReady(this, () => {
       this._compile();
-      this._layout();
+      setImmediate( () => this._layout());
     });
   }
 


### PR DESCRIPTION
@argelius somehow in react the layout did not have an effect, this would fix it, but probably there is a better solution.