### PR TITLE
Use $templateCache instead of internal.templateCache when using angular 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ v2.0.0-rc.16
  * ons-navigator: Improved iOS slide animation (again).
  * ons-icon: Fix [#1352](https://github.com/OnsenUI/OnsenUI/issues/1352).
  * ons-pull-hook, ons-carousel: Fix [#1004](https://github.com/OnsenUI/OnsenUI/issues/1004).
+ * ons-navigator, ons-tabbar, ons-splitter: Fix [#1209](https://github.com/OnsenUI/OnsenUI/issues/1209)
 
 v2.0.0-rc.15
 ----

--- a/bindings/angular1/js/onsen.js
+++ b/bindings/angular1/js/onsen.js
@@ -53,15 +53,17 @@ limitations under the License.
 
   function initAngularModule() {
     module.value('$onsGlobal', ons);
-    module.run(function($compile, $rootScope, $onsen, $q) {
+    module.run(function($compile, $rootScope, $onsen, $q, $http, $templateCache) {
       ons._onsenService = $onsen;
-      ons._qService = $q;
 
       $rootScope.ons = window.ons;
       $rootScope.console = window.console;
       $rootScope.alert = window.alert;
 
       ons.$compile = $compile;
+      ons._internal.q = $q;
+      ons._internal.http = $http;
+      ons._internal.templateCache = $templateCache;
     });
   }
 

--- a/bindings/angular1/services/onsen.js
+++ b/bindings/angular1/services/onsen.js
@@ -23,7 +23,7 @@ limitations under the License.
   /**
    * Internal service class for framework implementation.
    */
-  module.factory('$onsen', function($rootScope, $window, $cacheFactory, $document, $templateCache, $http, $q, $onsGlobal, ComponentCleaner) {
+  module.factory('$onsen', function($rootScope, $onsGlobal, ComponentCleaner) {
 
     var $onsen = createOnsenService();
     var ModifierUtil = $onsGlobal._internal.ModifierUtil;
@@ -170,42 +170,13 @@ limitations under the License.
          * @param {String} page
          * @return {Promise}
          */
-        getPageHTMLAsync: function(page) {
-          var cache = $templateCache.get(page);
-
-          if (cache) {
-            var deferred = $q.defer();
-
-            var html = typeof cache === 'string' ? cache : cache[1];
-            deferred.resolve(this.normalizePageHTML(html));
-
-            return deferred.promise;
-
-          } else {
-            return $http({
-              url: page,
-              method: 'GET'
-            }).then(function(response) {
-              var html = response.data;
-
-              return this.normalizePageHTML(html);
-            }.bind(this));
-          }
-        },
+        getPageHTMLAsync: $onsGlobal._internal.getPageHTMLAsync,
 
         /**
          * @param {String} html
          * @return {String}
          */
-        normalizePageHTML: function(html) {
-          html = ('' + html).trim();
-
-          if (!html.match(/^<ons-page/)) {
-            html = '<ons-page _muted>' + html + '</ons-page>';
-          }
-
-          return html;
-        },
+        normalizePageHTML: $onsGlobal._internal.normalizePageHTML,
 
         /**
          * Create modifier templater function. The modifier templater generate css classes bound modifier name.


### PR DESCRIPTION
With this the angular 1 bindings change the `templateCache` of the core with `$templateCache`. With this in theory we should be able to get rid of all the custom logic which we have for the templates in the bindings. However just to be safe from some timing issue I have left most of the logic in place. We could try to remove the rest of the logic if we want.

On a sidenote - we may think of exporting this so that users could use it in the core instead of having it hidden under `_internal`. 

@argelius - I would like to hear your opinion. If you think this is good enough feel free to merge it.

PS: I got this to work much earlier, but it turned out the bindings weren't applied without an action from the user. Since I'm already tired I just used `$q` and `$http` in the end (to get the free `$apply`), but I guess that probably makes less sense than just replacing the `getPageHTMLAsync`.