### PR TITLE
Tabs no page attr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ v2.0.0-rc.16
  * ons-modal: Fix [#1511](https://github.com/OnsenUI/OnsenUI/issues/1511).
  * ons-lazy-repeat: Expose `refresh()` method to user through delegate object.
  * ons-pull-hook: Remove DOM mutations to make it easier to integrate with frameworks and libs.
+ * ons-tab: Fix [#1528](https://github.com/OnsenUI/OnsenUI/issues/1528).
 
 v2.0.0-rc.15
 ----

--- a/core/src/elements/ons-tab.js
+++ b/core/src/elements/ons-tab.js
@@ -312,7 +312,11 @@ class TabElement extends BaseElement {
    * @param {Function} link
    */
   _loadPageElement(parent, callback, link) {
-    if (!this._loadedPage) {
+    if (!this._loadedPage && !this._getPageTarget()) {
+      const pages = this._findTabbarElement().pages;
+      const index = this._findTabIndex();
+      callback(pages[index]);
+    } else if (!this._loadedPage) {
       this._pageLoader.load({page: this._getPageTarget(), parent}, page => {
         this._loadedPage = page;
         link(page.element, element => {


### PR DESCRIPTION
@anatoo: I added this to support `<ons-tab>` without `page` attribute.

With this change you can render a tabbar like this:

```
<ons-tabbar>
  <div class="tab-bar__content">
    <ons-page>...</ons-page>
    <ons-page>...</ons-page>
    <ons-page>...</ons-page>
  </div>
  <div class="tab-bar">
    <ons-tab ...></ons-tab>
    <ons-tab ...></ons-tab>
    <ons-tab ...></ons-tab>
  </div>
</ons-tabbar>
```

The tabs and pages are already rendered so no need for the `page` attribute.

Is this change ok?