### PR TITLE
fix(dialogs): event.cancel() reset.

### DIFF
--- a/core/src/elements/ons-alert-dialog/index.js
+++ b/core/src/elements/ons-alert-dialog/index.js
@@ -489,12 +489,14 @@ export default class AlertDialogElement extends BaseElement {
   _cancel() {
     if (this.cancelable && !this._running) {
       this._running = true;
-      this.hide({
-        callback: () => {
-          this._running = false;
-          util.triggerElementEvent(this, 'dialog-cancel');
-        }
-      });
+      this.hide()
+        .then(
+          () => {
+            this._running = false;
+            util.triggerElementEvent(this, 'dialog-cancel');
+          },
+          () => this._running = false
+        );
     }
   }
 

--- a/core/src/elements/ons-dialog/index.js
+++ b/core/src/elements/ons-dialog/index.js
@@ -272,12 +272,14 @@ export default class DialogElement extends BaseElement {
   _cancel() {
     if (this.cancelable && !this._running) {
       this._running = true;
-      this.hide({
-        callback: () => {
-          this._running = false;
-          util.triggerElementEvent(this, 'dialog-cancel');
-        }
-      });
+      this.hide()
+        .then(
+          () => {
+            this._running = false;
+            util.triggerElementEvent(this, 'dialog-cancel');
+          },
+          () => this._running = false
+        );
     }
   }
 


### PR DESCRIPTION
@argelius This fixes https://community.onsen.io/topic/983/prehide-event-on-ons-dialog-with-cancelable-attribute

Basically `this._running` isn't set back to `false` when `event.cancel()` is called.