### PR TITLE
Fixed #1654.

### DIFF
--- a/core/src/elements/ons-tab.js
+++ b/core/src/elements/ons-tab.js
@@ -272,7 +272,11 @@ export default class TabElement extends BaseElement {
     const badge = this.getAttribute('badge');
 
     if (typeof icon === 'string') {
-      getIconElement().setAttribute('icon', icon);
+      const iconElement = getIconElement();
+      const last = iconElement.getAttribute('icon');
+      iconElement.setAttribute('icon', icon);
+      // dirty fix for https://github.com/OnsenUI/OnsenUI/issues/1654
+      getIconElement().attributeChangedCallback('icon', last, icon);
     } else {
       const wrapper = button.querySelector('.tab-bar__icon');
       if (wrapper) {

--- a/test/e2e/tabbar/issue-1672.html
+++ b/test/e2e/tabbar/issue-1672.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../../../build/css/onsenui.css"/>
+    <link rel="stylesheet" href="../../../build/css/onsen-css-components.css"/>
+
+    <script src="../../../build/js/onsenui.js"></script>
+    <script src="../../../build/js/angular/angular.js"></script>
+    <script src="../../../build/js/angular-onsenui.js"></script>
+    <script>
+      ons.bootstrap()
+
+      .controller('TestController', function($scope) {
+        $scope.label = 'My label';
+
+        $scope.toggleTabs = function() {
+          $scope.hideTabs = !$scope.hideTabs;
+        }
+      });
+    </script>
+  </head>
+  <body>
+    <ons-navigator id="navi">
+      <ons-page>
+        <ons-toolbar>
+          <div class="center">first</div>
+        </ons-toolbar>
+        <div class="content">
+          <ons-button id="button" onclick="document.querySelector('#navi').pushPage('page.html')">push</ons-button>
+        </div>
+      </ons-page>
+    </ons-navigator>
+
+    <script type="text/template" id="page.html">
+      <ons-page>
+        <ons-tabbar>
+          <ons-tab label="page" icon="fa-envelope, material:md-email" page="tab.html" active></ons-tab>
+        </ons-tabbar>
+      </ons-page>
+    </script>
+
+    <script type="text/template" id="tab.html">
+      <ons-page>
+        <ons-toolbar>
+          <div class="center">tabpage</div>
+        </ons-toolbar>
+        <div class="content">
+        </div>
+      </ons-page>
+    </script>
+  </body>
+</html>

--- a/test/e2e/tabbar/scenarios.js
+++ b/test/e2e/tabbar/scenarios.js
@@ -99,4 +99,17 @@
       expect(tabBar.isDisplayed()).toBeTruthy();
     });
   });
+
+  describe('tabbar/issue-1672.html', function() {
+    it('should work', function() {
+      var EC = protractor.ExpectedConditions;
+
+      browser.get('/test/e2e/tabbar/issue-1672.html');
+
+      element(by.css('#button')).click();
+      browser.wait(EC.presenceOf(element(by.css('ons-icon'))));
+
+      expect(element(by.css('ons-icon[class~="fa-envelope"]')).isPresent()).toBe(true);
+    });
+  });
 })();


### PR DESCRIPTION
@argelius I investigated #1654  and why `ons-icon` attribute change does not trigger `attributeChangedCallback()` in Safari. But I gave up and added dirty fix. Is there something that is considered to be the cause of that?