### PR TITLE
fix(angular2): Fix dependencies about RxJS.

### DIFF
--- a/bindings/angular2/package.json
+++ b/bindings/angular2/package.json
@@ -41,7 +41,7 @@
     "@angular/platform-browser": "^2.0.0",
     "@angular/platform-browser-dynamic": "^2.0.0",
     "core-js": "^2.4.0",
-    "rxjs": "^5.0.0-rc.1",
+    "rxjs": ">5.0.0-beta",
     "zone.js": "^0.6.21"
   },
   "devDependencies": {
@@ -60,7 +60,7 @@
     "gulp-shell": "^0.5.2",
     "open": "0.0.5",
     "protractor": "^3.3.0",
-    "rxjs": "^5.0.0-rc.1",
+    "rxjs": ">5.0.0-beta",
     "selenium-server-standalone-jar": "^2.53.0",
     "source-map-loader": "^0.1.5",
     "static-server": "^2.0.3",

--- a/bindings/angular2/package.json
+++ b/bindings/angular2/package.json
@@ -41,7 +41,7 @@
     "@angular/platform-browser": "^2.0.0",
     "@angular/platform-browser-dynamic": "^2.0.0",
     "core-js": "^2.4.0",
-    "rxjs": ">5.0.0-beta",
+    "rxjs": ">=5.0.0-beta",
     "zone.js": "^0.6.21"
   },
   "devDependencies": {
@@ -60,7 +60,7 @@
     "gulp-shell": "^0.5.2",
     "open": "0.0.5",
     "protractor": "^3.3.0",
-    "rxjs": ">5.0.0-beta",
+    "rxjs": ">=5.0.0-beta",
     "selenium-server-standalone-jar": "^2.53.0",
     "source-map-loader": "^0.1.5",
     "static-server": "^2.0.3",

--- a/bindings/angular2/yarn.lock
+++ b/bindings/angular2/yarn.lock
@@ -2609,9 +2609,9 @@ ripemd160@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-0.2.0.tgz#2bf198bde167cacfa51c0a928e84b68bbe171fce"
 
-rxjs@^5.0.0-rc.1:
-  version "5.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.0.0-rc.1.tgz#9e02b7044da81a2d5e138908d22af77e22d96973"
+rxjs@>=5.0.0-beta:
+  version "5.0.0-beta.12"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.0.0-beta.12.tgz#cdfde2d8c4639d20ae7794bff8fddf32da7ad337"
   dependencies:
     symbol-observable "^1.0.1"
 


### PR DESCRIPTION
@frankdiox @anatoo @argelius 

The latest Angular (= @angular/*@2.1.2) still depends on RxJS 5.x Beta, but `angular2-onsenui` depends on RxJS 5.x RC since the latest version (1.0.0-rc.2).
This makes `angular2-onsenui` unusable with Angular 2 (reported by @rdlabo).

This PR fixes `package.json` of `angular2-onsenui`.

It there is no problem, could anyone merge this PR and release a new version?

----
FYI:
`UNMET PEER DEPENDENCIES` on Monaca CLI with Onsen UI + Angular 2 templates
![2016-11-07 12 27 41](https://cloud.githubusercontent.com/assets/19771915/20046329/be231e28-a4eb-11e6-8855-b6ade551ed89.png)
