### PR TITLE
fix(css-components): List divider modifiers for MD.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ v2.0.0-rc.10
  * ons-navigator: Fix [#1440](https://github.com/OnsenUI/OnsenUI/issues/1440).
  * ons-toolbar, ons-speed-dial: Fix [#1441](https://github.com/OnsenUI/OnsenUI/issues/1441).
  * ons-splitter-side: Fix `_width` property.
+ * css-components: Fixed list divider modifiers for MD.
 
 v2.0.0-rc.9
 ----

--- a/css-components/components-src/stylus/components/list.styl
+++ b/css-components/components-src/stylus/components/list.styl
@@ -221,66 +221,6 @@ list__item()
   box-shadow none
 
 /*! topdoc
-  name: List item without divider
-  class: list__item--nodivider
-  use: List
-  markup:
-    <ul class="list">
-      <li class="list__item list__item--nodivider">
-        <div class="list__item__center list__item--nodivider__center">Item</div>
-      </li>
-      <li class="list__item list__item--nodivider">
-        <div class="list__item__center list__item--nodivider__center">Item</div>
-      </li>
-    </ul>
- */
-.list__item--nodivider__center
-  border none
-  background-image none
-
-.list__item--nodivider__right
-  border none
-  background-image none
-
-.list__item--nodivider.list__item--chevron:before
-  border none
-  background-image none
-
-/*! topdoc
-  name: List item with long divider
-  class: list__item--longdivider
-  use: List
-  markup:
-    <ul class="list">
-      <li class="list__item list__item--longdivider">
-        <div class="list__item__center list__item--longdivider__center">Item</div>
-      </li>
-      <li class="list__item list__item--longdivider">
-        <div class="list__item__center list__item--longdivider__center">Item</div>
-      </li>
-    </ul>
- */
-.list__item--longdivider
-  border-bottom var-list-border
-  retina-list-item-border()
-
-.list__item--longdivider:last-of-type
-  border none
-  background-image none
-
-.list__item--longdivider__center
-  border none
-  background-image none
-
-.list__item--longdivider__right
-  border none
-  background-image none
-
-.list__item--longdivider.list__item--chevron:before
-  border none
-  background-image none
-
-/*! topdoc
   name: Category List Header
   class: list__header
   use: List
@@ -866,3 +806,63 @@ list__item()
 .list__item--material__icon
   font-size 20px
   padding 0 4px
+
+/*! topdoc
+  name: List item without divider
+  class: list__item--nodivider
+  use: List
+  markup:
+    <ul class="list">
+      <li class="list__item list__item--nodivider">
+        <div class="list__item__center list__item--nodivider__center">Item</div>
+      </li>
+      <li class="list__item list__item--nodivider">
+        <div class="list__item__center list__item--nodivider__center">Item</div>
+      </li>
+    </ul>
+ */
+.list__item--nodivider__center
+  border none
+  background-image none
+
+.list__item--nodivider__right
+  border none
+  background-image none
+
+.list__item--nodivider.list__item--chevron:before
+  border none
+  background-image none
+
+/*! topdoc
+  name: List item with long divider
+  class: list__item--longdivider
+  use: List
+  markup:
+    <ul class="list">
+      <li class="list__item list__item--longdivider">
+        <div class="list__item__center list__item--longdivider__center">Item</div>
+      </li>
+      <li class="list__item list__item--longdivider">
+        <div class="list__item__center list__item--longdivider__center">Item</div>
+      </li>
+    </ul>
+ */
+.list__item--longdivider
+  border-bottom var-list-border
+  retina-list-item-border()
+
+.list__item--longdivider:last-of-type
+  border none
+  background-image none
+
+.list__item--longdivider__center
+  border none
+  background-image none
+
+.list__item--longdivider__right
+  border none
+  background-image none
+
+.list__item--longdivider.list__item--chevron:before
+  border none
+  background-image none

--- a/examples/list/index.html
+++ b/examples/list/index.html
@@ -37,6 +37,11 @@
       <ons-list-item modifier="longdivider">Two</ons-list-item>
       <ons-list-item modifier="longdivider">Three</ons-list-item>
 
+      <ons-list-header>No divider</ons-list-header>
+      <ons-list-item modifier="nodivider">One</ons-list-item>
+      <ons-list-item modifier="nodivider">Two</ons-list-item>
+      <ons-list-item modifier="nodivider">Three</ons-list-item>
+
       <ons-list-header>List with Switch</ons-list-header>
       <ons-list-item>
         <label for="switch-1" class="center">


### PR DESCRIPTION
@argelius A user reported that `nodivider` does not work for Material Design in a private chat. The changes we made for list-item paddings in rc.5 are overwriting `background-image none` of `nodivider`. I just moved the common modifiers to the bottom of the file, I guess this should not break anything.