### PR TITLE
Page content movement simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ v2.0.0-rc.16
  * ons-fab: Fix [#1496](https://github.com/OnsenUI/OnsenUI/issues/1496).
  * ons-list-item: Fix [#1499](https://github.com/OnsenUI/OnsenUI/issues/1499)
  * ons-tabbar: Fix [#1501](https://github.com/OnsenUI/OnsenUI/issues/1501)
+ * ons-page, ons-toolbar, ons-bottom-toolbar, ons-modal, ons-speed-dial: Improved location logic
+ * ons-fab: Now stays outside of `.page__content` when it has a `position` attribute.
+ * ons-modal: Fix [#1511](https://github.com/OnsenUI/OnsenUI/issues/1511).
 
 v2.0.0-rc.15
 ----

--- a/bindings/angular1/directives/modal.js
+++ b/bindings/angular1/directives/modal.js
@@ -38,8 +38,6 @@
             $onsen.declareVarAttribute(attrs, modal);
             element.data('ons-modal', modal);
 
-            element[0]._ensureNodePosition();
-
             scope.$on('$destroy', function() {
               $onsen.removeModifierMethods(modal);
               element.data('ons-modal', undefined);

--- a/bindings/angular1/directives/toolbar.js
+++ b/bindings/angular1/directives/toolbar.js
@@ -30,7 +30,6 @@
             if (element[0].nodeName === 'ons-toolbar') {
               CustomElements.upgrade(element[0]);
               GenericView.register(scope, element, attrs, {viewKey: 'ons-toolbar'});
-              element[0]._ensureNodePosition();
             }
           },
           post: function(scope, element, attrs) {

--- a/core/src/elements/ons-bottom-toolbar.js
+++ b/core/src/elements/ons-bottom-toolbar.js
@@ -53,21 +53,11 @@ class BottomToolbarElement extends BaseElement {
     this.classList.add('bottom-bar');
 
     ModifierUtil.initModifier(this, scheme);
-
-    this._tryToEnsureNodePosition();
-    setImmediate(() => this._tryToEnsureNodePosition());
   }
 
   attachedCallback() {
-    this._tryToEnsureNodePosition();
-    setImmediate(() => this._tryToEnsureNodePosition());
-  }
-
-  _tryToEnsureNodePosition() {
-    const page = util.findParent(this, 'ons-page');
-
-    if (page && page !== this.parentNode) {
-      page._registerBottomToolbar(this);
+    if (util.match(this.parentNode, 'ons-page')) {
+      this.parentNode.classList.add('page-with-bottom-toolbar');
     }
   }
 

--- a/core/src/elements/ons-bottom-toolbar.spec.js
+++ b/core/src/elements/ons-bottom-toolbar.spec.js
@@ -26,14 +26,14 @@ describe('ons-bottom-toolbar', () => {
     expect(element.classList.contains('bottom-bar--fuga')).to.be.true;
   });
 
-  it('ensures it\'s location in the page', () => {
+  it('ensures it\'s page\'s class', () => {
     var element = new OnsBottomToolbarElement(),
       page = new OnsPageElement();
 
     document.body.appendChild(page);
     page.appendChild(element);
 
-    expect(element.parentNode).to.equal(page);
+    expect(page.classList.contains('page-with-bottom-toolbar')).to.be.true;
 
     document.body.removeChild(page);
   });

--- a/core/src/elements/ons-bottom-toolbar.spec.js
+++ b/core/src/elements/ons-bottom-toolbar.spec.js
@@ -26,7 +26,7 @@ describe('ons-bottom-toolbar', () => {
     expect(element.classList.contains('bottom-bar--fuga')).to.be.true;
   });
 
-  it('ensures it\'s page\'s class', () => {
+  it('ensures its page\'s class', () => {
     var element = new OnsBottomToolbarElement(),
       page = new OnsPageElement();
 

--- a/core/src/elements/ons-modal/index.js
+++ b/core/src/elements/ons-modal/index.js
@@ -125,6 +125,7 @@ class ModalElement extends BaseElement {
 
   _compile() {
     this.style.display = 'none';
+    this.style.zIndex = 10001;
     this.classList.add('modal');
 
     if (!util.findChild(this, '.modal__content')) {
@@ -150,30 +151,7 @@ class ModalElement extends BaseElement {
   }
 
   attachedCallback() {
-    setImmediate(this._ensureNodePosition.bind(this));
     this.onDeviceBackButton = () => undefined;
-  }
-
-  _ensureNodePosition() {
-    if (!this.parentNode || this.hasAttribute('inline')) {
-      return;
-    }
-
-    if (this.parentNode.nodeName.toLowerCase() !== 'ons-page') {
-      var page = this;
-      for (;;) {
-        page = page.parentNode;
-
-        if (!page) {
-          return;
-        }
-
-        if (page.nodeName.toLowerCase() === 'ons-page') {
-          break;
-        }
-      }
-      page._registerExtraElement(this);
-    }
   }
 
   /**

--- a/core/src/elements/ons-modal/index.spec.js
+++ b/core/src/elements/ons-modal/index.spec.js
@@ -126,23 +126,6 @@ describe('OnsModalElement', () => {
     });
   });
 
-  describe('#_ensureNodePosition()', () => {
-    it('does not register extra element when has no parent ons-page', () => {
-      const spy = chai.spy.on(element, '_registerExtraElement');
-      expect(element._ensureNodePosition()).not.to.be.ok;
-      expect(spy).to.not.have.been.called();
-    });
-
-    it('registers extra element when has parent ons-page', () => {
-      const element = new OnsModalElement();
-      const parent = new OnsPageElement();
-      const spy = chai.spy.on(parent, '_registerExtraElement');
-      parent._registerExtraElement(element);
-      element._ensureNodePosition();
-      expect(spy).to.have.been.called.twice;
-    });
-  });
-
   describe('#attributeChangedCallback()', () => {
     it('triggers \'onModifierChanged()\' method', () => {
       const spy = chai.spy.on(ons._internal.ModifierUtil, 'onModifierChanged');

--- a/core/src/elements/ons-page.js
+++ b/core/src/elements/ons-page.js
@@ -364,7 +364,7 @@ class PageElement extends BaseElement {
   }
 
   _elementShouldBeMoved(el) {
-    if (el.className.match(/\bpage__/)) {
+    if (el.classList.contains('page__background')) {
       return false;
     }
     const tagName = el.tagName.toLowerCase();

--- a/core/src/elements/ons-page.js
+++ b/core/src/elements/ons-page.js
@@ -308,25 +308,6 @@ class PageElement extends BaseElement {
     return util.findChild(this, 'ons-toolbar') || nullToolbarElement;
   }
 
-  /**
-   * Register toolbar element to this page.
-   *
-   * @param {HTMLElement} element
-   */
-  _registerToolbar(element) {
-    this.insertBefore(element, this.children[0]);
-  }
-
-  /**
-   * Register toolbar element to this page.
-   *
-   * @param {HTMLElement} element
-   */
-  _registerBottomToolbar(element) {
-    this.classList.add('page-with-bottom-toolbar');
-    this.appendChild(element);
-  }
-
   attributeChangedCallback(name, last, current) {
     if (name === 'modifier') {
       return ModifierUtil.onModifierChanged(last, current, this, scheme);
@@ -362,12 +343,14 @@ class PageElement extends BaseElement {
       const content = util.create('.page__content');
 
       util.arrayFrom(this.childNodes).forEach(node => {
-        if (!node.classList || !node.classList.contains('page__background')) {
+        if (node.nodeType !== 1 || this._elementShouldBeMoved(node)) {
           content.appendChild(node);
         }
       });
 
-      this.appendChild(content);
+      const prevNode = util.findChild(this, '.page__background') || util.findChild(this, 'ons-toolbar');
+
+      this.insertBefore(content, prevNode && prevNode.nextSibling);
     }
 
     if (!util.findChild(this, '.page__background')) {
@@ -380,14 +363,16 @@ class PageElement extends BaseElement {
     this.setAttribute('_compiled', '');
   }
 
-  _registerExtraElement(element) {
-    let extra = util.findChild(this, '.page__extra');
-    if (!extra) {
-      extra = util.create('.page__extra', {zIndex: 10001});
-      this.appendChild(extra);
+  _elementShouldBeMoved(el) {
+    if (el.className.match(/\bpage__/)) {
+      return false;
     }
-
-    extra.appendChild(element);
+    const tagName = el.tagName.toLowerCase();
+    if (tagName === 'ons-fab') {
+      return !el.hasAttribute('position');
+    }
+    const fixedElements = ['ons-toolbar', 'ons-bottom-toolbar', 'ons-modal', 'ons-speed-dial'];
+    return el.hasAttribute('inline') || fixedElements.indexOf(tagName) === -1;
   }
 
   _show() {

--- a/core/src/elements/ons-page.spec.js
+++ b/core/src/elements/ons-page.spec.js
@@ -130,7 +130,7 @@ describe('OnsPageElement', () => {
   describe('#_canAnimateToolbar()', () => {
     it('works with normal toolbar', () => {
       expect(element._canAnimateToolbar()).to.be.false;
-      element._registerToolbar(new OnsToolbarElement());
+      element.insertBefore(new OnsToolbarElement(), element.children[0]);
       expect(element._canAnimateToolbar()).to.be.true;
     });
 
@@ -138,47 +138,6 @@ describe('OnsPageElement', () => {
       expect(element._canAnimateToolbar()).to.be.false;
       element.lastChild.appendChild(new OnsToolbarElement());
       expect(element._canAnimateToolbar()).to.be.true;
-    });
-  });
-
-  describe('#_getToolbarElement()', () => {
-    it('returns the toolbar element', () => {
-      element._registerToolbar(new OnsToolbarElement());
-      expect(element._getToolbarElement()).to.be.ok;
-    });
-  });
-
-  describe('#_registerToolbar()', () => {
-    it('inserts toolbar as a child', () => {
-      var spy = chai.spy.on(element, 'insertBefore');
-      var toolbarElement = new OnsToolbarElement();
-      element._registerToolbar(toolbarElement);
-      expect(spy).to.have.been.called.with(toolbarElement, element.children[0]);
-    });
-
-    it('inserts toolbar as a child after status-bar-fill', () => {
-      var fill = document.createElement('div');
-      fill.classList.add('page__status-bar-fill');
-      element.insertBefore(fill, element.firstChild);
-      var toolbarElement = new OnsToolbarElement();
-      var spy = chai.spy.on(element, 'insertBefore');
-      element._registerToolbar(toolbarElement);
-      expect(spy).to.have.been.called.with(toolbarElement, element.children[1]);
-    });
-  });
-
-  describe('#_getBottomToolbarElement()', () => {
-    it('inserts bottomToolbar as a child', () => {
-      element._registerBottomToolbar(new OnsBottomToolbarElement());
-      expect(element._getBottomToolbarElement()).to.be.ok;
-    });
-  });
-
-  describe('#registerExtraElement()', () => {
-    it('attaches a new child to the page', () => {
-      expect(element.lastChild.className).to.equal('page__content');
-      element._registerExtraElement(document.createElement('div'));
-      expect(element.lastChild.className).to.equal('page__extra');
     });
   });
 
@@ -242,6 +201,39 @@ describe('OnsPageElement', () => {
       div1.innerHTML = '<ons-page></ons-page>';
       div2.innerHTML = div1.innerHTML;
       expect(div1.isEqualNode(div2)).to.be.true;
+    });
+
+    it('adds elements in correct order', () => {
+      const div = document.createElement('div');
+      div.innerHTML = '<ons-page><span>test</span><ons-toolbar></ons-toolbar></ons-page>';
+      const elements = div.children[0].children;
+      expect(elements[0].tagName.toLowerCase()).to.equal('ons-toolbar');
+      expect(elements[1].className).to.equal('page__background');
+      expect(elements[2].className).to.equal('page__content');
+    });
+  });
+
+  describe('#_elementShouldBeMoved()', () => {
+
+    it('ignores .page__xxx elements', () => {
+      const el = selector => ons._util.create(selector);
+      expect(element._elementShouldBeMoved(el('.page__test'))).to.be.false;
+      expect(element._elementShouldBeMoved(el('.page__doge'))).to.be.false;
+      expect(element._elementShouldBeMoved(el('.doge__doge'))).to.be.true;
+    });
+
+    it('handles fabs accordingly', () => {
+      const toolbar = document.createElement('ons-fab');
+      expect(element._elementShouldBeMoved(toolbar)).to.be.true;
+      toolbar.setAttribute('position', 'top right');
+      expect(element._elementShouldBeMoved(toolbar)).to.be.false;
+    });
+
+    it('moves inline elements', () => {
+      const toolbar = document.createElement('ons-toolbar');
+      expect(element._elementShouldBeMoved(toolbar)).to.be.false;
+      toolbar.setAttribute('inline', '');
+      expect(element._elementShouldBeMoved(toolbar)).to.be.true;
     });
   });
 

--- a/core/src/elements/ons-page.spec.js
+++ b/core/src/elements/ons-page.spec.js
@@ -215,10 +215,10 @@ describe('OnsPageElement', () => {
 
   describe('#_elementShouldBeMoved()', () => {
 
-    it('ignores .page__xxx elements', () => {
+    it('ignores .page__background', () => {
       const el = selector => ons._util.create(selector);
-      expect(element._elementShouldBeMoved(el('.page__test'))).to.be.false;
-      expect(element._elementShouldBeMoved(el('.page__doge'))).to.be.false;
+      expect(element._elementShouldBeMoved(el('.page__background'))).to.be.false;
+      expect(element._elementShouldBeMoved(el('.page__doge'))).to.be.true;
       expect(element._elementShouldBeMoved(el('.doge__doge'))).to.be.true;
     });
 

--- a/core/src/elements/ons-toolbar.js
+++ b/core/src/elements/ons-toolbar.js
@@ -102,9 +102,6 @@ class ToolbarElement extends BaseElement {
         this._compile();
       }
     });
-
-    this._tryToEnsureNodePosition();
-    setImmediate(() => this._tryToEnsureNodePosition());
   }
 
   attributeChangedCallback(name, last, current) {
@@ -114,19 +111,6 @@ class ToolbarElement extends BaseElement {
   }
 
   attachedCallback() {
-    this._tryToEnsureNodePosition();
-    setImmediate(() => this._tryToEnsureNodePosition());
-  }
-
-  _tryToEnsureNodePosition() {
-    if (!this.parentNode || this.hasAttribute('inline')) {
-      return;
-    }
-    const page = util.findParent(this, 'ons-page');
-
-    if (page && page !== this.parentNode) {
-      page._registerToolbar(this);
-    }
   }
 
   /**

--- a/core/src/elements/ons-toolbar.spec.js
+++ b/core/src/elements/ons-toolbar.spec.js
@@ -79,14 +79,6 @@ describe('OnsToolbarElement', () => {
   });
   */
 
-  describe('#attachedCallbad()', () => {
-    it('does not register extra element when has no parent ons-page', () => {
-      var spy = chai.spy.on(element, '_registerToolbar');
-      document.body.appendChild(element);
-      expect(spy).to.not.have.been.called();
-    });
-  });
-
   describe('#_compile()', () => {
     it('removes non-element children', () => {
       const element = ons._util.createElement('<ons-toolbar>Test1<div class="center">Test2</div></ons-toolbar>');


### PR DESCRIPTION
Now only moves elements a single time only if it is necessary instead of moving them multiple times in both directions until one comes out on top.

Also fixes #1511.