### PR TITLE
fix(ons-navigator): Fixed display conflicts with ons-carousel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ v2.0.0-rc.16
  * ons-fab: Fix [#1496](https://github.com/OnsenUI/OnsenUI/issues/1496).
  * ons-list-item: Fix [#1499](https://github.com/OnsenUI/OnsenUI/issues/1499)
  * ons-tabbar: Fix [#1501](https://github.com/OnsenUI/OnsenUI/issues/1501)
+ * ons-carousel: initial-index works when the carousel is inside ons-navigator.
 
 v2.0.0-rc.15
 ----

--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -361,7 +361,6 @@ class NavigatorElement extends BaseElement {
     return new Promise(resolve => {
       var leavePage = this.pages[l - 1];
       var enterPage = this.pages[l - 2];
-      enterPage.style.display = 'block';
 
       options.animation = leavePage.pushedOptions.animation || options.animation;
       options.animationOptions = util.extend({}, leavePage.pushedOptions.animationOptions, options.animationOptions || {});
@@ -434,7 +433,7 @@ class NavigatorElement extends BaseElement {
         name: options.page,
         data: options.data
       });
-      element.style.display = 'none';
+      element.style.visibility = 'hidden';
       this.appendChild(element);
       resolve();
     });
@@ -483,10 +482,6 @@ class NavigatorElement extends BaseElement {
         var done = () => {
           this._isRunning = false;
 
-          if (leavePage) {
-            leavePage.style.display = 'none';
-          }
-
           enterPage._show();
           util.triggerElementEvent(this, 'postpush', {leavePage, enterPage, navigator: this});
 
@@ -497,10 +492,8 @@ class NavigatorElement extends BaseElement {
           resolve(enterPage);
         };
 
-        enterPage.style.display = 'none';
-
         var push = () =>  {
-          enterPage.style.display = 'block';
+          enterPage.style.visibility = '';
           if (leavePage) {
             leavePage._hide();
             animator.push(enterPage, leavePage, done);
@@ -577,7 +570,6 @@ class NavigatorElement extends BaseElement {
       );
 
       return new Promise(resolve => {
-        element.style.display = 'none';
         this.insertBefore(element, this.pages[index]);
         this.topPage.updateBackButton(true);
 
@@ -674,7 +666,6 @@ class NavigatorElement extends BaseElement {
       page: page.name,
       _linked: true
     });
-    page.style.display = 'none';
     page.setAttribute('_skipinit', '');
     page.parentNode.appendChild(page);
     return this._pushPage(options);

--- a/test/e2e/backButton/scenarios.js
+++ b/test/e2e/backButton/scenarios.js
@@ -28,11 +28,9 @@
 
       element(by.css('ons-button')).click();
       browser.wait(EC.visibilityOf(page2));
-      browser.wait(EC.invisibilityOf(page1));
 
       // Check that page2 was created and that it's displayed.
       expect((page2).isDisplayed()).toBeTruthy();
-      expect((page1).isDisplayed()).not.toBeTruthy();
       expect((page1).isPresent()).toBeTruthy();
 
       element(by.css('ons-back-button')).click();

--- a/test/e2e/composition/scenarios.js
+++ b/test/e2e/composition/scenarios.js
@@ -2,23 +2,18 @@
   'use strict';
 
   describe('navigator with split view', function() {
-    var path = '/test/e2e/composition/navigator+splitView.html',
-      EC = protractor.ExpectedConditions;
-
-    beforeEach(function() {
+    it('should push and pop the page', function() {
+      var path = '/test/e2e/composition/navigator+splitView.html',
+        EC = protractor.ExpectedConditions;
       browser.get(path);
       browser.waitForAngular();
-    });
 
-    it('should push and pop the page', function() {
       var pushPage = element(by.id('push-page')),
         popPage = element(by.id('pop-page'));
 
       pushPage.click();
       browser.wait(EC.visibilityOf(popPage));
-      browser.wait(EC.invisibilityOf(pushPage));
       expect(popPage.isDisplayed()).toBeTruthy();
-      expect(pushPage.isDisplayed()).not.toBeTruthy();
 
       popPage.click();
       browser.wait(EC.visibilityOf(pushPage));
@@ -29,15 +24,13 @@
   });
 
   describe('navigator with dialog', function() {
-    var path = '/test/e2e/composition/navigator+dialog.html',
-      EC = protractor.ExpectedConditions;
+    it('should not crash (issue #570)', function() {
+      var path = '/test/e2e/composition/navigator+dialog.html',
+        EC = protractor.ExpectedConditions;
 
-    beforeEach(function() {
       browser.get(path);
       browser.waitForAngular();
-    });
 
-    it('should not crash (issue #570)', function() {
       var pushPage = element(by.id('push-page')),
         popPage = element(by.id('pop-page')),
         hideDialog = element(by.id('hide-dialog'));

--- a/test/e2e/navigator/scenarios.js
+++ b/test/e2e/navigator/scenarios.js
@@ -26,11 +26,9 @@
 
         element(by.id('btn1')).click();
         browser.wait(EC.visibilityOf(page2));
-        browser.wait(EC.invisibilityOf(page1));
 
         // Check that page2 was created and that it's displayed.
         expect((page2).isDisplayed()).toBeTruthy();
-        expect((page1).isDisplayed()).not.toBeTruthy();
         expect((page1).isPresent()).toBeTruthy();
 
         element(by.id('btn2')).click();
@@ -56,7 +54,6 @@
 
         element(by.id('btn1')).click();
         browser.wait(EC.visibilityOf(page2));
-        browser.wait(EC.invisibilityOf(page1));
 
         element(by.id('btn3')).click();
         browser.wait(EC.stalenessOf(page2));
@@ -87,7 +84,6 @@
 
         element(by.id('btn1')).click();
         browser.wait(EC.visibilityOf(page2));
-        browser.wait(EC.invisibilityOf(page1));
 
         element(by.id('btn6-reset')).click();
         browser.wait(EC.stalenessOf(page2));
@@ -102,7 +98,6 @@
         var page2 = element(by.id('page2'));
         element(by.id('btn1')).click();
         browser.wait(EC.visibilityOf(page2));
-        browser.wait(EC.invisibilityOf(page1));
 
         element(by.id('btn-insert1')).click();
         browser.wait(protractor.until.elementLocated(by.id('background_1'), 500));
@@ -113,9 +108,7 @@
         var page3 = element(by.id('background_1'));
         var page4 = element(by.id('background_2'));
 
-        expect(element(by.id('page1')).isDisplayed()).toBe(false);
         expect(element(by.id('page2')).isDisplayed()).toBe(true);
-        expect(element(by.id('background_1')).isDisplayed()).toBe(false);
         expect(element(by.id('background_2')).isDisplayed()).toBe(false);
 
         // pop
@@ -143,7 +136,6 @@
 
         element(by.id('btn1')).click();
         browser.wait(EC.visibilityOf(page2));
-        browser.wait(EC.invisibilityOf(page1));
 
         element(by.id('btn4-device-backbutton')).click();
         browser.wait(EC.stalenessOf(page2));
@@ -164,11 +156,9 @@
 
         element(by.id('btn1')).click();
         browser.wait(EC.visibilityOf(page2));
-        browser.wait(EC.invisibilityOf(page1));
 
         // Check that page2 was created and that it's displayed.
         expect((page2).isDisplayed()).toBeTruthy();
-        expect((page1).isDisplayed()).not.toBeTruthy();
         expect((page1).isPresent()).toBeTruthy();
 
         element(by.id('btn5')).click();
@@ -197,7 +187,6 @@
       element(by.id('btn1')).click();
 
       browser.wait(EC.visibilityOf(page2));
-      browser.wait(EC.invisibilityOf(page1));
 
       browser.wait(EC.visibilityOf(element(by.id('btn2'))));
       element(by.id('btn2')).click();


### PR DESCRIPTION
@argelius This removes all the `style.display` stuff that were not necessary anymore in Onsen 2 navigator since the z-index and element position in the DOM do the job.

`style.visibility = 'hidden'` is needed to fix the flickering in iOS 9.3.