### PR TITLE
Fixed dependency problem between ons-page and ons-toolbar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ v2.0.0-rc.20
 ----
  * ons-splitter-side: Fix attribute watchers.
  * ons-range: Fix [#1554](https://github.com/OnsenUI/OnsenUI/issues/1554).
+ * ons-page: Fixed dependency problem between ons-page and ons-toolbar.
 
 v2.0.0-rc.19
 ----

--- a/core/src/elements/ons-page.js
+++ b/core/src/elements/ons-page.js
@@ -23,13 +23,15 @@ import BaseElement from 'ons/base-element';
 import deviceBackButtonDispatcher from 'ons/device-back-button-dispatcher';
 import contentReady from 'ons/content-ready';
 
+import 'elements/ons-toolbar'; // ensures that 'ons-toolbar' element is registered
+
 const scheme = {
   '': 'page--*',
   '.page__content': 'page--*__content',
   '.page__background': 'page--*__background'
 };
 
-const nullToolbarElement = document.createElement('ons-toolbar');
+const nullToolbarElement = document.createElement('ons-toolbar'); // requires that 'ons-toolbar' element is registered
 
 /**
  * @element ons-page


### PR DESCRIPTION
@argelius @frankdiox @anatoo

This patch fixes at least #1580.
`ons-page.js` calls `document.createElement('ons-toolbar')` ahead of `customElements.define('ons-toolbar', ToolbarElement)` (in `ons-toolbar.js`), so I added the following statement:

```
import 'elements/ons-toolbar';
```

If there is no problem, could you merge this patch?