### PR TITLE
fix(ons-switch): Closes #1464.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 v2.0.0-rc.12
 ----
  * core: Added type definitions.
+ * ons-switch: Fix [#1464](https://github.com/OnsenUI/OnsenUI/issues/1464).
 
 v2.0.0-rc.11
 ----

--- a/core/src/elements/ons-splitter-side.js
+++ b/core/src/elements/ons-splitter-side.js
@@ -160,6 +160,7 @@ class CollapseMode {
     const direction = event.gesture.interimDirection;
     const shouldOpen = el._side !== direction && distance > width * el._threshold;
     this.executeAction(shouldOpen ? 'open' : 'close');
+    this._ignoreDrag = true;
   }
 
   layout() {

--- a/core/src/elements/ons-switch.js
+++ b/core/src/elements/ons-switch.js
@@ -247,6 +247,9 @@ class SwitchElement extends BaseElement {
       this.classList.remove('switch--active');
       return;
     }
+
+    e.stopPropagation();
+
     this.classList.add('switch--active');
     this._startX = this._locations[this.checked ? 1 : 0];// - e.gesture.deltaX;
 


### PR DESCRIPTION
@argelius `stopPropagation` only works for `onDragStart`. `onDrag` and `onDragEnd` are ignored with `this._ignoreDrag`.