### PR TITLE
refactor(ons-navigator): remove arguments from `update` function.

### DIFF
--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -395,7 +395,7 @@ class NavigatorElement extends BaseElement {
     }).then(() => this._popPage(options, popUpdate));
   }
 
-  _popPage(options, update = () => Promise.resolve(), pages = []) {
+  _popPage(options, update = () => Promise.resolve()) {
     if (this._isRunning) {
       return Promise.reject('popPage is already running.');
     }
@@ -432,7 +432,7 @@ class NavigatorElement extends BaseElement {
 
       const callback = () => {
         pages.pop();
-        update(pages, this).then(() => {
+        update().then(() => {
           this._isRunning = false;
 
           enterPage._show();
@@ -521,7 +521,7 @@ class NavigatorElement extends BaseElement {
     }));
   }
 
-  _pushPage(options = {}, update = () => Promise.resolve(), pages = [], page = {}) {
+  _pushPage(options = {}, update = () => Promise.resolve()) {
     if (this._isRunning) {
       return Promise.reject('pushPage is already running.');
     }
@@ -537,9 +537,7 @@ class NavigatorElement extends BaseElement {
 
     const animator = this._animatorFactory.newAnimator(options);
 
-    pages.push(page);
-
-    return update(pages, this).then(() => {
+    return update().then(() => {
       const pageLength = this.pages.length;
 
       var enterPage  = this.pages[pageLength - 1];

--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -431,7 +431,6 @@ class NavigatorElement extends BaseElement {
       }
 
       const callback = () => {
-        pages.pop();
         update().then(() => {
           this._isRunning = false;
 


### PR DESCRIPTION
@frankdiox This removes the arguments to the `update` function that is passed to `_pushPage` and `_popPage` so the logic should be implemented in the bindings instead.