### PR TITLE
fix(css-components): Toolbar modifiers.

### DIFF
--- a/core/src/elements/ons-toolbar.js
+++ b/core/src/elements/ons-toolbar.js
@@ -38,6 +38,9 @@ const scheme = {
  * @modifier transparent
  *   [en]Transparent toolbar[/en]
  *   [ja]透明な背景を持つツールバーを表示します。[/ja]
+ * @modifier noshadow
+ *   [en]Toolbar without shadow[/en]
+ *   [ja]どうしよう[/ja]
  * @description
  *   [en]
  *     Toolbar component that can be used with navigation.

--- a/css-components/components-src/stylus/components/navigation-bar.styl
+++ b/css-components/components-src/stylus/components/navigation-bar.styl
@@ -218,32 +218,6 @@ navigation-bar__item()
 */
 
 /*! topdoc
-  name: Transparent Navigation Bar
-  class: navigation-bar--transparent
-  use: Toolbar Button, Navigation Bar
-  markup:
-    <!-- Prerequisite=This example use ionicons(http://ionicons.com) to display icons. -->
-    <div class="navigation-bar navigation-bar--transparent">
-      <div class="navigation-bar__left">
-        <span class="toolbar-button--quiet">
-          <i class="ion-navicon" style="font-size:32px; vertical-align:-6px;"></i>
-        </span>
-      </div>
-      <div class="navigation-bar__center">
-        Navigation Bar
-      </div>
-      <div class="navigation-bar__right">
-        <span class="toolbar-button--quiet">Label</span>
-      </div>
-    </div>
-*/
-
-.navigation-bar--transparent
-  background-color transparent
-  background-image none
-  border none
-
-/*! topdoc
   name: Bottom Bar
   class: bottom-bar
   use: Navigation Bar
@@ -325,6 +299,26 @@ navigation-bar__item()
   padding 0
   background-color var-material-navigation-bar-background-color
   background-size 0
+
+/*! topdoc
+  name: No Shadow Navigation Bar
+  class: navigation-bar--noshadow
+  use: Toolbar Button, Navigation Bar
+  markup:
+    <div class="navigation-bar navigation-bar--noshadow">
+      <div class="navigation-bar__left">
+        <span class="toolbar-button--quiet">
+          <i class="ion-navicon" style="font-size:32px; vertical-align:-6px;"></i>
+        </span>
+      </div>
+      <div class="navigation-bar__center">
+        Navigation Bar
+      </div>
+      <div class="navigation-bar__right">
+        <span class="toolbar-button--quiet">Label</span>
+      </div>
+    </div>
+*/
 
 .navigation-bar--noshadow
   box-shadow none


### PR DESCRIPTION
@argelius toolbar's transparent modifier was duplicated and `noshadow` is not in the docs. I think this would fix it.