### PR TITLE
Support ChromeDriver 2.23 and later for e2e testing on macOS.

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -468,9 +468,9 @@ gulp.task('webdriver-download', () => {
   const platform = os.platform();
   const destDir = path.join(__dirname, '.selenium');
   const chromeDriverUrl = (() => {
-    const filePath = platform === 'linux' ?
-      '/2.24/chromedriver_linux64.zip' :
-      `/2.24/chromedriver_${platform === 'darwin' ? 'mac' : 'win'}32.zip`;
+    const filePath = platform === 'win32' ?
+      '/2.25/chromedriver_win32.zip' :
+      `/2.25/chromedriver_${platform === 'darwin' ? 'mac' : 'linux'}64.zip`;
     return `http://chromedriver.storage.googleapis.com${filePath}`;
   })();
 


### PR DESCRIPTION
ChromeDriver seems to have renamed `chromedriver_mac32.zip` to `chromedriver_mac64.zip` since 2.23.
http://chromedriver.storage.googleapis.com/index.html?path=2.22/
http://chromedriver.storage.googleapis.com/index.html?path=2.23/

Then I fixed `gulpfile.babel.js` to support it.
If CircleCI reported no errors I will merge this PR.