### PR TITLE
Fix FastClick to support `contenteditable` attributes.

### DIFF
--- a/core/vendor/fastclick-patched.js
+++ b/core/vendor/fastclick-patched.js
@@ -399,6 +399,12 @@
 		targetElement = this.getTargetElementFromEventTarget(event.target);
 		touch = event.targetTouches[0];
 
+		// Ignore touches on contenteditable elements to prevent conflict with text selection.
+		// (For details: https://github.com/ftlabs/fastclick/pull/211 )
+		if (targetElement.isContentEditable) {
+			return true;
+		}
+
 		if (deviceIsIOS) {
 
 			// Only trusted events will deselect text on iOS (issue #49)


### PR DESCRIPTION
@argelius @fran @anatoo 
This PR fixes #1627.

Elements which have a `contenteditable` attribute need to be clicked through trusted `click` event, but FastClick eliminates trusted `click` events and creates non-trusted `click` events.
This issue has already been reported in [ftlabs/fastclick #211](https://github.com/ftlabs/fastclick/pull/211), but the official repo is no longer maintained, so I merged [ftlabs/fastclick #211](https://github.com/ftlabs/fastclick/pull/211) into `core/vendor/fastclick-patched.js` on behalf of the official repo.

If there is no problem, could you merge this PR?