### PR TITLE
fix(ons-navigator): 'init' before 'show'. Closes #1513.

### DIFF
--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -528,18 +528,15 @@ class NavigatorElement extends BaseElement {
    *   [ja]現在表示中のページをを指定したページに置き換えます。[/ja]
    */
   replacePage(page, options = {}) {
-    options = this._prepareOptions(options, page);
-    const callback = options.callback;
+    return this.pushPage(page, options)
+      .then(resolvedValue => {
+        if (this.pages.length > 1) {
+          this.pages[this.pages.length - 2]._destroy();
+        }
+        this._updateLastPageBackButton();
 
-    options.callback = () => {
-      if (this.pages.length > 1) {
-        this.pages[this.pages.length - 2]._destroy();
-      }
-      this._updateLastPageBackButton();
-      callback && callback();
-    };
-
-    return this.pushPage(options);
+        return Promise.resolve(resolvedValue);
+      });
   }
 
   /**

--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -487,7 +487,7 @@ class NavigatorElement extends BaseElement {
             leavePage.style.display = 'none';
           }
 
-          enterPage._show();
+          setImmediate(() => enterPage._show());
           util.triggerElementEvent(this, 'postpush', {leavePage, enterPage, navigator: this});
 
           if (typeof options.callback === 'function') {

--- a/core/src/elements/ons-navigator/index.spec.js
+++ b/core/src/elements/ons-navigator/index.spec.js
@@ -618,53 +618,46 @@ describe('OnsNavigatorElement', () => {
 
       document.body.appendChild(tpl1);
       document.body.appendChild(tpl2);
-      nav2 = ons._util.createElement(` <ons-navigator page='backPage'></ons-navigator> `);
-      nav2.options = {cancelIfRunning: false};
+      nav2 = ons._util.createElement(`<ons-navigator></ons-navigator>`);
       document.body.appendChild(nav2);
 
-      setImmediate(() => {
-        done();
-      });
+      nav2.pushPage('backPage').then(() => done());
     });
 
     it('should not display on first page', () => {
+      const backBtn = nav2.topPage.backButton;
+      expect(backBtn.style.display).to.equal('none');
+    });
+
+    it('should display button after push', () => {
+      return nav2.pushPage('backPage').then(() => {
         const backBtn = nav2.topPage.backButton;
-        expect(backBtn.style.display).to.equal('none');
+        expect(backBtn.style.display).to.equal('inline-block');
+      });
     });
 
-    it('should display button after push', (done) => {
-        nav2.pushPage('backPage').then(() => {
-          const backBtn = nav2.topPage.backButton;
-          expect(backBtn.style.display).to.equal('inline-block');
-          done();
+    it('should display button after insert and hide after pop', () => {
+      return nav2.insertPage(0, 'backPage').then(() => {
+        var backBtn = nav2.topPage.backButton;
+        expect(backBtn.style.display).to.equal('inline-block');
+
+        return nav2.popPage().then(() => {
+          backBtn = nav2.topPage.backButton;
+          expect(backBtn.style.display).to.equal('none');
         });
+      });
     });
 
-    it('should display button after insert and hide after pop', (done) => {
-        nav2.insertPage(0, 'backPage').then(() => {
-          var backBtn = nav2.topPage.backButton;
-          expect(backBtn.style.display).to.equal('inline-block');
+    it('should display button after insert and hide after reset', () => {
+      return nav2.pushPage('backPage2').then(() => {
+        var backBtn = nav2.topPage.backButton;
+        expect(backBtn.style.display).to.equal('inline-block');
 
-          nav2.popPage().then(() => {
-            backBtn = nav2.topPage.backButton;
-            expect(backBtn.style.display).to.equal('none');
-            done();
-          });
+        return nav2.resetToPage('backPage').then(() => {
+          backBtn = nav2.topPage.backButton;
+          expect(backBtn.style.display).to.equal('none');
         });
-    });
-
-
-    it('should display button after insert and hide after reset', (done) => {
-        nav2.pushPage('backPage2').then(() => {
-          var backBtn = nav2.topPage.backButton;
-          expect(backBtn.style.display).to.equal('inline-block');
-
-          nav2.resetToPage('backPage').then(() => {
-            backBtn = nav2.topPage.backButton;
-            expect(backBtn.style.display).to.equal('none');
-            done();
-          });
-        });
+      });
     });
 
     afterEach(() => {

--- a/core/src/elements/ons-navigator/index.spec.js
+++ b/core/src/elements/ons-navigator/index.spec.js
@@ -437,23 +437,20 @@ describe('OnsNavigatorElement', () => {
       expect(() => nav.replacePage('hoge', 'string')).to.throw(Error);
     });
 
-    it('replaces the current page with a new one', (done) => {
-      nav.pushPage('info', {
-        callback: () => {
+    it('replaces the current page with a new one', () => {
+      return nav.pushPage('info')
+        .then(() => {
           expect(nav.pages.length).to.equal(2);
           const content = nav.topPage._getContentElement();
           expect(content.innerHTML).to.equal('info');
 
-          nav.replacePage('fuga', {
-            callback: () => {
+          return nav.replacePage('fuga')
+            .then(() => {
               expect(nav.pages.length).to.equal(2);
               const content = nav.topPage._getContentElement();
               expect(content.innerHTML).to.equal('fuga');
-              done();
-            }
-          });
-        }
-      });
+            });
+        });
     });
 
     it('returns a promise that resolves to the new top page', (done) => {


### PR DESCRIPTION
@argelius `done` is called asynchronously in `pushPage` when there is animation, but synchronously when animation is `none`. This makes the `show` event be fired before `init`. For example, this also happens in the first page when using `page` attribute but not when the page is directly inside `ons-navigator`.

There are two fixes, call `done` always asynchronously or just fire `show` asynchronously. The only drawback about the first approach is related to this change: 

```
-      nav2 = ons._util.createElement(` <ons-navigator page='backPage'></ons-navigator> `);
+     nav2 = ons._util.createElement(`<ons-navigator></ons-navigator>`);

-      setImmediate(() => {
-        done();
-      });
+     nav2.pushPage('backPage').then(() => done());
```

We are not sure that the page is loaded right after creating the navigator with `page` attribute. Do you think this could be a problem?