### PR TITLE
fix(ons.notification): Wait for compilation. Closes #1595

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 v2.0.1
 ----
  * angular1: Fix [#1588](https://github.com/OnsenUI/OnsenUI/issues/1588).
+ * ons.notification: Fix [#1595](https://github.com/OnsenUI/OnsenUI/issues/1595).
 
 v2.0.0
 ----

--- a/core/src/ons/content-ready.js
+++ b/core/src/ons/content-ready.js
@@ -41,7 +41,7 @@ function consumeQueue(element) {
   callbacks.forEach(callback => callback());
 }
 
-export default function contentReady(element, fn) {
+export default function contentReady(element, fn = () => {}) {
   addCallback(element, fn);
 
   if (isContentReady(element)) {

--- a/core/src/ons/notification.js
+++ b/core/src/ons/notification.js
@@ -16,6 +16,7 @@ limitations under the License.
 */
 
 import util from './util';
+import contentReady from 'ons/content-ready';
 
 /**
  * @object ons.notification
@@ -70,6 +71,8 @@ notification._createAlertDialog = function(title, message,
     <div class="alert-dialog-content"></div>
     <div class="alert-dialog-footer"></div>
   `);
+
+  contentReady(dialogElement);
 
   if (id) {
     dialogElement.setAttribute('id', id);


### PR DESCRIPTION
@argelius @anatoo Commit 75f187ebcf972893364927087e6e5a58ea602b56 broke `ons.notification` styles (see #1595 ). The reason is that after this change onsAlertDialog's `contentReady` will postpone the element compilation until the next cycle, thus making `modifier = modifier || dialogElement.getAttribute('modifier');` to be `null`.

This also means that the rest of the function modifies the element content before it is compiled. Or that is what I thought until I noticed something peculiar. The element is compiled after it is attached to the DOM because in onsAlertDialog's `connectedCallback` we casually use `contentReady` for something different, and at this point it runs the callback queue synchronously (thus compiling the element). This feels like an unknown feature for me 😅 

I think maybe we could use `contentReady` for waiting until the element is compiled. I just modified it slightly to make it more elegant. There are other easy fixes (a bit uglier) but I thought this could be nicer. What do you think?

As a side idea, perhaps we can create `ons.createElement('<ons-element attributes>content</ons-element>')` that internally calls: 

```javascript
let el = document.createElement('ons-element')
el.setAttribute( -attributes- );
innerHTML(el, content)
contentReady(el);
```