### PR TITLE
fix(ons-popover): Closes #1450

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ v2.0.0-rc.11
 ----
  * ons-input: Fix `value` property bug for radio and checkbox.
  * ons-navigator: Fix [#1449](https://github.com/OnsenUI/OnsenUI/issues/1449).
+ * ons-popover: Fix [#1450](https://github.com/OnsenUI/OnsenUI/issues/1450).
 
 v2.0.0-rc.10
 ----

--- a/core/src/elements/ons-popover/index.js
+++ b/core/src/elements/ons-popover/index.js
@@ -544,7 +544,7 @@ class PopoverElement extends BaseElement {
 
     contentReady(this, () => {
       this._margin = this._margin || parseInt(window.getComputedStyle(this).getPropertyValue('top'));
-      this._radius = parseInt(window.getComputedStyle(this._content).getPropertyValue('border-radius'));
+      this._radius = parseInt(window.getComputedStyle(this._content).getPropertyValue('border-top-left-radius'));
 
       this._mask.addEventListener('click', this._boundCancel, false);
 


### PR DESCRIPTION
@argelius @IliaSky Looks like Firefox and Edge don't have a `borderRadius` property in the computed styles :/