### PR TITLE
Changed ons-splitter-* to use page-loader.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 
 v2.0.0-rc.16
 ----
+ * ons-splitter-side, ons-splitter-content: Added "page" and "pageLoader" property. Changed to use page-loader instead of `ons._internal.getPageHTMLAsync()`.
  * ons-navigator: Added "page" and "pageLoader" property. Changed to use page-loader instead of `ons._internal.getPageHTMLAsync()`.
  * ons-tabbar, ons-tab: Added "page" and "pageLoader" property. Changed to use page-loader instead of `ons._internal.getPageHTMLAsync()`.
  * core: Added ons.defaultPageLoader and ons.PageLoader.

--- a/core/src/elements/ons-splitter-content.spec.js
+++ b/core/src/elements/ons-splitter-content.spec.js
@@ -32,6 +32,17 @@ describe('ons-splitter-content', () => {
     expect(content._destroy instanceof Function).to.be.ok;
   });
 
+  it('provide page property', () => {
+    content.page = 'hoge';
+    expect(content.page).to.be.equal('hoge');
+  });
+
+  it('provide pageLoader property', () => {
+    expect(content.pageLoader instanceof ons.PageLoader).to.be.ok;
+    content.pageLoader = new ons.PageLoader();
+    expect(content.pageLoader instanceof ons.PageLoader).to.be.ok;
+  });
+
   describe('child elements', ()=> {
     it('should pass though child nodes', () => {
       expect(content.innerHTML).to.be.equal('content');

--- a/core/src/elements/ons-splitter-side.spec.js
+++ b/core/src/elements/ons-splitter-side.spec.js
@@ -31,6 +31,17 @@ describe('OnsSplitterSideElement', () => {
     expect(left._destroy instanceof Function).to.be.ok;
   });
 
+  it('provide page property', () => {
+    left.page = 'hoge';
+    expect(left.page).to.be.equal('hoge');
+  });
+
+  it('provide pageLoader property', () => {
+    expect(left.pageLoader instanceof ons.PageLoader).to.be.ok;
+    left.pageLoader = new ons.PageLoader();
+    expect(left.pageLoader instanceof ons.PageLoader).to.be.ok;
+  });
+
   describe('#load()', () => {
     let template;
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -58,7 +58,7 @@ gulp.task('browser-sync', () => {
 ////////////////////////////////////////
 gulp.task('core', function() {
   return gulp.src(['core/src/setup.js'], {read: false})
-    .pipe($.plumber(error => {
+    .pipe($.plumber(function(error) {
       $.util.log(error.message);
       this.emit('end');
     }))


### PR DESCRIPTION
@argelius Please merge this changes when you have a time.

Summary:
 * ons-splitter-side, ons-splitter-content: Added "page" and "pageLoader" property. Changed to use page-loader instead of `ons._internal.getPageHTMLAsync()`
 *  gulpfile: Fixed that "core" task is stopped when babel fail to transpile once in "serve" task.
 * angular2-binding: Reimplemented the directive for ons-splitter-content and ons-splitter-side.