### PR TITLE
refactor(*): change from absolute to relative imports

### DIFF
--- a/core/src/elements/ons-alert-dialog/index.js
+++ b/core/src/elements/ons-alert-dialog/index.js
@@ -15,16 +15,16 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import AnimatorFactory from 'ons/internal/animator-factory';
+import util from '../../ons/util';
+import autoStyle from '../../ons/autostyle';
+import ModifierUtil from '../../ons/internal/modifier-util';
+import AnimatorFactory from '../../ons/internal/animator-factory';
 import {AlertDialogAnimator, IOSAlertDialogAnimator, AndroidAlertDialogAnimator} from './animator';
-import platform from 'ons/platform';
-import BaseElement from 'ons/base-element';
-import deviceBackButtonDispatcher from 'ons/device-back-button-dispatcher';
-import DoorLock from 'ons/doorlock';
-import contentReady from 'ons/content-ready';
+import platform from '../../ons/platform';
+import BaseElement from '../../ons/base-element';
+import deviceBackButtonDispatcher from '../../ons/device-back-button-dispatcher';
+import DoorLock from '../../ons/doorlock';
+import contentReady from '../../ons/content-ready';
 
 const scheme = {
   '.alert-dialog': 'alert-dialog--*',

--- a/core/src/elements/ons-back-button.js
+++ b/core/src/elements/ons-back-button.js
@@ -15,11 +15,11 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
-import contentReady from 'ons/content-ready';
+import util from '../ons/util';
+import autoStyle from '../ons/autostyle';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
+import contentReady from '../ons/content-ready';
 
 var scheme = {
   '': 'back-button--*',

--- a/core/src/elements/ons-bottom-toolbar.js
+++ b/core/src/elements/ons-bottom-toolbar.js
@@ -15,10 +15,10 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
+import util from '../ons/util';
+import autoStyle from '../ons/autostyle';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
 
 const scheme = {'': 'bottom-bar--*'};
 

--- a/core/src/elements/ons-button.js
+++ b/core/src/elements/ons-button.js
@@ -15,10 +15,10 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
+import util from '../ons/util';
+import autoStyle from '../ons/autostyle';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
 
 const scheme = {'': 'button--*'};
 

--- a/core/src/elements/ons-carousel-item.js
+++ b/core/src/elements/ons-carousel-item.js
@@ -15,9 +15,9 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import BaseElement from 'ons/base-element';
-import ModifierUtil from 'ons/internal/modifier-util';
+import util from '../ons/util';
+import BaseElement from '../ons/base-element';
+import ModifierUtil from '../ons/internal/modifier-util';
 const scheme = {'': 'carousel-item--*'};
 
 /**

--- a/core/src/elements/ons-carousel.js
+++ b/core/src/elements/ons-carousel.js
@@ -15,10 +15,10 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import BaseElement from 'ons/base-element';
-import GestureDetector from 'ons/gesture-detector';
-import DoorLock from 'ons/doorlock';
+import util from '../ons/util';
+import BaseElement from '../ons/base-element';
+import GestureDetector from '../ons/gesture-detector';
+import DoorLock from '../ons/doorlock';
 
 const VerticalModeTrait = {
 

--- a/core/src/elements/ons-col.js
+++ b/core/src/elements/ons-col.js
@@ -15,7 +15,7 @@ limitations under the License.
 
 */
 
-import BaseElement from 'ons/base-element';
+import BaseElement from '../ons/base-element';
 
 /**
  * @element ons-col

--- a/core/src/elements/ons-dialog/index.js
+++ b/core/src/elements/ons-dialog/index.js
@@ -15,16 +15,16 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import AnimatorFactory from 'ons/internal/animator-factory';
+import util from '../../ons/util';
+import autoStyle from '../../ons/autostyle';
+import ModifierUtil from '../../ons/internal/modifier-util';
+import AnimatorFactory from '../../ons/internal/animator-factory';
 import {DialogAnimator, IOSDialogAnimator, AndroidDialogAnimator, SlideDialogAnimator} from './animator';
-import platform from 'ons/platform';
-import BaseElement from 'ons/base-element';
-import DoorLock from 'ons/doorlock';
-import deviceBackButtonDispatcher from 'ons/device-back-button-dispatcher';
-import contentReady from 'ons/content-ready';
+import platform from '../../ons/platform';
+import BaseElement from '../../ons/base-element';
+import DoorLock from '../../ons/doorlock';
+import deviceBackButtonDispatcher from '../../ons/device-back-button-dispatcher';
+import contentReady from '../../ons/content-ready';
 
 const scheme = {
   '.dialog': 'dialog--*',

--- a/core/src/elements/ons-fab.js
+++ b/core/src/elements/ons-fab.js
@@ -11,11 +11,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
-import util from 'ons/util';
-import contentReady from 'ons/content-ready';
+import autoStyle from '../ons/autostyle';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
+import util from '../ons/util';
+import contentReady from '../ons/content-ready';
 
 const scheme = {
   '': 'fab--*'

--- a/core/src/elements/ons-gesture-detector.js
+++ b/core/src/elements/ons-gesture-detector.js
@@ -15,8 +15,8 @@ limitations under the License.
 
 */
 
-import BaseElement from 'ons/base-element';
-import GestureDetector from 'ons/gesture-detector';
+import BaseElement from '../ons/base-element';
+import GestureDetector from '../ons/gesture-detector';
 
 /**
  * @element ons-gesture-detector

--- a/core/src/elements/ons-icon.js
+++ b/core/src/elements/ons-icon.js
@@ -15,9 +15,9 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import autoStyle from 'ons/autostyle';
-import BaseElement from 'ons/base-element';
+import util from '../ons/util';
+import autoStyle from '../ons/autostyle';
+import BaseElement from '../ons/base-element';
 
 /**
  * @element ons-icon

--- a/core/src/elements/ons-if.js
+++ b/core/src/elements/ons-if.js
@@ -15,10 +15,10 @@ limitations under the License.
 
 */
 
-import orientation from 'ons/orientation';
-import platform from 'ons/platform';
-import BaseElement from 'ons/base-element';
-import contentReady from 'ons/content-ready';
+import orientation from '../ons/orientation';
+import platform from '../ons/platform';
+import BaseElement from '../ons/base-element';
+import contentReady from '../ons/content-ready';
 
 /**
  * @element ons-if

--- a/core/src/elements/ons-input.js
+++ b/core/src/elements/ons-input.js
@@ -11,11 +11,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import util from 'ons/util';
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
-import contentReady from 'ons/content-ready';
+import util from '../ons/util';
+import autoStyle from '../ons/autostyle';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
+import contentReady from '../ons/content-ready';
 
 const scheme = {
   '.text-input': 'text-input--*',

--- a/core/src/elements/ons-lazy-repeat.js
+++ b/core/src/elements/ons-lazy-repeat.js
@@ -11,9 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import BaseElement from 'ons/base-element';
-import util from 'ons/util';
-import {LazyRepeatDelegate, LazyRepeatProvider} from 'ons/internal/lazy-repeat';
+import BaseElement from '../ons/base-element';
+import util from '../ons/util';
+import {LazyRepeatDelegate, LazyRepeatProvider} from '../ons/internal/lazy-repeat';
 
 /**
  * @element ons-lazy-repeat

--- a/core/src/elements/ons-list-header.js
+++ b/core/src/elements/ons-list-header.js
@@ -15,10 +15,10 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
+import util from '../ons/util';
+import autoStyle from '../ons/autostyle';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
 
 const scheme = {'': 'list__header--*'};
 

--- a/core/src/elements/ons-list-item.js
+++ b/core/src/elements/ons-list-item.js
@@ -15,11 +15,11 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
-import contentReady from 'ons/content-ready';
+import util from '../ons/util';
+import autoStyle from '../ons/autostyle';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
+import contentReady from '../ons/content-ready';
 
 const scheme = {
   '.list__item': 'list__item--*',

--- a/core/src/elements/ons-list.js
+++ b/core/src/elements/ons-list.js
@@ -15,10 +15,10 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
+import util from '../ons/util';
+import autoStyle from '../ons/autostyle';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
 
 const scheme = {'': 'list--*'};
 

--- a/core/src/elements/ons-modal/index.js
+++ b/core/src/elements/ons-modal/index.js
@@ -15,16 +15,16 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import ModifierUtil from 'ons/internal/modifier-util';
-import AnimatorFactory from 'ons/internal/animator-factory';
+import util from '../../ons/util';
+import ModifierUtil from '../../ons/internal/modifier-util';
+import AnimatorFactory from '../../ons/internal/animator-factory';
 import ModalAnimator from './animator';
 import FadeModalAnimator from './fade-animator';
-import platform from 'ons/platform';
-import BaseElement from 'ons/base-element';
-import deviceBackButtonDispatcher from 'ons/device-back-button-dispatcher';
-import DoorLock from 'ons/doorlock';
-import contentReady from 'ons/content-ready';
+import platform from '../../ons/platform';
+import BaseElement from '../../ons/base-element';
+import deviceBackButtonDispatcher from '../../ons/device-back-button-dispatcher';
+import DoorLock from '../../ons/doorlock';
+import contentReady from '../../ons/content-ready';
 
 const scheme = {
   '': 'modal--*',

--- a/core/src/elements/ons-navigator/animator.js
+++ b/core/src/elements/ons-navigator/animator.js
@@ -15,7 +15,7 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
+import util from '../../ons/util';
 
 export default class NavigatorTransitionAnimator {
 

--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -15,9 +15,9 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import internal from 'ons/internal';
-import AnimatorFactory from 'ons/internal/animator-factory';
+import util from '../../ons/util';
+import internal from '../../ons/internal';
+import AnimatorFactory from '../../ons/internal/animator-factory';
 import NavigatorTransitionAnimator from './animator';
 import IOSSlideNavigatorTransitionAnimator from './ios-slide-animator';
 import IOSLiftNavigatorTransitionAnimator from './ios-lift-animator';
@@ -26,11 +26,11 @@ import MDSlideNavigatorTransitionAnimator from './md-slide-animator';
 import MDLiftNavigatorTransitionAnimator from './md-lift-animator';
 import MDFadeNavigatorTransitionAnimator from './md-fade-animator';
 import NoneNavigatorTransitionAnimator from './none-animator';
-import platform from 'ons/platform';
-import contentReady from 'ons/content-ready';
-import BaseElement from 'ons/base-element';
-import deviceBackButtonDispatcher from 'ons/device-back-button-dispatcher';
-import {PageLoader, defaultPageLoader, instantPageLoader} from 'ons/page-loader';
+import platform from '../../ons/platform';
+import contentReady from '../../ons/content-ready';
+import BaseElement from '../../ons/base-element';
+import deviceBackButtonDispatcher from '../../ons/device-back-button-dispatcher';
+import {PageLoader, defaultPageLoader, instantPageLoader} from '../../ons/page-loader';
 
 const _animatorDict = {
   'default': () => platform.isAndroid() ? MDFadeNavigatorTransitionAnimator : IOSSlideNavigatorTransitionAnimator,

--- a/core/src/elements/ons-navigator/ios-fade-animator.js
+++ b/core/src/elements/ons-navigator/ios-fade-animator.js
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 import NavigatorTransitionAnimator from './animator';
-import util from 'ons/util';
+import util from '../../ons/util';
 
 /**
  * Fade-in screen transition.

--- a/core/src/elements/ons-navigator/ios-lift-animator.js
+++ b/core/src/elements/ons-navigator/ios-lift-animator.js
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 import NavigatorTransitionAnimator from './animator';
-import util from 'ons/util';
+import util from '../../ons/util';
 
 /**
  * Lift screen transition.

--- a/core/src/elements/ons-navigator/ios-slide-animator.js
+++ b/core/src/elements/ons-navigator/ios-slide-animator.js
@@ -16,8 +16,8 @@ limitations under the License.
 */
 
 import NavigatorTransitionAnimator from './animator';
-import util from 'ons/util';
-import contentReady from 'ons/content-ready';
+import util from '../../ons/util';
+import contentReady from '../../ons/content-ready';
 
 /**
  * Slide animator for navigator transition like iOS's screen slide transition.

--- a/core/src/elements/ons-navigator/md-fade-animator.js
+++ b/core/src/elements/ons-navigator/md-fade-animator.js
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 import NavigatorTransitionAnimator from './animator';
-import util from 'ons/util';
+import util from '../../ons/util';
 
 /**
  * Fade-in + Lift screen transition.

--- a/core/src/elements/ons-navigator/md-lift-animator.js
+++ b/core/src/elements/ons-navigator/md-lift-animator.js
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 import NavigatorTransitionAnimator from './animator';
-import util from 'ons/util';
+import util from '../../ons/util';
 
 /**
  * Lift screen transition.

--- a/core/src/elements/ons-navigator/md-slide-animator.js
+++ b/core/src/elements/ons-navigator/md-slide-animator.js
@@ -15,7 +15,7 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
+import util from '../../ons/util';
 import NavigatorTransitionAnimator from './animator';
 
 /**

--- a/core/src/elements/ons-page.js
+++ b/core/src/elements/ons-page.js
@@ -15,15 +15,15 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import internal from 'ons/internal';
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
-import deviceBackButtonDispatcher from 'ons/device-back-button-dispatcher';
-import contentReady from 'ons/content-ready';
+import util from '../ons/util';
+import internal from '../ons/internal';
+import autoStyle from '../ons/autostyle';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
+import deviceBackButtonDispatcher from '../ons/device-back-button-dispatcher';
+import contentReady from '../ons/content-ready';
 
-import 'elements/ons-toolbar'; // ensures that 'ons-toolbar' element is registered
+import './ons-toolbar'; // ensures that 'ons-toolbar' element is registered
 
 const scheme = {
   '': 'page--*',

--- a/core/src/elements/ons-popover/animator.js
+++ b/core/src/elements/ons-popover/animator.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
-import util from 'ons/util';
+import util from '../../ons/util';
 
 export class PopoverAnimator {
 

--- a/core/src/elements/ons-popover/index.js
+++ b/core/src/elements/ons-popover/index.js
@@ -15,16 +15,16 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import AnimatorFactory from 'ons/internal/animator-factory';
+import util from '../../ons/util';
+import autoStyle from '../../ons/autostyle';
+import ModifierUtil from '../../ons/internal/modifier-util';
+import AnimatorFactory from '../../ons/internal/animator-factory';
 import {PopoverAnimator, IOSFadePopoverAnimator, MDFadePopoverAnimator} from './animator';
-import platform from 'ons/platform';
-import BaseElement from 'ons/base-element';
-import deviceBackButtonDispatcher from 'ons/device-back-button-dispatcher';
-import DoorLock from 'ons/doorlock';
-import contentReady from 'ons/content-ready';
+import platform from '../../ons/platform';
+import BaseElement from '../../ons/base-element';
+import deviceBackButtonDispatcher from '../../ons/device-back-button-dispatcher';
+import DoorLock from '../../ons/doorlock';
+import contentReady from '../../ons/content-ready';
 
 const scheme = {
   '.popover': 'popover--*',

--- a/core/src/elements/ons-progress-bar.js
+++ b/core/src/elements/ons-progress-bar.js
@@ -15,10 +15,10 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
-import contentReady from 'ons/content-ready';
+import util from '../ons/util';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
+import contentReady from '../ons/content-ready';
 
 const scheme = {
   '.progress-bar': 'progress-bar--*',

--- a/core/src/elements/ons-progress-circular.js
+++ b/core/src/elements/ons-progress-circular.js
@@ -15,10 +15,10 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
-import contentReady from 'ons/content-ready';
+import util from '../ons/util';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
+import contentReady from '../ons/content-ready';
 
 const scheme = {
   '.progress-circular': 'progress-circular--*',

--- a/core/src/elements/ons-pull-hook.js
+++ b/core/src/elements/ons-pull-hook.js
@@ -15,10 +15,10 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import platform from 'ons/platform';
-import BaseElement from 'ons/base-element';
-import GestureDetector from 'ons/gesture-detector';
+import util from '../ons/util';
+import platform from '../ons/platform';
+import BaseElement from '../ons/base-element';
+import GestureDetector from '../ons/gesture-detector';
 
 const STATE_INITIAL = 'initial';
 const STATE_PREACTION = 'preaction';

--- a/core/src/elements/ons-range.js
+++ b/core/src/elements/ons-range.js
@@ -11,11 +11,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
-import util from 'ons/util';
-import contentReady from 'ons/content-ready';
+import autoStyle from '../ons/autostyle';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
+import util from '../ons/util';
+import contentReady from '../ons/content-ready';
 
 const scheme = {
   '.range': 'range--*',

--- a/core/src/elements/ons-ripple/animator-css.js
+++ b/core/src/elements/ons-ripple/animator-css.js
@@ -15,7 +15,7 @@ limitations under the License.
 
 */
 
-import internal from 'ons/internal';
+import internal from '../../ons/internal';
 
 /**
  * @class AnimatorCSS - implementation of Animator class using css transitions

--- a/core/src/elements/ons-ripple/animator-js.js
+++ b/core/src/elements/ons-ripple/animator-js.js
@@ -15,7 +15,7 @@ limitations under the License.
 
 */
 
-import internal from 'ons/internal';
+import internal from '../../ons/internal';
 
 
 var raf = (window.requestAnimationFrame || window.webkitRequestAnimationFrame || window.mozRequestAnimationFrame)

--- a/core/src/elements/ons-ripple/index.js
+++ b/core/src/elements/ons-ripple/index.js
@@ -15,11 +15,11 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import internal from 'ons/internal';
-import BaseElement from 'ons/base-element';
+import util from '../../ons/util';
+import internal from '../../ons/internal';
+import BaseElement from '../../ons/base-element';
 import Animator from './animator-css';
-import contentReady from 'ons/content-ready';
+import contentReady from '../../ons/content-ready';
 
 /**
  * @element ons-ripple

--- a/core/src/elements/ons-row.js
+++ b/core/src/elements/ons-row.js
@@ -15,7 +15,7 @@ limitations under the License.
 
 */
 
-import BaseElement from 'ons/base-element';
+import BaseElement from '../ons/base-element';
 
 /**
  * @element ons-row

--- a/core/src/elements/ons-speed-dial-item.js
+++ b/core/src/elements/ons-speed-dial-item.js
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import util from 'ons/util';
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
+import util from '../ons/util';
+import autoStyle from '../ons/autostyle';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
 
 const scheme = {
   '': 'speed-dial__item--*',

--- a/core/src/elements/ons-speed-dial.js
+++ b/core/src/elements/ons-speed-dial.js
@@ -11,12 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import util from 'ons/util';
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
-import contentReady from 'ons/content-ready';
-import styler from 'lib/styler';
+import util from '../ons/util';
+import autoStyle from '../ons/autostyle';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
+import contentReady from '../ons/content-ready';
+import styler from '../lib/styler';
 
 const scheme = {
   '': 'speed-dial--*',

--- a/core/src/elements/ons-splitter-content.js
+++ b/core/src/elements/ons-splitter-content.js
@@ -15,12 +15,12 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import internal from 'ons/internal';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
-import {PageLoader, defaultPageLoader} from 'ons/page-loader';
-import contentReady from 'ons/content-ready';
+import util from '../ons/util';
+import internal from '../ons/internal';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
+import {PageLoader, defaultPageLoader} from '../ons/page-loader';
+import contentReady from '../ons/content-ready';
 
 const rewritables = {
   /**

--- a/core/src/elements/ons-splitter-mask.js
+++ b/core/src/elements/ons-splitter-mask.js
@@ -15,8 +15,8 @@ limitations under the License.
 
 */
 
-import BaseElement from 'ons/base-element';
-import util from 'ons/util';
+import BaseElement from '../ons/base-element';
+import util from '../ons/util';
 
 export default class SplitterMaskElement extends BaseElement {
 

--- a/core/src/elements/ons-splitter-side.js
+++ b/core/src/elements/ons-splitter-side.js
@@ -15,17 +15,17 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import AnimatorFactory from 'ons/internal/animator-factory';
-import orientation from 'ons/orientation';
-import internal from 'ons/internal';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
+import util from '../ons/util';
+import AnimatorFactory from '../ons/internal/animator-factory';
+import orientation from '../ons/orientation';
+import internal from '../ons/internal';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
 import SplitterAnimator from './ons-splitter/animator';
-import GestureDetector from 'ons/gesture-detector';
-import DoorLock from 'ons/doorlock';
-import contentReady from 'ons/content-ready';
-import { PageLoader, defaultPageLoader} from 'ons/page-loader';
+import GestureDetector from '../ons/gesture-detector';
+import DoorLock from '../ons/doorlock';
+import contentReady from '../ons/content-ready';
+import { PageLoader, defaultPageLoader} from '../ons/page-loader';
 import SplitterElement from './ons-splitter';
 
 const SPLIT_MODE = 'split';

--- a/core/src/elements/ons-splitter/animator.js
+++ b/core/src/elements/ons-splitter/animator.js
@@ -15,8 +15,8 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import contentReady from 'ons/content-ready';
+import util from '../../ons/util';
+import contentReady from '../../ons/content-ready';
 
 export default class SplitterAnimator {
 

--- a/core/src/elements/ons-splitter/index.js
+++ b/core/src/elements/ons-splitter/index.js
@@ -15,13 +15,13 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import ModifierUtil from 'ons/internal/modifier-util';
-import AnimatorFactory from 'ons/internal/animator-factory';
+import util from '../../ons/util';
+import ModifierUtil from '../../ons/internal/modifier-util';
+import AnimatorFactory from '../../ons/internal/animator-factory';
 import SplitterAnimator from './animator';
-import BaseElement from 'ons/base-element';
-import deviceBackButtonDispatcher from 'ons/device-back-button-dispatcher';
-import contentReady from 'ons/content-ready';
+import BaseElement from '../../ons/base-element';
+import deviceBackButtonDispatcher from '../../ons/device-back-button-dispatcher';
+import contentReady from '../../ons/content-ready';
 
 const _animatorDict = {
   default: SplitterAnimator,

--- a/core/src/elements/ons-switch.js
+++ b/core/src/elements/ons-switch.js
@@ -15,12 +15,12 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
-import contentReady from 'ons/content-ready';
-import GestureDetector from 'ons/gesture-detector';
+import util from '../ons/util';
+import autoStyle from '../ons/autostyle';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
+import contentReady from '../ons/content-ready';
+import GestureDetector from '../ons/gesture-detector';
 
 const scheme = {
   '': 'switch--*',

--- a/core/src/elements/ons-tab.js
+++ b/core/src/elements/ons-tab.js
@@ -15,14 +15,14 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
-import internal from 'ons/internal';
+import util from '../ons/util';
+import autoStyle from '../ons/autostyle';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
+import internal from '../ons/internal';
 import TabbarElement from './ons-tabbar';
-import contentReady from 'ons/content-ready';
-import {PageLoader, defaultPageLoader} from 'ons/page-loader';
+import contentReady from '../ons/content-ready';
+import {PageLoader, defaultPageLoader} from '../ons/page-loader';
 
 const scheme = {
   '': 'tab-bar--*__item',

--- a/core/src/elements/ons-tabbar/index.js
+++ b/core/src/elements/ons-tabbar/index.js
@@ -15,16 +15,16 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import platform from 'ons/platform';
-import internal from 'ons/internal';
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import AnimatorFactory from 'ons/internal/animator-factory';
-import BaseElement from 'ons/base-element';
+import util from '../../ons/util';
+import platform from '../../ons/platform';
+import internal from '../../ons/internal';
+import autoStyle from '../../ons/autostyle';
+import ModifierUtil from '../../ons/internal/modifier-util';
+import AnimatorFactory from '../../ons/internal/animator-factory';
+import BaseElement from '../../ons/base-element';
 import {TabbarAnimator, TabbarFadeAnimator, TabbarNoneAnimator, TabbarSlideAnimator} from './animator';
 import TabElement from '../ons-tab';
-import contentReady from 'ons/content-ready';
+import contentReady from '../../ons/content-ready';
 
 const scheme = {
   '.tab-bar__content': 'tab-bar--*__content',

--- a/core/src/elements/ons-template.js
+++ b/core/src/elements/ons-template.js
@@ -15,7 +15,7 @@ limitations under the License.
 
 */
 
-import BaseElement from 'ons/base-element';
+import BaseElement from '../ons/base-element';
 
 /**
  * @element ons-template

--- a/core/src/elements/ons-toolbar-button.js
+++ b/core/src/elements/ons-toolbar-button.js
@@ -15,10 +15,10 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
+import util from '../ons/util';
+import autoStyle from '../ons/autostyle';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
 
 const scheme = {'': 'toolbar-button--*'};
 

--- a/core/src/elements/ons-toolbar.js
+++ b/core/src/elements/ons-toolbar.js
@@ -15,12 +15,12 @@ limitations under the License.
 
 */
 
-import util from 'ons/util';
-import internal from 'ons/internal';
-import autoStyle from 'ons/autostyle';
-import ModifierUtil from 'ons/internal/modifier-util';
-import BaseElement from 'ons/base-element';
-import contentReady from 'ons/content-ready';
+import util from '../ons/util';
+import internal from '../ons/internal';
+import autoStyle from '../ons/autostyle';
+import ModifierUtil from '../ons/internal/modifier-util';
+import BaseElement from '../ons/base-element';
+import contentReady from '../ons/content-ready';
 
 const scheme = {
   '': 'navigation-bar--*',

--- a/core/src/ons/notification.js
+++ b/core/src/ons/notification.js
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 import util from './util';
-import contentReady from 'ons/content-ready';
+import contentReady from './content-ready';
 
 /**
  * @object ons.notification

--- a/core/src/ons/page-loader.js
+++ b/core/src/ons/page-loader.js
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
-import util from 'ons/util';
-import internal from 'ons/internal';
+import util from './util';
+import internal from './internal';
 
 // Default implementation for global PageLoader.
 function loadPage({page, parent, params = {}, replace}, done) {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -66,22 +66,6 @@ gulp.task('core', function() {
     .pipe($.rollup({
       sourceMap: 'inline',
       plugins: [
-        {
-          resolveId: (code, id) => {
-            if (id && code.charAt(0) !== '.') {
-              let p = path.join(__dirname, 'core', 'src', code);
-
-              if (fs.existsSync(p)) {
-                p = path.join(p, 'index.js');
-              }
-              else {
-                p = p + '.js';
-              }
-
-              return p;
-            }
-          }
-        },
         nodeResolve(),
         babel({
           presets: ['es2015-rollup', 'stage-2'],


### PR DESCRIPTION
@anatoo @frankdiox @asial-matagawa 

This changes from absolute to relative imports in the Onsen UI core. I think this is more robust since we can change the build system and it should still work.

Also, we can get rid of a small Rollup plugin that I wrote which was causing some trouble with Babel.