### PR TITLE
fix(ons-splitter): Use a different pageLoader. Closes #1537.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 CHANGELOG
 ====
 
+v2.0.0-rc.18
+----
+ * ons-splitter: Fix [#1537](https://github.com/OnsenUI/OnsenUI/issues/1537).
+
 v2.0.0-rc.17
 ----
  * core: Update Typescript definitions.

--- a/core/src/elements/ons-splitter-content.js
+++ b/core/src/elements/ons-splitter-content.js
@@ -19,7 +19,7 @@ import util from 'ons/util';
 import internal from 'ons/internal';
 import ModifierUtil from 'ons/internal/modifier-util';
 import BaseElement from 'ons/base-element';
-import {PageLoader, replaceContentPageLoader} from 'ons/page-loader';
+import {PageLoader, defaultPageLoader} from 'ons/page-loader';
 import contentReady from 'ons/content-ready';
 
 const rewritables = {
@@ -86,7 +86,7 @@ class SplitterContentElement extends BaseElement {
    */
   createdCallback() {
     this._page = null;
-    this._pageLoader = replaceContentPageLoader;
+    this._pageLoader = defaultPageLoader;
 
     contentReady(this, () => {
       const page = this._getPageTarget();
@@ -168,7 +168,7 @@ class SplitterContentElement extends BaseElement {
     const callback = options.callback || function() {};
 
     return new Promise(resolve => {
-      this._pageLoader.load({page, parent: this}, ({element, unload}) => {
+      this._pageLoader.load({page, parent: this, replace: true}, ({element, unload}) => {
         rewritables.link(this, element, options, fragment => {
           setImmediate(() => this._show());
           callback();

--- a/core/src/elements/ons-splitter-content.js
+++ b/core/src/elements/ons-splitter-content.js
@@ -19,7 +19,7 @@ import util from 'ons/util';
 import internal from 'ons/internal';
 import ModifierUtil from 'ons/internal/modifier-util';
 import BaseElement from 'ons/base-element';
-import {PageLoader, defaultPageLoader} from 'ons/page-loader';
+import {PageLoader, replaceContentPageLoader} from 'ons/page-loader';
 import contentReady from 'ons/content-ready';
 
 const rewritables = {
@@ -86,7 +86,7 @@ class SplitterContentElement extends BaseElement {
    */
   createdCallback() {
     this._page = null;
-    this._pageLoader = defaultPageLoader;
+    this._pageLoader = replaceContentPageLoader;
 
     contentReady(this, () => {
       const page = this._getPageTarget();
@@ -170,13 +170,7 @@ class SplitterContentElement extends BaseElement {
     return new Promise(resolve => {
       this._pageLoader.load({page, parent: this}, ({element, unload}) => {
         rewritables.link(this, element, options, fragment => {
-          this._hide();
-          while (this.firstChild) {
-            this.firstChild.remove();
-          }
-
-          this.appendChild(fragment);
-          this._show();
+          setImmediate(() => this._show());
           callback();
 
           resolve(this.firstChild);

--- a/core/src/elements/ons-splitter-side.js
+++ b/core/src/elements/ons-splitter-side.js
@@ -25,7 +25,7 @@ import SplitterAnimator from './ons-splitter/animator';
 import GestureDetector from 'ons/gesture-detector';
 import DoorLock from 'ons/doorlock';
 import contentReady from 'ons/content-ready';
-import {defaultPageLoader, PageLoader} from 'ons/page-loader';
+import { PageLoader, replaceContentPageLoader} from 'ons/page-loader';
 import OnsSplitterElement from './ons-splitter';
 
 const SPLIT_MODE = 'split';
@@ -443,7 +443,7 @@ class SplitterSideElement extends BaseElement {
 
   createdCallback() {
     this._page = null;
-    this._pageLoader = defaultPageLoader;
+    this._pageLoader = replaceContentPageLoader;
     this._collapseMode = new CollapseMode(this);
     this._collapseDetection = new CollapseDetection(this);
 
@@ -720,13 +720,7 @@ class SplitterSideElement extends BaseElement {
     return new Promise(resolve => {
       this._pageLoader.load({page, parent: this}, ({element, unload}) => {
         rewritables.link(this, element, options, fragment => {
-          this._hide();
-          while (this.firstChild) {
-            this.firstChild.remove();
-          }
-
-          this.appendChild(fragment);
-          this._show();
+          setImmediate(() => this._show());
           callback();
 
           resolve(this.firstChild);

--- a/core/src/elements/ons-splitter-side.js
+++ b/core/src/elements/ons-splitter-side.js
@@ -25,7 +25,7 @@ import SplitterAnimator from './ons-splitter/animator';
 import GestureDetector from 'ons/gesture-detector';
 import DoorLock from 'ons/doorlock';
 import contentReady from 'ons/content-ready';
-import { PageLoader, replaceContentPageLoader} from 'ons/page-loader';
+import { PageLoader, defaultPageLoader} from 'ons/page-loader';
 import OnsSplitterElement from './ons-splitter';
 
 const SPLIT_MODE = 'split';
@@ -443,7 +443,7 @@ class SplitterSideElement extends BaseElement {
 
   createdCallback() {
     this._page = null;
-    this._pageLoader = replaceContentPageLoader;
+    this._pageLoader = defaultPageLoader;
     this._collapseMode = new CollapseMode(this);
     this._collapseDetection = new CollapseDetection(this);
 
@@ -718,7 +718,7 @@ class SplitterSideElement extends BaseElement {
     const callback = options.callback || (() => {});
 
     return new Promise(resolve => {
-      this._pageLoader.load({page, parent: this}, ({element, unload}) => {
+      this._pageLoader.load({page, parent: this, replace: true}, ({element, unload}) => {
         rewritables.link(this, element, options, fragment => {
           setImmediate(() => this._show());
           callback();

--- a/core/src/ons/page-loader.js
+++ b/core/src/ons/page-loader.js
@@ -84,3 +84,17 @@ export const instantPageLoader = new PageLoader(function({page, parent, params =
     unload: () => element.remove()
   });
 });
+
+export const replaceContentPageLoader = new PageLoader(function({page, parent, params = {}}, done) {
+  internal.getPageHTMLAsync(page).then(html => {
+    const element = util.createElement(html.trim());
+    util.propagateAction(parent, '_destroy');
+    parent.innerHTML = '';
+    parent.appendChild(element);
+
+    done({
+      element: element,
+      unload: () => element.remove()
+    });
+  });
+});

--- a/core/src/ons/page-loader.js
+++ b/core/src/ons/page-loader.js
@@ -18,8 +18,13 @@ import util from 'ons/util';
 import internal from 'ons/internal';
 
 // Default implementation for global PageLoader.
-function loadPage({page, parent, params = {}}, done) {
+function loadPage({page, parent, params = {}, replace}, done) {
   internal.getPageHTMLAsync(page).then(html => {
+    if (replace) {
+      util.propagateAction(parent, '_destroy');
+      parent.innerHTML = '';
+    }
+
     const element = util.createElement(html.trim());
     parent.appendChild(element);
 
@@ -56,10 +61,11 @@ export class PageLoader {
    * @param {any} options.page
    * @param {Element} options.parent A location to load page.
    * @param {Object} [options.params] Extra parameters for ons-page.
+   * @param {Boolean} [options.replace] Remove the previous content.
    * @param {Function} done Take an object that has "element" property and "unload" function.
    */
-  load({page, parent, params = {}}, done) {
-    this._loader({page, parent, params}, result => {
+  load({page, parent, params = {}, replace}, done) {
+    this._loader({page, parent, params, replace}, result => {
       if (!(result.element instanceof Element)) {
         throw Error('target.element must be an instance of Element.');
       }
@@ -75,26 +81,17 @@ export class PageLoader {
 
 export const defaultPageLoader = new PageLoader();
 
-export const instantPageLoader = new PageLoader(function({page, parent, params = {}}, done) {
+export const instantPageLoader = new PageLoader(function({page, parent, params = {}, replace}, done) {
+  if (replace) {
+    util.propagateAction(parent, '_destroy');
+    parent.innerHTML = '';
+  }
+
   const element = util.createElement(page.trim());
   parent.appendChild(element);
 
   done({
     element: element,
     unload: () => element.remove()
-  });
-});
-
-export const replaceContentPageLoader = new PageLoader(function({page, parent, params = {}}, done) {
-  internal.getPageHTMLAsync(page).then(html => {
-    const element = util.createElement(html.trim());
-    util.propagateAction(parent, '_destroy');
-    parent.innerHTML = '';
-    parent.appendChild(element);
-
-    done({
-      element: element,
-      unload: () => element.remove()
-    });
   });
 });


### PR DESCRIPTION
@anatoo @argelius Possible fix for #1537 . This fires the 4 lifecycle events in the right order and doesn't repeat anything. Do you think adding `replaceContentPageLoader` is fine?