### PR TITLE
Remove global `ons` object

### DIFF
--- a/bindings/angular2/src/directives/ons-tabbar.ts
+++ b/bindings/angular2/src/directives/ons-tabbar.ts
@@ -11,7 +11,7 @@ import {
   OnDestroy
 } from '@angular/core';
 
-declare var ons: any;
+import {PageLoader} from 'onsenui';
 
 /**
  * @element ons-tabbar
@@ -44,7 +44,7 @@ export class OnsTab implements OnDestroy {
     private _resolver: ComponentResolver) {
 
     // set up ons-tab's page loader
-    this._elementRef.nativeElement.pageLoader = new ons.PageLoader((page, parent, done) => {
+    this._elementRef.nativeElement.pageLoader = new PageLoader((page, parent, done) => {
       this._resolver.resolveComponent(page).then(factory => {
         const pageComponentRef = this._viewContainer.createComponent(factory, 0);
 

--- a/bindings/angular2/src/ons/notification.ts
+++ b/bindings/angular2/src/ons/notification.ts
@@ -1,3 +1,3 @@
-declare var ons: any;
+import {notification} from 'onsenui';
 
-export const onsNotification = ons.notification;
+export const onsNotification = notification;

--- a/bindings/angular2/src/ons/platform.ts
+++ b/bindings/angular2/src/ons/platform.ts
@@ -1,3 +1,3 @@
-declare var ons: any;
+import {platform} from 'onsenui';
 
-export const onsPlatform = ons.platform;
+export const onsPlatform = platform;

--- a/bindings/angular2/webpack.config.js
+++ b/bindings/angular2/webpack.config.js
@@ -62,6 +62,10 @@ var defaultConfig = {
     ]
   },
 
+  externals: {
+    onsenui: 'ons'
+  },
+
   resolve: {
     root: [path.join(__dirname, 'src')],
     extensions: ['', '.ts', '.js']


### PR DESCRIPTION
@anatoo This should make it possible to use the Angular 2 bindings without assigning `window.ons` or using a script tag.

Please merge if there are no problems.