### PR TITLE
Update selenium-server-standalone from 2.51.0 to 3.0.1.

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -479,7 +479,7 @@ gulp.task('webdriver-download', () => {
     return gulp.src('');
   }
 
-  const selenium = $.download('https://selenium-release.storage.googleapis.com/2.51/selenium-server-standalone-2.51.0.jar')
+  const selenium = $.download('https://selenium-release.storage.googleapis.com/3.0/selenium-server-standalone-3.0.1.jar')
     .pipe(gulp.dest(destDir));
 
   const chromedriver = $.download(chromeDriverUrl)
@@ -513,7 +513,7 @@ gulp.task('e2e-test', ['webdriver-download', 'prepare'], function() {
     configFile: './test/e2e/protractor.conf.js',
     args: [
       '--baseUrl', 'http://127.0.0.1:' + port,
-      '--seleniumServerJar', path.join(__dirname, '.selenium/selenium-server-standalone-2.51.0.jar'),
+      '--seleniumServerJar', path.join(__dirname, '.selenium/selenium-server-standalone-3.0.1.jar'),
       '--chromeDriver', path.join(__dirname, '.selenium/chromedriver')
     ]
   };


### PR DESCRIPTION
@anatoo @argelius @frankdiox @masahirotanaka 

This PR is needed for enabling Onsen UI to support [the official SafariDriver](https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_10_0.html#//apple_ref/doc/uid/TP40014305-CH11-DontLinkElementID_30) included in Safari 10.

SafariDriver needs `selenium-server-standalone` 3.0.0 or higher, but the current `gulpfile.babel.js` depends on `selenium-server-standalone` 2.51.0, so I have updated it.

After this PR, E2E testing environment for Chrome/Safari will result in the following structure.
---

**E2E testing environment for Chrome after this PR:**

```
gulp-protractor@2.4.0
 [↓ uses]
protractor@3.3.0
 [↓ uses]
selenium-webdriver@2.52.0
 [↓ uses]
selenium-server-standalone-3.0.1.jar [<- updated by this PR]
 [↓ uses]
ChromeDriver 2.25 (for win32/linux64/mac64)
 [↓ uses]
Google Chrome (which version can be specified by user)
 [↓ accesses]
http://localhost:8081
```
---

**E2E testing environment for Safari (<- not existing now) after this PR:**

```
gulp-protractor@2.4.0
 [↓ uses]
protractor@3.3.0
 [↓ uses]
selenium-webdriver@2.52.0
 [↓ uses]
selenium-server-standalone-3.0.1.jar [<- updated by this PR]
 [↓ uses]
SafariDriver (included in Safari 10 for macOS El Capitan / Sierra) [<- not depended by this repo now]
 [↓ uses]
Safari (which version can be specified by user)
 [↓ accesses]
http://localhost:8081
```
---

Note:
We have to update also `gulp-protractor`, `protractor`, and `selenium-webdriver` (WebDriverJS), but `protractor` [is yet to support `selenium-webdriver` 3.x](https://github.com/angular/protractor/blob/99518ce3fe499e88a9ed5d2a07898aa493f92af8/package.json#L27) and `selenium-webdriver` [is in beta (`3.0.0-beta-3`)](https://github.com/SeleniumHQ/selenium/blob/aabb225fda151bd2d4095fe8e94d57d23fb8ac6b/javascript/node/selenium-webdriver/CHANGES.md) at this moment.
So it might be impossible to completely support SafariDriver at this moment.
---

There is a version mismatch between `selenium-webdriver` ([WebDriverJS](https://github.com/SeleniumHQ/selenium/wiki/WebDriverJs)) (2.52.0) and `selenium-server-standalone` (3.0.1), but it worked fine on my environment (macOS El Capitan + Chrome 54) because Protractor might be not using `selenium-webdriver` to run ChromeDriver since the Protractor says `I/direct - Using ChromeDriver directly...`.

If there is no problem, could anyone merge this PR?
