### PR TITLE
fix(core): Fixed PageLoader.load() missing return type

### DIFF
--- a/core/src/onsenui.d.ts
+++ b/core/src/onsenui.d.ts
@@ -288,7 +288,7 @@ declare namespace ons {
    */
   class PageLoader {
     internalLoader: Function;
-    load(options: {page: any, parent: Element, params?: Object}, done: Function);
+    load(options: {page: any, parent: Element, params?: Object}, done: Function): void;
   }
 }
 


### PR DESCRIPTION
I just downloaded onsenui-2.0.3 and ran into this error when I tried to compile:

```
error TS7010: 'load', which lacks return-type annotation, implicitly has an 'any' return type.
```

I'm using TypeScript and have `noImplicitAny` enabled. I'd prefer to keep it that way if possible. I believe this commit will fix the issue, but please bear with me and let me know if there's anything wrong with my PR!

Thanks!