### PR TITLE
Fix device back button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v2.0.2
  * ons-toolbar-button: Style refactor.
  * ons-navigator: Fix show-init event order.
  * ons-tab: Add `badge` attribute to display notification on tab.
+ * ons.notification: Fix [#1638](https://github.com/OnsenUI/OnsenUI/issues/1638).
 
 v2.0.1
 ----

--- a/core/css/common.css
+++ b/core/css/common.css
@@ -27,7 +27,9 @@ ons-gesture-detector {
 }
 
 ons-navigator,
-ons-tabbar {
+ons-tabbar,
+ons-dialog,
+ons-alert-dialog {
   position: absolute;
   top: 0;
   left: 0;
@@ -40,7 +42,7 @@ ons-tab {
   transform: translate3d(0, 0, 0);
 }
 
-ons-page, ons-navigator, ons-tabbar, ons-sliding-menu, ons-split-view {
+ons-page, ons-navigator, ons-tabbar, ons-sliding-menu, ons-split-view, ons-dialog, ons-alert-dialog {
   z-index: 2;
 }
 


### PR DESCRIPTION
@anatoo @frankdiox 

This fixes an issue with the device back button and dialogs. The function that finds which element to run the back button handler relies on the z-index if there are more than two components on the same level.

This changes the CSS of `ons-dialog` and `ons-alert-dialog` so they have the same z-index as other components.

Fixes this issue: https://github.com/OnsenUI/OnsenUI/issues/1638