### PR TITLE
Fix 1636

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v2.0.2
  * ons-toolbar-button: Style refactor.
  * ons-navigator: Fix show-init event order.
  * ons-tab: Add `badge` attribute to display notification on tab.
+ * ons-icon: Fix [#1636](https://github.com/OnsenUI/OnsenUI/issues/1636).
 
 v2.0.1
 ----

--- a/core/css/icon.css
+++ b/core/css/icon.css
@@ -23,7 +23,7 @@ limitations under the License.
   -moz-osx-font-smoothing: grayscale;
 }
 
-.ons-icon--ion {
+:not(ons-toolbar-button) > .ons-icon--ion {
   line-height: 0.75em;
   vertical-align: -25%;
 }


### PR DESCRIPTION
@anatoo @frankdiox 

Fixes this issue:
https://github.com/OnsenUI/OnsenUI/issues/1636

There was some CSS that fixed the alignment only for Ionicons, however in the case where they are used in the toolbar buttons it is not necessary since they are displayed vertically aligned anyway.