### PR TITLE
Rename internal Cancel event to `dialog-cancel`

### DIFF
--- a/core/src/elements/ons-alert-dialog/index.js
+++ b/core/src/elements/ons-alert-dialog/index.js
@@ -491,7 +491,7 @@ class AlertDialogElement extends BaseElement {
       this.hide({
         callback: () => {
           this._running = false;
-          util.triggerElementEvent(this, 'cancel');
+          util.triggerElementEvent(this, 'dialog-cancel');
         }
       });
     }

--- a/core/src/elements/ons-dialog/index.js
+++ b/core/src/elements/ons-dialog/index.js
@@ -272,7 +272,7 @@ class DialogElement extends BaseElement {
       this.hide({
         callback: () => {
           this._running = false;
-          util.triggerElementEvent(this, 'cancel');
+          util.triggerElementEvent(this, 'dialog-cancel');
         }
       });
     }

--- a/core/src/elements/ons-dialog/index.spec.js
+++ b/core/src/elements/ons-dialog/index.spec.js
@@ -92,9 +92,9 @@ describe('OnsDialogElement', () => {
       expect(spy).to.have.been.called.once;
     });
 
-    it('emits a \'cancel\' event', () => {
+    it('emits a \'dialog-cancel\' event', () => {
       const promise = new Promise((resolve) => {
-        dialog.addEventListener('cancel', resolve);
+        dialog.addEventListener('dialog-cancel', resolve);
       });
 
       dialog.setAttribute('cancelable', '');

--- a/core/src/elements/ons-popover/index.js
+++ b/core/src/elements/ons-popover/index.js
@@ -582,7 +582,7 @@ class PopoverElement extends BaseElement {
     if (this.cancelable) {
       this.hide({
         callback: () => {
-          util.triggerElementEvent(this, 'cancel');
+          util.triggerElementEvent(this, 'dialog-cancel');
         }
       });
     }


### PR DESCRIPTION
@argelius  There is a problem when catching these events in Chrome, as it emits a syntax error. The solution for now is to rename the events since they are not documented.