### PR TITLE
Enable regression test on macOS Safari.

### DIFF
--- a/core/src/elements/ons-alert-dialog/index.spec.js
+++ b/core/src/elements/ons-alert-dialog/index.spec.js
@@ -29,6 +29,7 @@ describe('OnsAlertDialogElement', () => {
     expect(window.ons.AlertDialogElement).to.be.ok;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides \'modifier\' attribute', () => {
     const element = dialog.querySelector('.alert-dialog');
     const content = dialog.querySelector('.alert-dialog-content');
@@ -52,18 +53,21 @@ describe('OnsAlertDialogElement', () => {
   });
 
   describe('#_titleElement', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is an HTML element', () => {
       expect(dialog._titleElement).to.be.an.instanceof(HTMLElement);
     });
   });
 
   describe('#_contentElement', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is an HTML element', () => {
       expect(dialog._contentElement).to.be.an.instanceof(HTMLElement);
     });
   });
 
   describe('#_dialog', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is an HTML element', () => {
       expect(dialog._dialog).to.be.an.instanceof(HTMLElement);
     });
@@ -86,6 +90,7 @@ describe('OnsAlertDialogElement', () => {
   });
 
   describe('#show()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('shows the dialog', () => {
       expect(dialog.style.display).to.equal('none');
       dialog.show();
@@ -102,6 +107,7 @@ describe('OnsAlertDialogElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('emits \'postshow\' event', () => {
       const promise = new Promise((resolve) => {
         dialog.addEventListener('postshow', resolve);
@@ -112,6 +118,7 @@ describe('OnsAlertDialogElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('can be cancelled', () => {
       dialog.addEventListener('preshow', (event) => {
         event.detail.cancel();
@@ -121,6 +128,7 @@ describe('OnsAlertDialogElement', () => {
       expect(dialog.style.display).to.equal('none');
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns a promise that resolves to the displayed element', () => {
       return expect(dialog.show()).to.eventually.be.fulfilled.then(
         element => {
@@ -136,6 +144,7 @@ describe('OnsAlertDialogElement', () => {
       dialog.show({animation: 'none'});
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('hides the dialog', () => {
       expect(dialog.style.display).to.equal('block');
       dialog.hide({animation: 'none'});
@@ -171,6 +180,7 @@ describe('OnsAlertDialogElement', () => {
       expect(dialog.style.display).to.equal('block');
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns a promise that resolves to the hidden element', () => {
       return expect(dialog.hide()).to.eventually.be.fulfilled.then(
         element => {
@@ -182,6 +192,7 @@ describe('OnsAlertDialogElement', () => {
   });
 
   describe('#onDeviceBackButton', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('cancels if dialog is cancelable', () => {
       const spy = chai.spy.on(dialog, '_cancel');
       dialog.setAttribute('cancelable', '');
@@ -189,6 +200,7 @@ describe('OnsAlertDialogElement', () => {
       expect(spy).to.have.been.called.once;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('calls parent handler if dialog is not cancelable', () => {
       const event = {};
       const spy = chai.spy.on(event, 'callParentHandler');
@@ -208,6 +220,7 @@ describe('OnsAlertDialogElement', () => {
   });
 
   describe('#visible', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns whether the dialog is visible or not', () => {
       expect(dialog.visible).to.be.false;
       dialog.show({animation: 'none'});
@@ -239,6 +252,7 @@ describe('OnsAlertDialogElement', () => {
 });
 
   describe('autoStyling', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('adds \'material\' modifier on Android', () => {
       ons.platform.select('android');
       const e = ons._util.createElement('<ons-alert-dialog>contents</ons-alert-dialog>');

--- a/core/src/elements/ons-alert-dialog/index.spec.js
+++ b/core/src/elements/ons-alert-dialog/index.spec.js
@@ -29,8 +29,7 @@ describe('OnsAlertDialogElement', () => {
     expect(window.ons.AlertDialogElement).to.be.ok;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides \'modifier\' attribute', () => {
+  onlyChrome(it)('provides \'modifier\' attribute', () => {
     const element = dialog.querySelector('.alert-dialog');
     const content = dialog.querySelector('.alert-dialog-content');
     const title = dialog.querySelector('.alert-dialog-title');
@@ -53,22 +52,19 @@ describe('OnsAlertDialogElement', () => {
   });
 
   describe('#_titleElement', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is an HTML element', () => {
+    onlyChrome(it)('is an HTML element', () => {
       expect(dialog._titleElement).to.be.an.instanceof(HTMLElement);
     });
   });
 
   describe('#_contentElement', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is an HTML element', () => {
+    onlyChrome(it)('is an HTML element', () => {
       expect(dialog._contentElement).to.be.an.instanceof(HTMLElement);
     });
   });
 
   describe('#_dialog', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is an HTML element', () => {
+    onlyChrome(it)('is an HTML element', () => {
       expect(dialog._dialog).to.be.an.instanceof(HTMLElement);
     });
   });
@@ -90,8 +86,7 @@ describe('OnsAlertDialogElement', () => {
   });
 
   describe('#show()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('shows the dialog', () => {
+    onlyChrome(it)('shows the dialog', () => {
       expect(dialog.style.display).to.equal('none');
       dialog.show();
       expect(dialog.style.display).to.equal('block');
@@ -107,8 +102,7 @@ describe('OnsAlertDialogElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('emits \'postshow\' event', () => {
+    onlyChrome(it)('emits \'postshow\' event', () => {
       const promise = new Promise((resolve) => {
         dialog.addEventListener('postshow', resolve);
       });
@@ -118,8 +112,7 @@ describe('OnsAlertDialogElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('can be cancelled', () => {
+    onlyChrome(it)('can be cancelled', () => {
       dialog.addEventListener('preshow', (event) => {
         event.detail.cancel();
       });
@@ -128,8 +121,7 @@ describe('OnsAlertDialogElement', () => {
       expect(dialog.style.display).to.equal('none');
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns a promise that resolves to the displayed element', () => {
+    onlyChrome(it)('returns a promise that resolves to the displayed element', () => {
       return expect(dialog.show()).to.eventually.be.fulfilled.then(
         element => {
           expect(element).to.equal(dialog);
@@ -144,8 +136,7 @@ describe('OnsAlertDialogElement', () => {
       dialog.show({animation: 'none'});
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('hides the dialog', () => {
+    onlyChrome(it)('hides the dialog', () => {
       expect(dialog.style.display).to.equal('block');
       dialog.hide({animation: 'none'});
       expect(dialog.style.display).to.equal('none');
@@ -180,8 +171,7 @@ describe('OnsAlertDialogElement', () => {
       expect(dialog.style.display).to.equal('block');
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns a promise that resolves to the hidden element', () => {
+    onlyChrome(it)('returns a promise that resolves to the hidden element', () => {
       return expect(dialog.hide()).to.eventually.be.fulfilled.then(
         element => {
           expect(element).to.equal(dialog);
@@ -192,16 +182,14 @@ describe('OnsAlertDialogElement', () => {
   });
 
   describe('#onDeviceBackButton', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('cancels if dialog is cancelable', () => {
+    onlyChrome(it)('cancels if dialog is cancelable', () => {
       const spy = chai.spy.on(dialog, '_cancel');
       dialog.setAttribute('cancelable', '');
       dialog.onDeviceBackButton._callback();
       expect(spy).to.have.been.called.once;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('calls parent handler if dialog is not cancelable', () => {
+    onlyChrome(it)('calls parent handler if dialog is not cancelable', () => {
       const event = {};
       const spy = chai.spy.on(event, 'callParentHandler');
 
@@ -220,8 +208,7 @@ describe('OnsAlertDialogElement', () => {
   });
 
   describe('#visible', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns whether the dialog is visible or not', () => {
+    onlyChrome(it)('returns whether the dialog is visible or not', () => {
       expect(dialog.visible).to.be.false;
       dialog.show({animation: 'none'});
       expect(dialog.visible).to.be.true;
@@ -252,8 +239,7 @@ describe('OnsAlertDialogElement', () => {
 });
 
   describe('autoStyling', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('adds \'material\' modifier on Android', () => {
+    onlyChrome(it)('adds \'material\' modifier on Android', () => {
       ons.platform.select('android');
       const e = ons._util.createElement('<ons-alert-dialog>contents</ons-alert-dialog>');
       expect(e.getAttribute('modifier')).to.equal('material');

--- a/core/src/elements/ons-back-button.spec.js
+++ b/core/src/elements/ons-back-button.spec.js
@@ -5,8 +5,7 @@ describe('OnsBackButtonElement', () => {
     expect(window.ons.BackButtonElement).to.be.ok;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides \'modifier\' attribute', () => {
+  onlyChrome(it)('provides \'modifier\' attribute', () => {
     const element = ons._util.createElement('<ons-back-button>label</ons-back-button>');
 
     element.setAttribute('modifier', 'hoge');
@@ -23,8 +22,7 @@ describe('OnsBackButtonElement', () => {
     expect(element.classList.contains('back-button--fuga')).to.be.true;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('has two children', () => {
+  onlyChrome(it)('has two children', () => {
     const element = ons._util.createElement('<ons-back-button>label</ons-back-button>');
     document.body.appendChild(element);
 
@@ -33,8 +31,7 @@ describe('OnsBackButtonElement', () => {
     expect(element.children[2]).not.to.be.ok;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  describe('#_onClick()', () => {
+  onlyChrome(describe)('#_onClick()', () => {
     let div, nav;
 
     beforeEach((done) => {
@@ -102,8 +99,7 @@ describe('OnsBackButtonElement', () => {
     });
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  describe('autoStyling', () => {
+  onlyChrome(describe)('autoStyling', () => {
     it('adds \'material\' modifiers and effects on Android', () => {
       ons.platform.select('android');
       const e = ons._util.createElement('<ons-back-button>label</ons-back-button>');

--- a/core/src/elements/ons-back-button.spec.js
+++ b/core/src/elements/ons-back-button.spec.js
@@ -5,6 +5,7 @@ describe('OnsBackButtonElement', () => {
     expect(window.ons.BackButtonElement).to.be.ok;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides \'modifier\' attribute', () => {
     const element = ons._util.createElement('<ons-back-button>label</ons-back-button>');
 
@@ -22,6 +23,7 @@ describe('OnsBackButtonElement', () => {
     expect(element.classList.contains('back-button--fuga')).to.be.true;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('has two children', () => {
     const element = ons._util.createElement('<ons-back-button>label</ons-back-button>');
     document.body.appendChild(element);
@@ -31,6 +33,7 @@ describe('OnsBackButtonElement', () => {
     expect(element.children[2]).not.to.be.ok;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   describe('#_onClick()', () => {
     let div, nav;
 
@@ -99,6 +102,7 @@ describe('OnsBackButtonElement', () => {
     });
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   describe('autoStyling', () => {
     it('adds \'material\' modifiers and effects on Android', () => {
       ons.platform.select('android');

--- a/core/src/elements/ons-bottom-toolbar.spec.js
+++ b/core/src/elements/ons-bottom-toolbar.spec.js
@@ -10,8 +10,7 @@ describe('ons-bottom-toolbar', () => {
     expect(element.classList.contains('bottom-bar')).to.be.true;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides \'modifier\' attribute', () => {
+  onlyChrome(it)('provides \'modifier\' attribute', () => {
     var element = new ons.BottomToolbarElement();
     element.setAttribute('modifier', 'hoge');
     expect(element.classList.contains('bottom-bar--hoge')).to.be.true;
@@ -27,8 +26,7 @@ describe('ons-bottom-toolbar', () => {
     expect(element.classList.contains('bottom-bar--fuga')).to.be.true;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('ensures its page\'s class', () => {
+  onlyChrome(it)('ensures its page\'s class', () => {
     var element = new ons.BottomToolbarElement(),
       page = new ons.PageElement();
 

--- a/core/src/elements/ons-bottom-toolbar.spec.js
+++ b/core/src/elements/ons-bottom-toolbar.spec.js
@@ -10,6 +10,7 @@ describe('ons-bottom-toolbar', () => {
     expect(element.classList.contains('bottom-bar')).to.be.true;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides \'modifier\' attribute', () => {
     var element = new ons.BottomToolbarElement();
     element.setAttribute('modifier', 'hoge');
@@ -26,6 +27,7 @@ describe('ons-bottom-toolbar', () => {
     expect(element.classList.contains('bottom-bar--fuga')).to.be.true;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('ensures its page\'s class', () => {
     var element = new ons.BottomToolbarElement(),
       page = new ons.PageElement();

--- a/core/src/elements/ons-button.spec.js
+++ b/core/src/elements/ons-button.spec.js
@@ -5,8 +5,7 @@ describe('ons-button', () => {
     expect(window.ons.ButtonElement).to.be.ok;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides modifier attribute', () => {
+  onlyChrome(it)('provides modifier attribute', () => {
     var element = new ons.ButtonElement();
     element.setAttribute('modifier', 'hoge');
     expect(element.classList.contains('button--hoge')).to.be.true;

--- a/core/src/elements/ons-button.spec.js
+++ b/core/src/elements/ons-button.spec.js
@@ -5,6 +5,7 @@ describe('ons-button', () => {
     expect(window.ons.ButtonElement).to.be.ok;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides modifier attribute', () => {
     var element = new ons.ButtonElement();
     element.setAttribute('modifier', 'hoge');

--- a/core/src/elements/ons-carousel-item.spec.js
+++ b/core/src/elements/ons-carousel-item.spec.js
@@ -5,6 +5,7 @@ describe('OnsCarouselItemElement', () => {
     expect(window.ons.CarouselItemElement).to.be.ok;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides \'modifier\' attribute', () => {
     var carouselItem = new ons.CarouselItemElement();
 

--- a/core/src/elements/ons-carousel-item.spec.js
+++ b/core/src/elements/ons-carousel-item.spec.js
@@ -5,8 +5,7 @@ describe('OnsCarouselItemElement', () => {
     expect(window.ons.CarouselItemElement).to.be.ok;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides \'modifier\' attribute', () => {
+  onlyChrome(it)('provides \'modifier\' attribute', () => {
     var carouselItem = new ons.CarouselItemElement();
 
     carouselItem.setAttribute('modifier', 'hoge');

--- a/core/src/elements/ons-carousel.spec.js
+++ b/core/src/elements/ons-carousel.spec.js
@@ -24,6 +24,7 @@ describe('OnsCarouselElement', () => {
   });
 
   describe('#_updateSwipeable()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('attaches and removes listeners', () => {
       const spyOn = chai.spy.on(carousel._gestureDetector, 'on'),
         spyOff = chai.spy.on(carousel._gestureDetector, 'off');
@@ -37,6 +38,7 @@ describe('OnsCarouselElement', () => {
   });
 
   describe('#_updateAutoRefresh()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('starts and stops observing', () => {
       const spyOn = chai.spy.on(carousel._mutationObserver, 'observe'),
         spyOff = chai.spy.on(carousel._mutationObserver, 'disconnect');
@@ -77,6 +79,7 @@ describe('OnsCarouselElement', () => {
   });
 
   describe('#_onDirectionChange()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is fired when the \'direction\' attribute is changed', () => {
       const spy = chai.spy.on(carousel, '_onDirectionChange');
       carousel.setAttribute('direction', 'vertical');
@@ -167,6 +170,7 @@ describe('OnsCarouselElement', () => {
       expect(carousel.getActiveIndex()).to.equal(2);
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('should fire \'postchange\' event', () => {
       const promise = new Promise((resolve) =>
         carousel.addEventListener('postchange', resolve)
@@ -176,6 +180,7 @@ describe('OnsCarouselElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns a promise that resolves to the element', () => {
       return expect(carousel.setActiveIndex(1)).to.be.eventually.fulfilled.then(element => {
         expect(element).to.equal(carousel);

--- a/core/src/elements/ons-carousel.spec.js
+++ b/core/src/elements/ons-carousel.spec.js
@@ -24,8 +24,7 @@ describe('OnsCarouselElement', () => {
   });
 
   describe('#_updateSwipeable()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('attaches and removes listeners', () => {
+    onlyChrome(it)('attaches and removes listeners', () => {
       const spyOn = chai.spy.on(carousel._gestureDetector, 'on'),
         spyOff = chai.spy.on(carousel._gestureDetector, 'off');
 
@@ -38,8 +37,7 @@ describe('OnsCarouselElement', () => {
   });
 
   describe('#_updateAutoRefresh()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('starts and stops observing', () => {
+    onlyChrome(it)('starts and stops observing', () => {
       const spyOn = chai.spy.on(carousel._mutationObserver, 'observe'),
         spyOff = chai.spy.on(carousel._mutationObserver, 'disconnect');
 
@@ -79,8 +77,7 @@ describe('OnsCarouselElement', () => {
   });
 
   describe('#_onDirectionChange()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is fired when the \'direction\' attribute is changed', () => {
+    onlyChrome(it)('is fired when the \'direction\' attribute is changed', () => {
       const spy = chai.spy.on(carousel, '_onDirectionChange');
       carousel.setAttribute('direction', 'vertical');
       carousel.setAttribute('direction', 'horizontal');
@@ -170,8 +167,7 @@ describe('OnsCarouselElement', () => {
       expect(carousel.getActiveIndex()).to.equal(2);
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('should fire \'postchange\' event', () => {
+    onlyChrome(it)('should fire \'postchange\' event', () => {
       const promise = new Promise((resolve) =>
         carousel.addEventListener('postchange', resolve)
       );
@@ -180,8 +176,7 @@ describe('OnsCarouselElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns a promise that resolves to the element', () => {
+    onlyChrome(it)('returns a promise that resolves to the element', () => {
       return expect(carousel.setActiveIndex(1)).to.be.eventually.fulfilled.then(element => {
         expect(element).to.equal(carousel);
         expect(element.getActiveIndex()).to.equal(1);

--- a/core/src/elements/ons-col.spec.js
+++ b/core/src/elements/ons-col.spec.js
@@ -26,6 +26,7 @@ describe('OnsColElement', () => {
   });
 
   describe('#attributeChangedCallback()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('provides \'width\' attribute', () => {
       var element = new ons.ColElement();
       element.setAttribute('width', '100px');

--- a/core/src/elements/ons-col.spec.js
+++ b/core/src/elements/ons-col.spec.js
@@ -26,8 +26,7 @@ describe('OnsColElement', () => {
   });
 
   describe('#attributeChangedCallback()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('provides \'width\' attribute', () => {
+    onlyChrome(it)('provides \'width\' attribute', () => {
       var element = new ons.ColElement();
       element.setAttribute('width', '100px');
 

--- a/core/src/elements/ons-dialog/index.spec.js
+++ b/core/src/elements/ons-dialog/index.spec.js
@@ -22,8 +22,7 @@ describe('OnsDialogElement', () => {
     expect(window.ons.DialogElement).to.be.ok;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides \'modifier\' attribute', () => {
+  onlyChrome(it)('provides \'modifier\' attribute', () => {
     const element = dialog.querySelector('.dialog');
 
     dialog.setAttribute('modifier', 'hoge');
@@ -41,15 +40,13 @@ describe('OnsDialogElement', () => {
   });
 
   describe('#_mask', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is an HTML element', () => {
+    onlyChrome(it)('is an HTML element', () => {
       expect(dialog._mask).to.be.an.instanceof(HTMLElement);
     });
   });
 
   describe('#_dialog', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is an HTML element', () => {
+    onlyChrome(it)('is an HTML element', () => {
       expect(dialog._dialog).to.be.an.instanceof(HTMLElement);
     });
   });
@@ -65,23 +62,20 @@ describe('OnsDialogElement', () => {
   });
 
   describe('#onDeviceBackButton', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns the back button handler', () => {
+    onlyChrome(it)('returns the back button handler', () => {
       expect(dialog.onDeviceBackButton).to.be.an('object');
     });
   });
 
   describe('#onDeviceBackButton', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('cancels if dialog is cancelable', () => {
+    onlyChrome(it)('cancels if dialog is cancelable', () => {
       const spy = chai.spy.on(dialog, '_cancel');
       dialog.setAttribute('cancelable', '');
       dialog.onDeviceBackButton._callback();
       expect(spy).to.have.been.called.once;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('calls parent handler if dialog is not cancelable', () => {
+    onlyChrome(it)('calls parent handler if dialog is not cancelable', () => {
       const event = {};
       const spy = chai.spy.on(event, 'callParentHandler');
 
@@ -127,8 +121,7 @@ describe('OnsDialogElement', () => {
   });
 
   describe('#show()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('shows the dialog', () => {
+    onlyChrome(it)('shows the dialog', () => {
       expect(dialog.style.display).to.equal('none');
       dialog.show();
       expect(dialog.style.display).to.equal('block');
@@ -144,8 +137,7 @@ describe('OnsDialogElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('emits \'postshow\' event', () => {
+    onlyChrome(it)('emits \'postshow\' event', () => {
       const promise = new Promise((resolve) => {
         dialog.addEventListener('postshow', resolve);
       });
@@ -155,8 +147,7 @@ describe('OnsDialogElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('can be cancelled', () => {
+    onlyChrome(it)('can be cancelled', () => {
       dialog.addEventListener('preshow', (event) => {
         event.detail.cancel();
       });
@@ -165,8 +156,7 @@ describe('OnsDialogElement', () => {
       expect(dialog.style.display).to.equal('none');
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns a promise that resolves to the displayed element', () => {
+    onlyChrome(it)('returns a promise that resolves to the displayed element', () => {
       return expect(dialog.show()).to.eventually.be.fulfilled.then(
         element => {
           expect(element).to.equal(dialog);
@@ -181,8 +171,7 @@ describe('OnsDialogElement', () => {
       dialog.show({animation: 'none'});
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('hides the dialog', () => {
+    onlyChrome(it)('hides the dialog', () => {
       expect(dialog.style.display).to.equal('block');
       dialog.hide({animation: 'none'});
       expect(dialog.style.display).to.equal('none');
@@ -217,8 +206,7 @@ describe('OnsDialogElement', () => {
       expect(dialog.style.display).to.equal('block');
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns a promise that resolves to the hidden element', () => {
+    onlyChrome(it)('returns a promise that resolves to the hidden element', () => {
       return expect(dialog.hide()).to.eventually.be.fulfilled.then(
         element => {
           expect(element).to.equal(dialog);
@@ -229,8 +217,7 @@ describe('OnsDialogElement', () => {
   });
 
   describe('#visible', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns whether the dialog is visible or not', () => {
+    onlyChrome(it)('returns whether the dialog is visible or not', () => {
       expect(dialog.visible).to.be.false;
       dialog.show({animation: 'none'});
       expect(dialog.visible).to.be.true;
@@ -252,8 +239,7 @@ describe('OnsDialogElement', () => {
   });
 
   describe('autoStyling', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('adds \'material\' modifier on Android', () => {
+    onlyChrome(it)('adds \'material\' modifier on Android', () => {
       ons.platform.select('android');
       const e = ons._util.createElement('<ons-dialog>contents</ons-dialog>');
       expect(e.getAttribute('modifier')).to.equal('material');

--- a/core/src/elements/ons-dialog/index.spec.js
+++ b/core/src/elements/ons-dialog/index.spec.js
@@ -22,6 +22,7 @@ describe('OnsDialogElement', () => {
     expect(window.ons.DialogElement).to.be.ok;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides \'modifier\' attribute', () => {
     const element = dialog.querySelector('.dialog');
 
@@ -40,12 +41,14 @@ describe('OnsDialogElement', () => {
   });
 
   describe('#_mask', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is an HTML element', () => {
       expect(dialog._mask).to.be.an.instanceof(HTMLElement);
     });
   });
 
   describe('#_dialog', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is an HTML element', () => {
       expect(dialog._dialog).to.be.an.instanceof(HTMLElement);
     });
@@ -62,12 +65,14 @@ describe('OnsDialogElement', () => {
   });
 
   describe('#onDeviceBackButton', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns the back button handler', () => {
       expect(dialog.onDeviceBackButton).to.be.an('object');
     });
   });
 
   describe('#onDeviceBackButton', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('cancels if dialog is cancelable', () => {
       const spy = chai.spy.on(dialog, '_cancel');
       dialog.setAttribute('cancelable', '');
@@ -75,6 +80,7 @@ describe('OnsDialogElement', () => {
       expect(spy).to.have.been.called.once;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('calls parent handler if dialog is not cancelable', () => {
       const event = {};
       const spy = chai.spy.on(event, 'callParentHandler');
@@ -121,6 +127,7 @@ describe('OnsDialogElement', () => {
   });
 
   describe('#show()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('shows the dialog', () => {
       expect(dialog.style.display).to.equal('none');
       dialog.show();
@@ -137,6 +144,7 @@ describe('OnsDialogElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('emits \'postshow\' event', () => {
       const promise = new Promise((resolve) => {
         dialog.addEventListener('postshow', resolve);
@@ -147,6 +155,7 @@ describe('OnsDialogElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('can be cancelled', () => {
       dialog.addEventListener('preshow', (event) => {
         event.detail.cancel();
@@ -156,6 +165,7 @@ describe('OnsDialogElement', () => {
       expect(dialog.style.display).to.equal('none');
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns a promise that resolves to the displayed element', () => {
       return expect(dialog.show()).to.eventually.be.fulfilled.then(
         element => {
@@ -171,6 +181,7 @@ describe('OnsDialogElement', () => {
       dialog.show({animation: 'none'});
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('hides the dialog', () => {
       expect(dialog.style.display).to.equal('block');
       dialog.hide({animation: 'none'});
@@ -206,6 +217,7 @@ describe('OnsDialogElement', () => {
       expect(dialog.style.display).to.equal('block');
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns a promise that resolves to the hidden element', () => {
       return expect(dialog.hide()).to.eventually.be.fulfilled.then(
         element => {
@@ -217,6 +229,7 @@ describe('OnsDialogElement', () => {
   });
 
   describe('#visible', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns whether the dialog is visible or not', () => {
       expect(dialog.visible).to.be.false;
       dialog.show({animation: 'none'});
@@ -239,6 +252,7 @@ describe('OnsDialogElement', () => {
   });
 
   describe('autoStyling', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('adds \'material\' modifier on Android', () => {
       ons.platform.select('android');
       const e = ons._util.createElement('<ons-dialog>contents</ons-dialog>');

--- a/core/src/elements/ons-fab.spec.js
+++ b/core/src/elements/ons-fab.spec.js
@@ -12,6 +12,7 @@ describe('OnsFabElement', () => {
     expect(window.ons.FabElement).to.be.ok;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides modifier attribute', () => {
     fab.setAttribute('modifier', 'hoge');
     expect(fab.classList.contains('fab--hoge')).to.be.true;
@@ -44,6 +45,7 @@ describe('OnsFabElement', () => {
   });
 
   describe('#_updatePosition()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is called when the "position" attribute changes', () => {
       const spy = chai.spy.on(fab, '_updatePosition');
 
@@ -53,6 +55,7 @@ describe('OnsFabElement', () => {
       expect(spy).to.have.been.called.twice;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('adds the correct class', () => {
       fab.setAttribute('position', 'top right');
       expect(fab.classList.contains('fab--top__right')).to.be.true;
@@ -176,6 +179,7 @@ describe('OnsFabElement', () => {
   });
 
   describe('autoStyling', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('adds \'material\' effects on Android', () => {
       ons.platform.select('android');
       const e = ons._util.createElement('<ons-fab> </ons-fab>');

--- a/core/src/elements/ons-fab.spec.js
+++ b/core/src/elements/ons-fab.spec.js
@@ -12,8 +12,7 @@ describe('OnsFabElement', () => {
     expect(window.ons.FabElement).to.be.ok;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides modifier attribute', () => {
+  onlyChrome(it)('provides modifier attribute', () => {
     fab.setAttribute('modifier', 'hoge');
     expect(fab.classList.contains('fab--hoge')).to.be.true;
 
@@ -45,8 +44,7 @@ describe('OnsFabElement', () => {
   });
 
   describe('#_updatePosition()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is called when the "position" attribute changes', () => {
+    onlyChrome(it)('is called when the "position" attribute changes', () => {
       const spy = chai.spy.on(fab, '_updatePosition');
 
       fab.setAttribute('position', 'top left');
@@ -55,8 +53,7 @@ describe('OnsFabElement', () => {
       expect(spy).to.have.been.called.twice;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('adds the correct class', () => {
+    onlyChrome(it)('adds the correct class', () => {
       fab.setAttribute('position', 'top right');
       expect(fab.classList.contains('fab--top__right')).to.be.true;
 
@@ -179,8 +176,7 @@ describe('OnsFabElement', () => {
   });
 
   describe('autoStyling', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('adds \'material\' effects on Android', () => {
+    onlyChrome(it)('adds \'material\' effects on Android', () => {
       ons.platform.select('android');
       const e = ons._util.createElement('<ons-fab> </ons-fab>');
       expect(e.hasAttribute('ripple')).to.be.true;

--- a/core/src/elements/ons-icon.spec.js
+++ b/core/src/elements/ons-icon.spec.js
@@ -6,6 +6,7 @@ describe('OnsIconElement', () => {
   });
 
   describe('icon attribute', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('provides \'icon\' attribute', () => {
       var element = new ons.IconElement();
       element.setAttribute('icon', 'ion-navicon');
@@ -28,6 +29,7 @@ describe('OnsIconElement', () => {
       expect(element.classList.contains('zmdi')).not.to.be.true;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('supports a second icon depending on modifiers', () => {
       var element = new ons.IconElement();
       element.setAttribute('icon', 'ion-navicon, material:md-face');
@@ -44,6 +46,7 @@ describe('OnsIconElement', () => {
   });
 
   describe('size attribute', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('provides \'size\' attribute', () => {
       var element = new ons.IconElement();
       element.setAttribute('size', '10px');
@@ -67,6 +70,7 @@ describe('OnsIconElement', () => {
       expect(element.classList.contains('fa-5x')).not.to.be.true;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('supports a second size depending on modifiers', () => {
       var element = new ons.IconElement();
       element.setAttribute('size', '20px, material:30px');

--- a/core/src/elements/ons-icon.spec.js
+++ b/core/src/elements/ons-icon.spec.js
@@ -6,8 +6,7 @@ describe('OnsIconElement', () => {
   });
 
   describe('icon attribute', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('provides \'icon\' attribute', () => {
+    onlyChrome(it)('provides \'icon\' attribute', () => {
       var element = new ons.IconElement();
       element.setAttribute('icon', 'ion-navicon');
       expect(element.classList.contains('ion-navicon')).to.be.true;
@@ -29,8 +28,7 @@ describe('OnsIconElement', () => {
       expect(element.classList.contains('zmdi')).not.to.be.true;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('supports a second icon depending on modifiers', () => {
+    onlyChrome(it)('supports a second icon depending on modifiers', () => {
       var element = new ons.IconElement();
       element.setAttribute('icon', 'ion-navicon, material:md-face');
       expect(element.classList.contains('ion-navicon')).to.be.true;
@@ -46,8 +44,7 @@ describe('OnsIconElement', () => {
   });
 
   describe('size attribute', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('provides \'size\' attribute', () => {
+    onlyChrome(it)('provides \'size\' attribute', () => {
       var element = new ons.IconElement();
       element.setAttribute('size', '10px');
       expect(element.style.fontSize).to.equal('10px');
@@ -70,8 +67,7 @@ describe('OnsIconElement', () => {
       expect(element.classList.contains('fa-5x')).not.to.be.true;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('supports a second size depending on modifiers', () => {
+    onlyChrome(it)('supports a second size depending on modifiers', () => {
       var element = new ons.IconElement();
       element.setAttribute('size', '20px, material:30px');
       expect(element.style.fontSize).to.equal('20px');

--- a/core/src/elements/ons-if.spec.js
+++ b/core/src/elements/ons-if.spec.js
@@ -10,8 +10,7 @@ describe('ons-if', () => {
     expect(element.hasChildNodes()).not.to.be.true;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('filters depending on \'platform\' attribute', () => {
+  onlyChrome(it)('filters depending on \'platform\' attribute', () => {
     ons.platform.select('android');
     let element = ons._util.createElement('<ons-if platform="android">Content</ons-if>');
     expect(element.hasChildNodes()).to.be.true;
@@ -20,8 +19,7 @@ describe('ons-if', () => {
     expect(element.hasChildNodes()).not.to.be.true;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('filters depending on \'orientation\' attribute', (done) => {
+  onlyChrome(it)('filters depending on \'orientation\' attribute', (done) => {
     const originalIsPortrait = ons.orientation._isPortrait;
     let isPortrait = true;
     ons.orientation._isPortrait = () => isPortrait;

--- a/core/src/elements/ons-if.spec.js
+++ b/core/src/elements/ons-if.spec.js
@@ -10,6 +10,7 @@ describe('ons-if', () => {
     expect(element.hasChildNodes()).not.to.be.true;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('filters depending on \'platform\' attribute', () => {
     ons.platform.select('android');
     let element = ons._util.createElement('<ons-if platform="android">Content</ons-if>');
@@ -19,6 +20,7 @@ describe('ons-if', () => {
     expect(element.hasChildNodes()).not.to.be.true;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('filters depending on \'orientation\' attribute', (done) => {
     const originalIsPortrait = ons.orientation._isPortrait;
     let isPortrait = true;

--- a/core/src/elements/ons-input.spec.js
+++ b/core/src/elements/ons-input.spec.js
@@ -21,6 +21,7 @@ describe('OnsInputElement', () => {
     expect(window.ons.InputElement).to.be.ok;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides \'modifier\' attribute', () => {
     element.setAttribute('modifier', 'hoge');
     expect(element._input.classList.contains('text-input--hoge')).to.be.true;
@@ -36,6 +37,7 @@ describe('OnsInputElement', () => {
   });
 
   describe('#_updateLabel()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is called when the placeholder attribute changes', () => {
       const spy = chai.spy.on(element, '_updateLabel');
 
@@ -43,6 +45,7 @@ describe('OnsInputElement', () => {
       expect(spy).to.have.been.called.once;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('removes the label text if there is no placeholder attribute', () => {
       element.removeAttribute('placeholder');
       expect(element._helper.innerText).to.equal('');
@@ -50,12 +53,14 @@ describe('OnsInputElement', () => {
   });
 
   describe('#_updateBoundAttributes()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is called when one of the bound attribute changes', () => {
       const spy = chai.spy.on(element, '_updateBoundAttributes');
       element.setAttribute('value', 'abc');
       expect(spy).to.have.been.called.once;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('removes attributes from the input element', () => {
       element.setAttribute('value', 'abc');
       expect(element._input.getAttribute('value')).to.equal('abc');
@@ -113,6 +118,7 @@ describe('OnsInputElement', () => {
       });
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('provides \'content-left\' attribute', () => {
       let element = ons._util.createElement('<ons-input>content</ons-input>');
       expect(element.firstChild.lastChild.className).to.equal('input-label');
@@ -122,6 +128,7 @@ describe('OnsInputElement', () => {
   });
 
   describe('#type attribute', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('creates checkbox', (done) => {
       const element = ons._util.createElement('<ons-input type="checkbox"></ons-input>');
 

--- a/core/src/elements/ons-input.spec.js
+++ b/core/src/elements/ons-input.spec.js
@@ -21,8 +21,7 @@ describe('OnsInputElement', () => {
     expect(window.ons.InputElement).to.be.ok;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides \'modifier\' attribute', () => {
+  onlyChrome(it)('provides \'modifier\' attribute', () => {
     element.setAttribute('modifier', 'hoge');
     expect(element._input.classList.contains('text-input--hoge')).to.be.true;
     expect(element._helper.classList.contains('text-input--hoge__label')).to.be.true;
@@ -37,31 +36,27 @@ describe('OnsInputElement', () => {
   });
 
   describe('#_updateLabel()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is called when the placeholder attribute changes', () => {
+    onlyChrome(it)('is called when the placeholder attribute changes', () => {
       const spy = chai.spy.on(element, '_updateLabel');
 
       element.setAttribute('placeholder', 'Password');
       expect(spy).to.have.been.called.once;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('removes the label text if there is no placeholder attribute', () => {
+    onlyChrome(it)('removes the label text if there is no placeholder attribute', () => {
       element.removeAttribute('placeholder');
       expect(element._helper.innerText).to.equal('');
     });
   });
 
   describe('#_updateBoundAttributes()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is called when one of the bound attribute changes', () => {
+    onlyChrome(it)('is called when one of the bound attribute changes', () => {
       const spy = chai.spy.on(element, '_updateBoundAttributes');
       element.setAttribute('value', 'abc');
       expect(spy).to.have.been.called.once;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('removes attributes from the input element', () => {
+    onlyChrome(it)('removes attributes from the input element', () => {
       element.setAttribute('value', 'abc');
       expect(element._input.getAttribute('value')).to.equal('abc');
       element.removeAttribute('value');
@@ -118,8 +113,7 @@ describe('OnsInputElement', () => {
       });
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('provides \'content-left\' attribute', () => {
+    onlyChrome(it)('provides \'content-left\' attribute', () => {
       let element = ons._util.createElement('<ons-input>content</ons-input>');
       expect(element.firstChild.lastChild.className).to.equal('input-label');
       element = ons._util.createElement('<ons-input content-left>content</ons-input>');
@@ -128,8 +122,7 @@ describe('OnsInputElement', () => {
   });
 
   describe('#type attribute', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('creates checkbox', (done) => {
+    onlyChrome(it)('creates checkbox', (done) => {
       const element = ons._util.createElement('<ons-input type="checkbox"></ons-input>');
 
       setImmediate(() => {

--- a/core/src/elements/ons-lazy-repeat.spec.js
+++ b/core/src/elements/ons-lazy-repeat.spec.js
@@ -1,7 +1,6 @@
 'use strict';
 
-if (['local_chrome'].indexOf(window.browser) != -1)
-describe('OnsLazyRepeatElement', () => {
+onlyChrome(describe)('OnsLazyRepeatElement', () => {
   let element;
   let lazyRepeat;
 

--- a/core/src/elements/ons-lazy-repeat.spec.js
+++ b/core/src/elements/ons-lazy-repeat.spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+if (['local_chrome'].indexOf(window.browser) != -1)
 describe('OnsLazyRepeatElement', () => {
   let element;
   let lazyRepeat;

--- a/core/src/elements/ons-list-header.spec.js
+++ b/core/src/elements/ons-list-header.spec.js
@@ -10,6 +10,7 @@ describe('ons-list-header', () => {
     expect(element.classList.contains('list__header')).to.be.true;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides modifier attribute', () => {
     var element = new ons.ListHeaderElement();
     element.setAttribute('modifier', 'hoge');

--- a/core/src/elements/ons-list-header.spec.js
+++ b/core/src/elements/ons-list-header.spec.js
@@ -10,8 +10,7 @@ describe('ons-list-header', () => {
     expect(element.classList.contains('list__header')).to.be.true;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides modifier attribute', () => {
+  onlyChrome(it)('provides modifier attribute', () => {
     var element = new ons.ListHeaderElement();
     element.setAttribute('modifier', 'hoge');
     expect(element.classList.contains('list__header--hoge')).to.be.true;

--- a/core/src/elements/ons-list-item.spec.js
+++ b/core/src/elements/ons-list-item.spec.js
@@ -17,6 +17,7 @@ describe('OnsListItemElement', () => {
     expect(listItem.classList.contains('list__item')).to.be.true;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides modifier attribute', () => {
     listItem.setAttribute('modifier', 'hoge');
     expect(listItem.classList.contains('list__item--hoge')).to.be.true;
@@ -99,6 +100,7 @@ describe('OnsListItemElement', () => {
   });
 
   describe('autoStyling', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('adds \'material\' modifiers and effects on Android if tappable', () => {
       ons.platform.select('android');
       const e = ons._util.createElement('<ons-list-item tappable>Content</ons-list-item>');

--- a/core/src/elements/ons-list-item.spec.js
+++ b/core/src/elements/ons-list-item.spec.js
@@ -17,8 +17,7 @@ describe('OnsListItemElement', () => {
     expect(listItem.classList.contains('list__item')).to.be.true;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides modifier attribute', () => {
+  onlyChrome(it)('provides modifier attribute', () => {
     listItem.setAttribute('modifier', 'hoge');
     expect(listItem.classList.contains('list__item--hoge')).to.be.true;
 
@@ -100,8 +99,7 @@ describe('OnsListItemElement', () => {
   });
 
   describe('autoStyling', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('adds \'material\' modifiers and effects on Android if tappable', () => {
+    onlyChrome(it)('adds \'material\' modifiers and effects on Android if tappable', () => {
       ons.platform.select('android');
       const e = ons._util.createElement('<ons-list-item tappable>Content</ons-list-item>');
       expect(e.getAttribute('modifier')).to.equal('material');

--- a/core/src/elements/ons-list.spec.js
+++ b/core/src/elements/ons-list.spec.js
@@ -10,8 +10,7 @@ describe('ons-list', () => {
     expect(element.classList.contains('list')).to.be.true;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides modifier attribute', () => {
+  onlyChrome(it)('provides modifier attribute', () => {
     var element = new ons.ListElement();
     element.setAttribute('modifier', 'hoge');
     expect(element.classList.contains('list--hoge')).to.be.true;

--- a/core/src/elements/ons-list.spec.js
+++ b/core/src/elements/ons-list.spec.js
@@ -10,6 +10,7 @@ describe('ons-list', () => {
     expect(element.classList.contains('list')).to.be.true;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides modifier attribute', () => {
     var element = new ons.ListElement();
     element.setAttribute('modifier', 'hoge');

--- a/core/src/elements/ons-modal/index.spec.js
+++ b/core/src/elements/ons-modal/index.spec.js
@@ -22,15 +22,18 @@ describe('OnsModalElement', () => {
     expect(window.ons.ModalElement).to.be.ok;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('is not displayed by default', () => {
     expect(element.style.display).to.equal('none');
   });
 
   describe('#_compile()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('adds a class \'modal\' by default', () => {
       expect(element.classList.contains('modal')).to.be.true;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('adds a \'modal__content\' by default', () => {
       const wrapper = document.createElement('div');
       element.appendChild(wrapper);
@@ -47,6 +50,7 @@ describe('OnsModalElement', () => {
   });
 
   describe('#show()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('displays the modal', () => {
       expect(element.style.display).to.equal('none');
       element.show();
@@ -87,6 +91,7 @@ describe('OnsModalElement', () => {
   });
 
   describe('#toggle()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('alternates the modal displaying state', () => {
       expect(element.style.display).to.equal('none');
       element.toggle();
@@ -99,6 +104,7 @@ describe('OnsModalElement', () => {
   });
 
   describe('#visible', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns whether the modal is shown', () => {
       expect(element.style.display).to.equal('none');
       expect(element.visible).to.be.false;
@@ -110,14 +116,17 @@ describe('OnsModalElement', () => {
 
 
   describe('#onDeviceBackButton', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('gets the callback', () => {
       expect(element.onDeviceBackButton).to.be.ok;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns nothing by default', () => {
       expect(element.onDeviceBackButton._callback()).not.to.be.ok;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('overwrites the callback', () => {
       const spy = chai.spy.on(element._backButtonHandler, 'destroy');
       element.onDeviceBackButton = () => { return; };

--- a/core/src/elements/ons-modal/index.spec.js
+++ b/core/src/elements/ons-modal/index.spec.js
@@ -22,19 +22,16 @@ describe('OnsModalElement', () => {
     expect(window.ons.ModalElement).to.be.ok;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('is not displayed by default', () => {
+  onlyChrome(it)('is not displayed by default', () => {
     expect(element.style.display).to.equal('none');
   });
 
   describe('#_compile()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('adds a class \'modal\' by default', () => {
+    onlyChrome(it)('adds a class \'modal\' by default', () => {
       expect(element.classList.contains('modal')).to.be.true;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('adds a \'modal__content\' by default', () => {
+    onlyChrome(it)('adds a \'modal__content\' by default', () => {
       const wrapper = document.createElement('div');
       element.appendChild(wrapper);
       expect(element.children[0].classList.contains('modal__content')).to.be.true;
@@ -50,8 +47,7 @@ describe('OnsModalElement', () => {
   });
 
   describe('#show()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('displays the modal', () => {
+    onlyChrome(it)('displays the modal', () => {
       expect(element.style.display).to.equal('none');
       element.show();
       expect(element.style.display).to.equal('table');
@@ -91,8 +87,7 @@ describe('OnsModalElement', () => {
   });
 
   describe('#toggle()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('alternates the modal displaying state', () => {
+    onlyChrome(it)('alternates the modal displaying state', () => {
       expect(element.style.display).to.equal('none');
       element.toggle();
       expect(element.style.display).to.equal('table');
@@ -104,8 +99,7 @@ describe('OnsModalElement', () => {
   });
 
   describe('#visible', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns whether the modal is shown', () => {
+    onlyChrome(it)('returns whether the modal is shown', () => {
       expect(element.style.display).to.equal('none');
       expect(element.visible).to.be.false;
       element.show();
@@ -116,18 +110,15 @@ describe('OnsModalElement', () => {
 
 
   describe('#onDeviceBackButton', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('gets the callback', () => {
+    onlyChrome(it)('gets the callback', () => {
       expect(element.onDeviceBackButton).to.be.ok;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns nothing by default', () => {
+    onlyChrome(it)('returns nothing by default', () => {
       expect(element.onDeviceBackButton._callback()).not.to.be.ok;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('overwrites the callback', () => {
+    onlyChrome(it)('overwrites the callback', () => {
       const spy = chai.spy.on(element._backButtonHandler, 'destroy');
       element.onDeviceBackButton = () => { return; };
       expect(spy).to.have.been.called.once;

--- a/core/src/elements/ons-navigator/index.spec.js
+++ b/core/src/elements/ons-navigator/index.spec.js
@@ -33,8 +33,7 @@ describe('OnsNavigatorElement', () => {
     expect(window.ons.NavigatorElement.animators).to.be.an('object');
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides \'page\' attribute', () => {
+  onlyChrome(it)('provides \'page\' attribute', () => {
     const content = nav.topPage._getContentElement();
     expect(content.innerHTML).to.equal('hoge');
   });
@@ -55,22 +54,19 @@ describe('OnsNavigatorElement', () => {
   });
 
   describe('#pages', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('provides \'pages\' property', () => {
+    onlyChrome(it)('provides \'pages\' property', () => {
         const pages = nav.pages;
         expect(pages[0]).to.be.an.instanceof(Element);
         expect(pages[0].name).to.be.an('string');
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('should have one page after initialization', () => {
+    onlyChrome(it)('should have one page after initialization', () => {
        expect(nav.pages.length).to.equal(1);
     });
   });
 
   describe('#pushPage()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('adds a new page to the top of the page stack', (done) => {
+    onlyChrome(it)('adds a new page to the top of the page stack', (done) => {
       nav.pushPage('hoge', {
         callback: () => {
           const content = nav.topPage._getContentElement();
@@ -81,8 +77,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('adds a new page to the top of the page stack using options.pageHTML', (done) => {
+    onlyChrome(it)('adds a new page to the top of the page stack using options.pageHTML', (done) => {
       nav.pushPage(null, {
         pageHTML: '<ons-page>hoge2</ons-page>',
         callback: () => {
@@ -148,8 +143,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('removes the top page from the stack', (done) => {
+    onlyChrome(it)('removes the top page from the stack', (done) => {
       nav.pushPage('fuga', {
         callback: () => {
           const content = nav.topPage._getContentElement();
@@ -167,8 +161,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is canceled if already performing another popPage', (done) => {
+    onlyChrome(it)('is canceled if already performing another popPage', (done) => {
       var calls = [false, false];
       var finished = (num) => {
         calls[num] = true;
@@ -192,8 +185,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('can refresh the previous page', (done) => {
+    onlyChrome(it)('can refresh the previous page', (done) => {
       nav.pushPage('info', {
         callback: () => {
           var content = nav.topPage._getContentElement();
@@ -215,8 +207,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('throws error when refreshing pages directly inside the navigator', (done) => {
+    onlyChrome(it)('throws error when refreshing pages directly inside the navigator', (done) => {
       nav.innerHTML = '<ons-page> Test </ons-page>';
 
       return nav.pushPage('hoge').then(() => {
@@ -228,8 +219,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('emits \'prepop\' event', () => {
+    onlyChrome(it)('emits \'prepop\' event', () => {
       const promise = new Promise((resolve) => {
         nav.addEventListener('prepop', (event) => { resolve(event); });
       });
@@ -241,8 +231,7 @@ describe('OnsNavigatorElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('should be possible to cancel the \'prepop\' event', (done) => {
+    onlyChrome(it)('should be possible to cancel the \'prepop\' event', (done) => {
       nav.addEventListener('prepop', (event) => {
         event.detail.cancel();
       });
@@ -259,8 +248,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('emits \'postpop\' event', () => {
+    onlyChrome(it)('emits \'postpop\' event', () => {
       const promise = new Promise((resolve) => {
         nav.addEventListener('postpop', (event) => { resolve(event); });
       });
@@ -272,8 +260,7 @@ describe('OnsNavigatorElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('emits \'show\' event', (done) => {
+    onlyChrome(it)('emits \'show\' event', (done) => {
       const promise = new Promise((resolve) => {
         nav.addEventListener('show', (event) => { resolve(event); });
       });
@@ -287,8 +274,7 @@ describe('OnsNavigatorElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns a promise that resolves to the new top page', () => {
+    onlyChrome(it)('returns a promise that resolves to the new top page', () => {
       return nav.pushPage('hoge').then(() => {
         return expect(nav.popPage()).to.eventually.be.fulfilled.then(
           page => expect(page).to.equal(nav.topPage)
@@ -306,16 +292,14 @@ describe('OnsNavigatorElement', () => {
       done();
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('does nothing when the page is already on top', (done) => {
+    onlyChrome(it)('does nothing when the page is already on top', (done) => {
       const spy = chai.spy.on(nav, '_pushPage');
       nav.bringPageTop('hoge');
       expect(spy).not.to.have.been.called();
       done();
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('brings the given pageUrl to the top', (done) => {
+    onlyChrome(it)('brings the given pageUrl to the top', (done) => {
       expect(nav.pages.length).to.equal(1);
       expect(nav.topPage.name).to.equal('hoge');
       nav.bringPageTop('fuga', {
@@ -334,8 +318,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('brings the given page index to the top', (done) => {
+    onlyChrome(it)('brings the given page index to the top', (done) => {
       expect(nav.pages.length).to.equal(1);
       expect(nav.topPage.name).to.equal('hoge');
       nav.bringPageTop('fuga', {
@@ -367,8 +350,7 @@ describe('OnsNavigatorElement', () => {
     });
 
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('should be possible to cancel the \'prepush\' event', (done) => {
+    onlyChrome(it)('should be possible to cancel the \'prepush\' event', (done) => {
       expect(nav.pages.length).to.equal(1);
 
       nav.bringPageTop('info', {callback: () => {
@@ -385,8 +367,7 @@ describe('OnsNavigatorElement', () => {
       }});
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns a promise that resolves to the new top page', () => {
+    onlyChrome(it)('returns a promise that resolves to the new top page', () => {
       return nav.pushPage('info').then(() => {
         return nav.pushPage('fuga').then(() => {
           return expect(nav.bringPageTop('info')).to.eventually.be.fulfilled.then(
@@ -398,8 +379,7 @@ describe('OnsNavigatorElement', () => {
   });
 
   describe('#insertPage()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('inserts a new page on a given index', (done) => {
+    onlyChrome(it)('inserts a new page on a given index', (done) => {
       nav.pushPage('info', {
         callback: () => {
           nav.insertPage(0, 'fuga');
@@ -415,8 +395,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('inserts a new page on a given index using `options.pageHTML`', (done) => {
+    onlyChrome(it)('inserts a new page on a given index using `options.pageHTML`', (done) => {
       nav.pushPage('info', {
         callback: () => {
           nav.insertPage(0, null, {pageHTML: '<ons-page>fuga</ons-page>'});
@@ -442,8 +421,7 @@ describe('OnsNavigatorElement', () => {
       expect(spy).to.have.been.called.once;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('normalizes the index', (done) => {
+    onlyChrome(it)('normalizes the index', (done) => {
       nav.pushPage('info', {
         callback: () => {
           nav.insertPage(-2, 'fuga').then( () => {
@@ -458,8 +436,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns a promise that resolves to the inserted page', () => {
+    onlyChrome(it)('returns a promise that resolves to the inserted page', () => {
       return nav.pushPage('hoge').then(() => {
         return expect(nav.insertPage(0, 'fuga')).to.eventually.be.fulfilled.then(
           page => expect(page).to.equal(nav.pages[0])
@@ -473,8 +450,7 @@ describe('OnsNavigatorElement', () => {
       expect(() => nav.replacePage('hoge', 'string')).to.throw(Error);
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('replaces the current page with a new one', () => {
+    onlyChrome(it)('replaces the current page with a new one', () => {
       return nav.pushPage('info')
         .then(() => {
           expect(nav.pages.length).to.equal(2);
@@ -490,8 +466,7 @@ describe('OnsNavigatorElement', () => {
         });
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns a promise that resolves to the new top page', (done) => {
+    onlyChrome(it)('returns a promise that resolves to the new top page', (done) => {
       return nav.pushPage('hoge').then(() => {
         return expect(nav.replacePage('fuga')).to.eventually.be.fulfilled.then(
           page => {
@@ -508,8 +483,7 @@ describe('OnsNavigatorElement', () => {
       expect(() => nav.resetToPage('hoge', 'string')).to.throw(Error);
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('replaces all the page stack with only a new page', (done) => {
+    onlyChrome(it)('replaces all the page stack with only a new page', (done) => {
       nav.pushPage('fuga', {callback: () => {
         nav.resetToPage('hoge', {
           callback: () => {
@@ -522,8 +496,7 @@ describe('OnsNavigatorElement', () => {
       }});
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns a promise that resolves to the new top page', () => {
+    onlyChrome(it)('returns a promise that resolves to the new top page', () => {
       return nav.pushPage('hoge').then(() => {
         return expect(nav.resetToPage('fuga')).to.eventually.be.fulfilled.then(
           page => expect(page).to.equal(nav.topPage)
@@ -533,8 +506,7 @@ describe('OnsNavigatorElement', () => {
   });
 
   describe('#topPage', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns the current page', () => {
+    onlyChrome(it)('returns the current page', () => {
       const page = nav.topPage;
 
       expect(page).to.be.an.instanceof(Element);
@@ -548,8 +520,7 @@ describe('OnsNavigatorElement', () => {
   });
 
   describe('#_destroy()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('destroys all the pages', () => {
+    onlyChrome(it)('destroys all the pages', () => {
       expect(nav.pages.length).to.equal(1);
       nav._destroy();
       expect(nav.pages.length).to.equal(0);
@@ -566,8 +537,7 @@ describe('OnsNavigatorElement', () => {
   });
 
   describe('#_onDeviceBackButton()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('pops a page if there are more than one', (done) => {
+    onlyChrome(it)('pops a page if there are more than one', (done) => {
       nav.pushPage('hoge', {
         callback: () => {
           var spy = chai.spy.on(nav, 'popPage');
@@ -588,8 +558,7 @@ describe('OnsNavigatorElement', () => {
 
   describe('propagate API', () => {
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('fires \'show\' event', () => {
+    onlyChrome(it)('fires \'show\' event', () => {
       const promise = new Promise((resolve) => {
         nav.addEventListener('show', (event) => resolve());
       });
@@ -604,8 +573,7 @@ describe('OnsNavigatorElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('fires \'hide\' event', () => {
+    onlyChrome(it)('fires \'hide\' event', () => {
       const promise = new Promise((resolve) => {
         nav.addEventListener('hide', () => resolve());
       });
@@ -617,8 +585,7 @@ describe('OnsNavigatorElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('fires \'destroy\' event', () => {
+    onlyChrome(it)('fires \'destroy\' event', () => {
       const promise = new Promise((resolve) => {
         nav.addEventListener('destroy', () => resolve());
       });
@@ -651,8 +618,7 @@ describe('OnsNavigatorElement', () => {
       window.ons.NavigatorElement.registerAnimator('fuga', MyAnimator);
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('overwrites specified properties', () => {
+    onlyChrome(it)('overwrites specified properties', () => {
       const deferred = {};
       deferred.promise = new Promise((resolve) => {
         deferred.resolve = resolve
@@ -692,8 +658,7 @@ describe('OnsNavigatorElement', () => {
     });
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  describe('#backButton', () => {
+  onlyChrome(describe)('#backButton', () => {
     beforeEach((done) => {
       const tpl1 = ons._util.createElement(`<ons-template id="backPage"><ons-back-button>Back</ons-back-button><ons-page>hoge</ons-page></ons-template>`)
       const tpl2 = ons._util.createElement(`<ons-template id="backPage2"><ons-back-button>Back</ons-back-button><ons-page>hoge2</ons-page></ons-template>`);

--- a/core/src/elements/ons-navigator/index.spec.js
+++ b/core/src/elements/ons-navigator/index.spec.js
@@ -33,6 +33,7 @@ describe('OnsNavigatorElement', () => {
     expect(window.ons.NavigatorElement.animators).to.be.an('object');
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides \'page\' attribute', () => {
     const content = nav.topPage._getContentElement();
     expect(content.innerHTML).to.equal('hoge');
@@ -54,18 +55,21 @@ describe('OnsNavigatorElement', () => {
   });
 
   describe('#pages', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('provides \'pages\' property', () => {
         const pages = nav.pages;
         expect(pages[0]).to.be.an.instanceof(Element);
         expect(pages[0].name).to.be.an('string');
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('should have one page after initialization', () => {
        expect(nav.pages.length).to.equal(1);
     });
   });
 
   describe('#pushPage()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('adds a new page to the top of the page stack', (done) => {
       nav.pushPage('hoge', {
         callback: () => {
@@ -77,6 +81,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('adds a new page to the top of the page stack using options.pageHTML', (done) => {
       nav.pushPage(null, {
         pageHTML: '<ons-page>hoge2</ons-page>',
@@ -143,6 +148,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('removes the top page from the stack', (done) => {
       nav.pushPage('fuga', {
         callback: () => {
@@ -161,6 +167,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is canceled if already performing another popPage', (done) => {
       var calls = [false, false];
       var finished = (num) => {
@@ -185,6 +192,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('can refresh the previous page', (done) => {
       nav.pushPage('info', {
         callback: () => {
@@ -207,6 +215,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('throws error when refreshing pages directly inside the navigator', (done) => {
       nav.innerHTML = '<ons-page> Test </ons-page>';
 
@@ -219,6 +228,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('emits \'prepop\' event', () => {
       const promise = new Promise((resolve) => {
         nav.addEventListener('prepop', (event) => { resolve(event); });
@@ -231,6 +241,7 @@ describe('OnsNavigatorElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('should be possible to cancel the \'prepop\' event', (done) => {
       nav.addEventListener('prepop', (event) => {
         event.detail.cancel();
@@ -248,6 +259,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('emits \'postpop\' event', () => {
       const promise = new Promise((resolve) => {
         nav.addEventListener('postpop', (event) => { resolve(event); });
@@ -260,6 +272,7 @@ describe('OnsNavigatorElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('emits \'show\' event', (done) => {
       const promise = new Promise((resolve) => {
         nav.addEventListener('show', (event) => { resolve(event); });
@@ -274,6 +287,7 @@ describe('OnsNavigatorElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns a promise that resolves to the new top page', () => {
       return nav.pushPage('hoge').then(() => {
         return expect(nav.popPage()).to.eventually.be.fulfilled.then(
@@ -292,6 +306,7 @@ describe('OnsNavigatorElement', () => {
       done();
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('does nothing when the page is already on top', (done) => {
       const spy = chai.spy.on(nav, '_pushPage');
       nav.bringPageTop('hoge');
@@ -299,6 +314,7 @@ describe('OnsNavigatorElement', () => {
       done();
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('brings the given pageUrl to the top', (done) => {
       expect(nav.pages.length).to.equal(1);
       expect(nav.topPage.name).to.equal('hoge');
@@ -318,6 +334,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('brings the given page index to the top', (done) => {
       expect(nav.pages.length).to.equal(1);
       expect(nav.topPage.name).to.equal('hoge');
@@ -350,6 +367,7 @@ describe('OnsNavigatorElement', () => {
     });
 
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('should be possible to cancel the \'prepush\' event', (done) => {
       expect(nav.pages.length).to.equal(1);
 
@@ -367,6 +385,7 @@ describe('OnsNavigatorElement', () => {
       }});
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns a promise that resolves to the new top page', () => {
       return nav.pushPage('info').then(() => {
         return nav.pushPage('fuga').then(() => {
@@ -379,6 +398,7 @@ describe('OnsNavigatorElement', () => {
   });
 
   describe('#insertPage()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('inserts a new page on a given index', (done) => {
       nav.pushPage('info', {
         callback: () => {
@@ -395,6 +415,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('inserts a new page on a given index using `options.pageHTML`', (done) => {
       nav.pushPage('info', {
         callback: () => {
@@ -421,6 +442,7 @@ describe('OnsNavigatorElement', () => {
       expect(spy).to.have.been.called.once;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('normalizes the index', (done) => {
       nav.pushPage('info', {
         callback: () => {
@@ -436,6 +458,7 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns a promise that resolves to the inserted page', () => {
       return nav.pushPage('hoge').then(() => {
         return expect(nav.insertPage(0, 'fuga')).to.eventually.be.fulfilled.then(
@@ -450,6 +473,7 @@ describe('OnsNavigatorElement', () => {
       expect(() => nav.replacePage('hoge', 'string')).to.throw(Error);
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('replaces the current page with a new one', () => {
       return nav.pushPage('info')
         .then(() => {
@@ -466,6 +490,7 @@ describe('OnsNavigatorElement', () => {
         });
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns a promise that resolves to the new top page', (done) => {
       return nav.pushPage('hoge').then(() => {
         return expect(nav.replacePage('fuga')).to.eventually.be.fulfilled.then(
@@ -483,6 +508,7 @@ describe('OnsNavigatorElement', () => {
       expect(() => nav.resetToPage('hoge', 'string')).to.throw(Error);
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('replaces all the page stack with only a new page', (done) => {
       nav.pushPage('fuga', {callback: () => {
         nav.resetToPage('hoge', {
@@ -496,6 +522,7 @@ describe('OnsNavigatorElement', () => {
       }});
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns a promise that resolves to the new top page', () => {
       return nav.pushPage('hoge').then(() => {
         return expect(nav.resetToPage('fuga')).to.eventually.be.fulfilled.then(
@@ -506,6 +533,7 @@ describe('OnsNavigatorElement', () => {
   });
 
   describe('#topPage', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns the current page', () => {
       const page = nav.topPage;
 
@@ -520,6 +548,7 @@ describe('OnsNavigatorElement', () => {
   });
 
   describe('#_destroy()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('destroys all the pages', () => {
       expect(nav.pages.length).to.equal(1);
       nav._destroy();
@@ -537,6 +566,7 @@ describe('OnsNavigatorElement', () => {
   });
 
   describe('#_onDeviceBackButton()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('pops a page if there are more than one', (done) => {
       nav.pushPage('hoge', {
         callback: () => {
@@ -558,6 +588,7 @@ describe('OnsNavigatorElement', () => {
 
   describe('propagate API', () => {
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('fires \'show\' event', () => {
       const promise = new Promise((resolve) => {
         nav.addEventListener('show', (event) => resolve());
@@ -573,6 +604,7 @@ describe('OnsNavigatorElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('fires \'hide\' event', () => {
       const promise = new Promise((resolve) => {
         nav.addEventListener('hide', () => resolve());
@@ -585,6 +617,7 @@ describe('OnsNavigatorElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('fires \'destroy\' event', () => {
       const promise = new Promise((resolve) => {
         nav.addEventListener('destroy', () => resolve());
@@ -618,6 +651,7 @@ describe('OnsNavigatorElement', () => {
       window.ons.NavigatorElement.registerAnimator('fuga', MyAnimator);
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('overwrites specified properties', () => {
       const deferred = {};
       deferred.promise = new Promise((resolve) => {
@@ -658,6 +692,7 @@ describe('OnsNavigatorElement', () => {
     });
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   describe('#backButton', () => {
     beforeEach((done) => {
       const tpl1 = ons._util.createElement(`<ons-template id="backPage"><ons-back-button>Back</ons-back-button><ons-page>hoge</ons-page></ons-template>`)

--- a/core/src/elements/ons-page.spec.js
+++ b/core/src/elements/ons-page.spec.js
@@ -20,6 +20,7 @@ describe('OnsPageElement', () => {
     expect(element.classList.contains('page')).to.be.true;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('should fill class name automatically on content wrapper element', () => {
     const page = ons._util.createElement(`<ons-page>
       <div class="content">...</div>
@@ -28,6 +29,7 @@ describe('OnsPageElement', () => {
     expect(page.querySelector('.page__content').textContent).to.be.equal('...');
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('should fill class name automatically on background element', () => {
     const page = ons._util.createElement(`<ons-page>
       <div class="background" id="test">...</div>
@@ -36,6 +38,7 @@ describe('OnsPageElement', () => {
     expect(page.querySelector('.page__background').id).to.be.equal('test');
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('should create background element automatically', () => {
     const page = ons._util.createElement(`<ons-page>
       <div class="page__content">...</div>
@@ -53,6 +56,7 @@ describe('OnsPageElement', () => {
       return expect(initPromise).to.eventually.be.fulfilled;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('consumes _skipinit attribute if present', () => {
       element.setAttribute('_skipinit', '');
       expect(element.hasAttribute('_skipinit')).to.be.true;
@@ -62,6 +66,7 @@ describe('OnsPageElement', () => {
   });
 
   describe('#_tryToFillStatusBar()', (done) => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('fills status bar', () => {
       var tmp = ons._internal.autoStatusBarFill;
       ons._internal.autoStatusBarFill = action => action();
@@ -72,6 +77,7 @@ describe('OnsPageElement', () => {
   });
 
   describe('#detachedCallback', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('fires \'destroy\' event', () => {
       var spy = chai.spy();
       document.addEventListener('destroy', spy);
@@ -100,6 +106,7 @@ describe('OnsPageElement', () => {
       expect(spy).to.have.been.called.once;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is correctly deleted', () => {
       element.onDeviceBackButton = () => { return; };
       expect(element._backButtonHandler).to.be.ok;
@@ -110,10 +117,12 @@ describe('OnsPageElement', () => {
   });
 
   describe('#_getBackgroundElement()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('gets page__background', () => {
       expect(() => element._getBackgroundElement()).not.to.throw(Error);
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('throws page__background error', () => {
       element.removeChild(element.getElementsByClassName('page__background')[0]);
       expect(() => element._getBackgroundElement()).to.throw(Error);
@@ -121,6 +130,7 @@ describe('OnsPageElement', () => {
   });
 
   describe('#_getContentElement()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('throws page__content error', () => {
       element.removeChild(element.getElementsByClassName('page__content')[0]);
       expect(() => element._getContentElement()).to.throw(Error);
@@ -128,12 +138,14 @@ describe('OnsPageElement', () => {
   });
 
   describe('#_canAnimateToolbar()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('works with normal toolbar', () => {
       expect(element._canAnimateToolbar()).to.be.false;
       element.insertBefore(new ons.ToolbarElement(), element.children[0]);
       expect(element._canAnimateToolbar()).to.be.true;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('works with toolbar in page__content', () => {
       expect(element._canAnimateToolbar()).to.be.false;
       element.lastChild.appendChild(new ons.ToolbarElement());
@@ -148,6 +160,7 @@ describe('OnsPageElement', () => {
       expect(spy).to.have.been.called.once;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('sets _onInfiniteScroll', () => {
       let i = 0;
       window._testApp = {
@@ -162,6 +175,7 @@ describe('OnsPageElement', () => {
       expect(i).to.equal(84);
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('infiniteScroll doesn\'t throw error until it\'s called', () => {
       const app = {a: () => 42};
       element.attributeChangedCallback('on-infinite-scroll', '', '_testApp.a');
@@ -184,6 +198,7 @@ describe('OnsPageElement', () => {
   });
 
   describe('#_hide()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('fires \'hide\' event', () => {
       var spy = chai.spy();
       document.addEventListener('hide', spy);
@@ -203,6 +218,7 @@ describe('OnsPageElement', () => {
       expect(div1.isEqualNode(div2)).to.be.true;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('adds elements in correct order', () => {
       const div = document.createElement('div');
       div.innerHTML = '<ons-page><span>test</span><ons-toolbar></ons-toolbar></ons-page>';
@@ -238,6 +254,7 @@ describe('OnsPageElement', () => {
   });
 
   describe('autoStyling', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('adds \'material\' modifier on Android', () => {
       ons.platform.select('android');
       const e = ons._util.createElement('<ons-page>content</ons-page>');
@@ -246,6 +263,7 @@ describe('OnsPageElement', () => {
     });
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   describe('infiniteScroll', () => {
     var content, page, i, maxScroll;
     beforeEach(() => {

--- a/core/src/elements/ons-page.spec.js
+++ b/core/src/elements/ons-page.spec.js
@@ -20,8 +20,7 @@ describe('OnsPageElement', () => {
     expect(element.classList.contains('page')).to.be.true;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('should fill class name automatically on content wrapper element', () => {
+  onlyChrome(it)('should fill class name automatically on content wrapper element', () => {
     const page = ons._util.createElement(`<ons-page>
       <div class="content">...</div>
     </ons-page>`);
@@ -29,8 +28,7 @@ describe('OnsPageElement', () => {
     expect(page.querySelector('.page__content').textContent).to.be.equal('...');
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('should fill class name automatically on background element', () => {
+  onlyChrome(it)('should fill class name automatically on background element', () => {
     const page = ons._util.createElement(`<ons-page>
       <div class="background" id="test">...</div>
     </ons-page>`);
@@ -38,8 +36,7 @@ describe('OnsPageElement', () => {
     expect(page.querySelector('.page__background').id).to.be.equal('test');
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('should create background element automatically', () => {
+  onlyChrome(it)('should create background element automatically', () => {
     const page = ons._util.createElement(`<ons-page>
       <div class="page__content">...</div>
     </ons-page>`);
@@ -56,8 +53,7 @@ describe('OnsPageElement', () => {
       return expect(initPromise).to.eventually.be.fulfilled;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('consumes _skipinit attribute if present', () => {
+    onlyChrome(it)('consumes _skipinit attribute if present', () => {
       element.setAttribute('_skipinit', '');
       expect(element.hasAttribute('_skipinit')).to.be.true;
       document.body.appendChild(element);
@@ -66,8 +62,7 @@ describe('OnsPageElement', () => {
   });
 
   describe('#_tryToFillStatusBar()', (done) => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('fills status bar', () => {
+    onlyChrome(it)('fills status bar', () => {
       var tmp = ons._internal.autoStatusBarFill;
       ons._internal.autoStatusBarFill = action => action();
       element._tryToFillStatusBar();
@@ -77,8 +72,7 @@ describe('OnsPageElement', () => {
   });
 
   describe('#detachedCallback', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('fires \'destroy\' event', () => {
+    onlyChrome(it)('fires \'destroy\' event', () => {
       var spy = chai.spy();
       document.addEventListener('destroy', spy);
       document.body.appendChild(element);
@@ -106,8 +100,7 @@ describe('OnsPageElement', () => {
       expect(spy).to.have.been.called.once;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is correctly deleted', () => {
+    onlyChrome(it)('is correctly deleted', () => {
       element.onDeviceBackButton = () => { return; };
       expect(element._backButtonHandler).to.be.ok;
 
@@ -117,36 +110,31 @@ describe('OnsPageElement', () => {
   });
 
   describe('#_getBackgroundElement()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('gets page__background', () => {
+    onlyChrome(it)('gets page__background', () => {
       expect(() => element._getBackgroundElement()).not.to.throw(Error);
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('throws page__background error', () => {
+    onlyChrome(it)('throws page__background error', () => {
       element.removeChild(element.getElementsByClassName('page__background')[0]);
       expect(() => element._getBackgroundElement()).to.throw(Error);
     });
   });
 
   describe('#_getContentElement()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('throws page__content error', () => {
+    onlyChrome(it)('throws page__content error', () => {
       element.removeChild(element.getElementsByClassName('page__content')[0]);
       expect(() => element._getContentElement()).to.throw(Error);
     });
   });
 
   describe('#_canAnimateToolbar()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('works with normal toolbar', () => {
+    onlyChrome(it)('works with normal toolbar', () => {
       expect(element._canAnimateToolbar()).to.be.false;
       element.insertBefore(new ons.ToolbarElement(), element.children[0]);
       expect(element._canAnimateToolbar()).to.be.true;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('works with toolbar in page__content', () => {
+    onlyChrome(it)('works with toolbar in page__content', () => {
       expect(element._canAnimateToolbar()).to.be.false;
       element.lastChild.appendChild(new ons.ToolbarElement());
       expect(element._canAnimateToolbar()).to.be.true;
@@ -160,8 +148,7 @@ describe('OnsPageElement', () => {
       expect(spy).to.have.been.called.once;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('sets _onInfiniteScroll', () => {
+    onlyChrome(it)('sets _onInfiniteScroll', () => {
       let i = 0;
       window._testApp = {
         a: () => i += 42
@@ -175,8 +162,7 @@ describe('OnsPageElement', () => {
       expect(i).to.equal(84);
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('infiniteScroll doesn\'t throw error until it\'s called', () => {
+    onlyChrome(it)('infiniteScroll doesn\'t throw error until it\'s called', () => {
       const app = {a: () => 42};
       element.attributeChangedCallback('on-infinite-scroll', '', '_testApp.a');
       window._testApp = app;
@@ -198,8 +184,7 @@ describe('OnsPageElement', () => {
   });
 
   describe('#_hide()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('fires \'hide\' event', () => {
+    onlyChrome(it)('fires \'hide\' event', () => {
       var spy = chai.spy();
       document.addEventListener('hide', spy);
       document.body.appendChild(element);
@@ -218,8 +203,7 @@ describe('OnsPageElement', () => {
       expect(div1.isEqualNode(div2)).to.be.true;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('adds elements in correct order', () => {
+    onlyChrome(it)('adds elements in correct order', () => {
       const div = document.createElement('div');
       div.innerHTML = '<ons-page><span>test</span><ons-toolbar></ons-toolbar></ons-page>';
       const elements = div.children[0].children;
@@ -254,8 +238,7 @@ describe('OnsPageElement', () => {
   });
 
   describe('autoStyling', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('adds \'material\' modifier on Android', () => {
+    onlyChrome(it)('adds \'material\' modifier on Android', () => {
       ons.platform.select('android');
       const e = ons._util.createElement('<ons-page>content</ons-page>');
       expect(e.getAttribute('modifier')).to.equal('material');
@@ -263,8 +246,7 @@ describe('OnsPageElement', () => {
     });
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  describe('infiniteScroll', () => {
+  onlyChrome(describe)('infiniteScroll', () => {
     var content, page, i, maxScroll;
     beforeEach(() => {
       i = 0;

--- a/core/src/elements/ons-popover/index.spec.js
+++ b/core/src/elements/ons-popover/index.spec.js
@@ -250,8 +250,14 @@ describe('OnsPopoverElement', () => {
   });
 
   describe('\'style\' attribute', () => {
-    const popover = ons._util.createElement('<ons-popover style="background: blue">Test</ons-popover>');
-    expect(popover._popover.style.background).to.equal('blue');
+    it ('works', (done) => {
+      const popover = ons._util.createElement('<ons-popover style="background: blue">Test</ons-popover>');
+
+      setImmediate(() => {
+        expect(popover._popover.style.background).to.equal('blue');
+        done();
+      });
+    });
   });
 
 

--- a/core/src/elements/ons-popover/index.spec.js
+++ b/core/src/elements/ons-popover/index.spec.js
@@ -24,8 +24,7 @@ describe('OnsPopoverElement', () => {
     expect(window.ons.PopoverElement).to.be.ok;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides \'modifier\' attribute', () => {
+  onlyChrome(it)('provides \'modifier\' attribute', () => {
     const container = popover.querySelector('.popover__container');
     const content = popover.querySelector('.popover__content');
 
@@ -67,8 +66,7 @@ describe('OnsPopoverElement', () => {
   });
 
   describe('#onDeviceBackButton', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('should hide the popover if it is cancelable', () => {
+    onlyChrome(it)('should hide the popover if it is cancelable', () => {
       popover.setAttribute('animation', 'none');
       popover.setAttribute('cancelable', '');
 
@@ -146,8 +144,7 @@ describe('OnsPopoverElement', () => {
       });
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns a promise that resolves to the displayed element', () => {
+    onlyChrome(it)('returns a promise that resolves to the displayed element', () => {
       return expect(popover.show(target)).to.eventually.be.fulfilled.then(element => {
         expect(element).to.equal(popover);
         expect(popoverDisplay()).to.equal('block');
@@ -214,8 +211,7 @@ describe('OnsPopoverElement', () => {
       expect(popoverDisplay()).to.equal('block');
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('should hide the popover if it is cancelable', () => {
+    onlyChrome(it)('should hide the popover if it is cancelable', () => {
       popover.setAttribute('animation', 'none');
       popover.show(target);
       popover.setAttribute('cancelable', '');
@@ -289,8 +285,7 @@ describe('OnsPopoverElement', () => {
   });
 
   describe('autoStyling', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('adds \'material\' modifier on Android', () => {
+    onlyChrome(it)('adds \'material\' modifier on Android', () => {
       ons.platform.select('android');
       const e = ons._util.createElement('<ons-popover>Content</ons-popover>');
       expect(e.getAttribute('modifier')).to.equal('material');

--- a/core/src/elements/ons-popover/index.spec.js
+++ b/core/src/elements/ons-popover/index.spec.js
@@ -24,6 +24,7 @@ describe('OnsPopoverElement', () => {
     expect(window.ons.PopoverElement).to.be.ok;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides \'modifier\' attribute', () => {
     const container = popover.querySelector('.popover__container');
     const content = popover.querySelector('.popover__content');
@@ -66,6 +67,7 @@ describe('OnsPopoverElement', () => {
   });
 
   describe('#onDeviceBackButton', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('should hide the popover if it is cancelable', () => {
       popover.setAttribute('animation', 'none');
       popover.setAttribute('cancelable', '');
@@ -144,6 +146,7 @@ describe('OnsPopoverElement', () => {
       });
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns a promise that resolves to the displayed element', () => {
       return expect(popover.show(target)).to.eventually.be.fulfilled.then(element => {
         expect(element).to.equal(popover);
@@ -211,6 +214,7 @@ describe('OnsPopoverElement', () => {
       expect(popoverDisplay()).to.equal('block');
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('should hide the popover if it is cancelable', () => {
       popover.setAttribute('animation', 'none');
       popover.show(target);
@@ -285,6 +289,7 @@ describe('OnsPopoverElement', () => {
   });
 
   describe('autoStyling', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('adds \'material\' modifier on Android', () => {
       ons.platform.select('android');
       const e = ons._util.createElement('<ons-popover>Content</ons-popover>');

--- a/core/src/elements/ons-progress-bar.spec.js
+++ b/core/src/elements/ons-progress-bar.spec.js
@@ -12,6 +12,7 @@ describe('OnsProgressBarElement', () => {
     expect(window.ons.ProgressBarElement).to.be.ok;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides modifier attribute', () => {
     var template = progress._template,
       primary = progress._primary,
@@ -35,6 +36,7 @@ describe('OnsProgressBarElement', () => {
   });
 
   describe('#_updateDeterminate()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is called when the "indeterminate" attribute is changed', () => {
       const spy = chai.spy.on(progress, '_updateDeterminate');
 
@@ -46,6 +48,7 @@ describe('OnsProgressBarElement', () => {
   });
 
   describe('#_updateValue()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is called when the "value" attribute is changed', () => {
       const spy = chai.spy.on(progress, '_updateValue');
 
@@ -53,6 +56,7 @@ describe('OnsProgressBarElement', () => {
       expect(spy).to.have.been.called.once;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is called when the "secondary-value" attribute is changed', () => {
       const spy = chai.spy.on(progress, '_updateValue');
 
@@ -62,6 +66,7 @@ describe('OnsProgressBarElement', () => {
   });
 
   describe('#_compile()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is called when an element is created', () => {
       const spy = chai.spy.on(window.ons.ProgressBarElement.prototype, '_compile');
       ons._util.createElement('<ons-progress-bar> </ons-progress-bar>');

--- a/core/src/elements/ons-progress-bar.spec.js
+++ b/core/src/elements/ons-progress-bar.spec.js
@@ -12,8 +12,7 @@ describe('OnsProgressBarElement', () => {
     expect(window.ons.ProgressBarElement).to.be.ok;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides modifier attribute', () => {
+  onlyChrome(it)('provides modifier attribute', () => {
     var template = progress._template,
       primary = progress._primary,
       secondary = progress._secondary;
@@ -36,8 +35,7 @@ describe('OnsProgressBarElement', () => {
   });
 
   describe('#_updateDeterminate()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is called when the "indeterminate" attribute is changed', () => {
+    onlyChrome(it)('is called when the "indeterminate" attribute is changed', () => {
       const spy = chai.spy.on(progress, '_updateDeterminate');
 
       progress.setAttribute('indeterminate', '');
@@ -48,16 +46,14 @@ describe('OnsProgressBarElement', () => {
   });
 
   describe('#_updateValue()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is called when the "value" attribute is changed', () => {
+    onlyChrome(it)('is called when the "value" attribute is changed', () => {
       const spy = chai.spy.on(progress, '_updateValue');
 
       progress.setAttribute('value', '10');
       expect(spy).to.have.been.called.once;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is called when the "secondary-value" attribute is changed', () => {
+    onlyChrome(it)('is called when the "secondary-value" attribute is changed', () => {
       const spy = chai.spy.on(progress, '_updateValue');
 
       progress.setAttribute('secondary-value', '10');
@@ -66,8 +62,7 @@ describe('OnsProgressBarElement', () => {
   });
 
   describe('#_compile()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is called when an element is created', () => {
+    onlyChrome(it)('is called when an element is created', () => {
       const spy = chai.spy.on(window.ons.ProgressBarElement.prototype, '_compile');
       ons._util.createElement('<ons-progress-bar> </ons-progress-bar>');
 

--- a/core/src/elements/ons-progress-circular.spec.js
+++ b/core/src/elements/ons-progress-circular.spec.js
@@ -12,8 +12,7 @@ describe('OnsProgressCircularElement', () => {
     expect(window.ons.ProgressCircularElement).to.be.ok;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides modifier attribute', () => {
+  onlyChrome(it)('provides modifier attribute', () => {
     var template = progress._template,
       primary = progress._primary,
       secondary = progress._secondary;
@@ -36,8 +35,7 @@ describe('OnsProgressCircularElement', () => {
   });
 
   describe('#_updateDeterminate()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is called when the "indeterminate" attribute is changed', () => {
+    onlyChrome(it)('is called when the "indeterminate" attribute is changed', () => {
       const spy = chai.spy.on(progress, '_updateDeterminate');
 
       progress.setAttribute('indeterminate', '');
@@ -48,16 +46,14 @@ describe('OnsProgressCircularElement', () => {
   });
 
   describe('#_updateValue()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is called when the "value" attribute is changed', () => {
+    onlyChrome(it)('is called when the "value" attribute is changed', () => {
       const spy = chai.spy.on(progress, '_updateValue');
 
       progress.setAttribute('value', '10');
       expect(spy).to.have.been.called.once;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is called when the "secondary-value" attribute is changed', () => {
+    onlyChrome(it)('is called when the "secondary-value" attribute is changed', () => {
       const spy = chai.spy.on(progress, '_updateValue');
 
       progress.setAttribute('secondary-value', '10');
@@ -66,8 +62,7 @@ describe('OnsProgressCircularElement', () => {
   });
 
   describe('#_compile()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is called when an element is created', () => {
+    onlyChrome(it)('is called when an element is created', () => {
       const spy = chai.spy.on(window.ons.ProgressCircularElement.prototype, '_compile');
       ons._util.createElement('<ons-progress-circular> </ons-progress-circular>');
 

--- a/core/src/elements/ons-progress-circular.spec.js
+++ b/core/src/elements/ons-progress-circular.spec.js
@@ -12,6 +12,7 @@ describe('OnsProgressCircularElement', () => {
     expect(window.ons.ProgressCircularElement).to.be.ok;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides modifier attribute', () => {
     var template = progress._template,
       primary = progress._primary,
@@ -35,6 +36,7 @@ describe('OnsProgressCircularElement', () => {
   });
 
   describe('#_updateDeterminate()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is called when the "indeterminate" attribute is changed', () => {
       const spy = chai.spy.on(progress, '_updateDeterminate');
 
@@ -46,6 +48,7 @@ describe('OnsProgressCircularElement', () => {
   });
 
   describe('#_updateValue()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is called when the "value" attribute is changed', () => {
       const spy = chai.spy.on(progress, '_updateValue');
 
@@ -53,6 +56,7 @@ describe('OnsProgressCircularElement', () => {
       expect(spy).to.have.been.called.once;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is called when the "secondary-value" attribute is changed', () => {
       const spy = chai.spy.on(progress, '_updateValue');
 
@@ -62,6 +66,7 @@ describe('OnsProgressCircularElement', () => {
   });
 
   describe('#_compile()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is called when an element is created', () => {
       const spy = chai.spy.on(window.ons.ProgressCircularElement.prototype, '_compile');
       ons._util.createElement('<ons-progress-circular> </ons-progress-circular>');

--- a/core/src/elements/ons-pull-hook.spec.js
+++ b/core/src/elements/ons-pull-hook.spec.js
@@ -1,7 +1,6 @@
 'use strict';
 
-if (['local_chrome'].indexOf(window.browser) != -1)
-describe('OnsPullHookElement', () => {
+onlyChrome(describe)('OnsPullHookElement', () => {
   it('exists', () => {
     expect(window.ons.PullHookElement).to.be.ok;
   });

--- a/core/src/elements/ons-pull-hook.spec.js
+++ b/core/src/elements/ons-pull-hook.spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+if (['local_chrome'].indexOf(window.browser) != -1)
 describe('OnsPullHookElement', () => {
   it('exists', () => {
     expect(window.ons.PullHookElement).to.be.ok;

--- a/core/src/elements/ons-range.spec.js
+++ b/core/src/elements/ons-range.spec.js
@@ -22,8 +22,7 @@ describe('OnsRangeElement', () => {
     expect(element._input.classList.contains('range')).to.be.true;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides \'modifier\' attribute', () => {
+  onlyChrome(it)('provides \'modifier\' attribute', () => {
     const input = element.querySelector('input');
 
     element.setAttribute('modifier', 'hoge');

--- a/core/src/elements/ons-range.spec.js
+++ b/core/src/elements/ons-range.spec.js
@@ -22,6 +22,7 @@ describe('OnsRangeElement', () => {
     expect(element._input.classList.contains('range')).to.be.true;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides \'modifier\' attribute', () => {
     const input = element.querySelector('input');
 

--- a/core/src/elements/ons-ripple/index.spec.js
+++ b/core/src/elements/ons-ripple/index.spec.js
@@ -71,20 +71,17 @@ describe('OnsRippleElement', () => {
       expect(spy).to.have.been.called.exactly(attributes.length);
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('sets the color of the wave based on the "color" attribute', () => {
+    onlyChrome(it)('sets the color of the wave based on the "color" attribute', () => {
       ripple.setAttribute('color', 'black');
       expect(wave.style.background).to.equal('black');
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('sets the color of the background based on the "color" attribute', () => {
+    onlyChrome(it)('sets the color of the background based on the "color" attribute', () => {
       ripple.setAttribute('color', 'black');
       expect(background.style.background).to.equal('black');
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('sets the color of the background based on the "background" attribute', () => {
+    onlyChrome(it)('sets the color of the background based on the "background" attribute', () => {
       ripple.setAttribute('color', 'black');
       ripple.setAttribute('background', 'rgb(0, 255, 255)');
       expect(background.style.background).to.equal('rgb(0, 255, 255)');
@@ -92,14 +89,12 @@ describe('OnsRippleElement', () => {
       expect(background.style.background).to.equal('rgb(0, 255, 255)');
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('disables background if the "background" attribute is "none"', () => {
+    onlyChrome(it)('disables background if the "background" attribute is "none"', () => {
       ripple.setAttribute('background', 'none');
       expect(background.hasAttribute('disabled')).to.be.true;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('makes sure the background is enabled if "background != none"', () => {
+    onlyChrome(it)('makes sure the background is enabled if "background != none"', () => {
       background.setAttribute('disabled', 'disabled');
       ripple.setAttribute('background', 'rgb(0, 123, 5)');
       expect(background.hasAttribute('disabled')).to.be.false;
@@ -133,8 +128,7 @@ describe('OnsRippleElement', () => {
       expect(coords.r).to.equal(500);
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('cares about it\'s center', () => {
+    onlyChrome(it)('cares about it\'s center', () => {
       ons._util.extend(ripple.style, style);
       ripple.setAttribute('center', 'true');
       const coords = ripple._calculateCoords({clientY: 0, clientX: 0});
@@ -191,8 +185,7 @@ describe('OnsRippleElement', () => {
   });
 
   describe('#_onHold()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('sets _holding', () => {
+    onlyChrome(it)('sets _holding', () => {
       expect(ripple._holding).to.not.be.ok;
       ripple._onHold(e);
       expect(ripple._holding).to.be.ok;
@@ -202,8 +195,7 @@ describe('OnsRippleElement', () => {
   describe('#_onDragStart()', () => {
     itCalls('_rippleAnimation').whenUsing('_onDragStart', e);
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('calls _onRelease', () => {
+    onlyChrome(it)('calls _onRelease', () => {
       const spy = spyOn('_onRelease');
 
       ripple._onHold(e);
@@ -213,8 +205,7 @@ describe('OnsRippleElement', () => {
   });
 
   describe('#_onRelease()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('unsets _holding', () => {
+    onlyChrome(it)('unsets _holding', () => {
       ripple._onHold(e);
       expect(ripple._holding).to.be.ok;
       ripple._onRelease(e);

--- a/core/src/elements/ons-ripple/index.spec.js
+++ b/core/src/elements/ons-ripple/index.spec.js
@@ -71,16 +71,19 @@ describe('OnsRippleElement', () => {
       expect(spy).to.have.been.called.exactly(attributes.length);
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('sets the color of the wave based on the "color" attribute', () => {
       ripple.setAttribute('color', 'black');
       expect(wave.style.background).to.equal('black');
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('sets the color of the background based on the "color" attribute', () => {
       ripple.setAttribute('color', 'black');
       expect(background.style.background).to.equal('black');
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('sets the color of the background based on the "background" attribute', () => {
       ripple.setAttribute('color', 'black');
       ripple.setAttribute('background', 'rgb(0, 255, 255)');
@@ -89,11 +92,13 @@ describe('OnsRippleElement', () => {
       expect(background.style.background).to.equal('rgb(0, 255, 255)');
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('disables background if the "background" attribute is "none"', () => {
       ripple.setAttribute('background', 'none');
       expect(background.hasAttribute('disabled')).to.be.true;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('makes sure the background is enabled if "background != none"', () => {
       background.setAttribute('disabled', 'disabled');
       ripple.setAttribute('background', 'rgb(0, 123, 5)');
@@ -128,6 +133,7 @@ describe('OnsRippleElement', () => {
       expect(coords.r).to.equal(500);
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('cares about it\'s center', () => {
       ons._util.extend(ripple.style, style);
       ripple.setAttribute('center', 'true');
@@ -185,6 +191,7 @@ describe('OnsRippleElement', () => {
   });
 
   describe('#_onHold()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('sets _holding', () => {
       expect(ripple._holding).to.not.be.ok;
       ripple._onHold(e);
@@ -195,6 +202,7 @@ describe('OnsRippleElement', () => {
   describe('#_onDragStart()', () => {
     itCalls('_rippleAnimation').whenUsing('_onDragStart', e);
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('calls _onRelease', () => {
       const spy = spyOn('_onRelease');
 
@@ -205,6 +213,7 @@ describe('OnsRippleElement', () => {
   });
 
   describe('#_onRelease()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('unsets _holding', () => {
       ripple._onHold(e);
       expect(ripple._holding).to.be.ok;

--- a/core/src/elements/ons-speed-dial-item.spec.js
+++ b/core/src/elements/ons-speed-dial-item.spec.js
@@ -16,8 +16,7 @@ describe('OnsSpeedDialItemElement', () => {
     expect(window.ons.SpeedDialItemElement).to.be.ok;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides modifier attribute', () => {
+  onlyChrome(it)('provides modifier attribute', () => {
     item.setAttribute('modifier', 'hoge');
     expect(item.classList.contains('speed-dial__item--hoge')).to.be.true;
 

--- a/core/src/elements/ons-speed-dial-item.spec.js
+++ b/core/src/elements/ons-speed-dial-item.spec.js
@@ -16,6 +16,7 @@ describe('OnsSpeedDialItemElement', () => {
     expect(window.ons.SpeedDialItemElement).to.be.ok;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides modifier attribute', () => {
     item.setAttribute('modifier', 'hoge');
     expect(item.classList.contains('speed-dial__item--hoge')).to.be.true;

--- a/core/src/elements/ons-speed-dial.spec.js
+++ b/core/src/elements/ons-speed-dial.spec.js
@@ -26,8 +26,7 @@ describe('OnsSpeedDialElement', () => {
     expect(window.ons.SpeedDialElement).to.be.ok;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides modifier attribute', () => {
+  onlyChrome(it)('provides modifier attribute', () => {
     speedDial.setAttribute('modifier', 'hoge');
     expect(speedDial.classList.contains('speed-dial--hoge')).to.be.true;
 
@@ -91,8 +90,7 @@ describe('OnsSpeedDialElement', () => {
   });
 
   describe('#_updateDirection()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is called when element is created', () => {
+    onlyChrome(it)('is called when element is created', () => {
       const spy = chai.spy.on(window.ons.SpeedDialElement.prototype, '_updateDirection');
       const speedDial = ons._util.createElement(`
           <ons-speed-dial direction="up"><ons-fab></ons-fab></ons-speed-dial>
@@ -101,8 +99,7 @@ describe('OnsSpeedDialElement', () => {
       expect(spy).to.have.been.called.with('up');
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is called with the value of the direction attribute', () => {
+    onlyChrome(it)('is called with the value of the direction attribute', () => {
       const spy = chai.spy.on(window.ons.SpeedDialElement.prototype, '_updateDirection');
       const speedDial = ons._util.createElement(`
           <ons-speed-dial direction="down"><ons-fab></ons-fab></ons-speed-dial>
@@ -111,8 +108,7 @@ describe('OnsSpeedDialElement', () => {
       expect(spy).to.have.been.called.with('down');
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is called when direction changes', () => {
+    onlyChrome(it)('is called when direction changes', () => {
       const spy = chai.spy.on(speedDial, '_updateDirection');
 
       speedDial.setAttribute('direction', 'left');
@@ -132,8 +128,7 @@ describe('OnsSpeedDialElement', () => {
   });
 
   describe('#_updatePosition()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('is called when the "position" attribute changes', () => {
+    onlyChrome(it)('is called when the "position" attribute changes', () => {
       const spy = chai.spy.on(speedDial, '_updatePosition');
 
       speedDial.setAttribute('position', 'top left');
@@ -142,8 +137,7 @@ describe('OnsSpeedDialElement', () => {
       expect(spy).to.have.been.called.twice;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('adds the correct class', () => {
+    onlyChrome(it)('adds the correct class', () => {
       speedDial.setAttribute('position', 'top right');
       expect(speedDial.classList.contains('fab--top__right')).to.be.true;
 
@@ -248,8 +242,7 @@ describe('OnsSpeedDialElement', () => {
   });
 
   describe('#set disabled()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('disables it\'s direct fab element', () => {
+    onlyChrome(it)('disables it\'s direct fab element', () => {
       speedDial.disabled = true;
       expect(ons._util.findChild(speedDial, '.fab').disabled).to.be.true;
     });

--- a/core/src/elements/ons-speed-dial.spec.js
+++ b/core/src/elements/ons-speed-dial.spec.js
@@ -26,6 +26,7 @@ describe('OnsSpeedDialElement', () => {
     expect(window.ons.SpeedDialElement).to.be.ok;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides modifier attribute', () => {
     speedDial.setAttribute('modifier', 'hoge');
     expect(speedDial.classList.contains('speed-dial--hoge')).to.be.true;
@@ -90,6 +91,7 @@ describe('OnsSpeedDialElement', () => {
   });
 
   describe('#_updateDirection()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is called when element is created', () => {
       const spy = chai.spy.on(window.ons.SpeedDialElement.prototype, '_updateDirection');
       const speedDial = ons._util.createElement(`
@@ -99,6 +101,7 @@ describe('OnsSpeedDialElement', () => {
       expect(spy).to.have.been.called.with('up');
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is called with the value of the direction attribute', () => {
       const spy = chai.spy.on(window.ons.SpeedDialElement.prototype, '_updateDirection');
       const speedDial = ons._util.createElement(`
@@ -108,6 +111,7 @@ describe('OnsSpeedDialElement', () => {
       expect(spy).to.have.been.called.with('down');
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is called when direction changes', () => {
       const spy = chai.spy.on(speedDial, '_updateDirection');
 
@@ -128,6 +132,7 @@ describe('OnsSpeedDialElement', () => {
   });
 
   describe('#_updatePosition()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('is called when the "position" attribute changes', () => {
       const spy = chai.spy.on(speedDial, '_updatePosition');
 
@@ -137,6 +142,7 @@ describe('OnsSpeedDialElement', () => {
       expect(spy).to.have.been.called.twice;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('adds the correct class', () => {
       speedDial.setAttribute('position', 'top right');
       expect(speedDial.classList.contains('fab--top__right')).to.be.true;
@@ -242,6 +248,7 @@ describe('OnsSpeedDialElement', () => {
   });
 
   describe('#set disabled()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('disables it\'s direct fab element', () => {
       speedDial.disabled = true;
       expect(ons._util.findChild(speedDial, '.fab').disabled).to.be.true;

--- a/core/src/elements/ons-splitter-content.spec.js
+++ b/core/src/elements/ons-splitter-content.spec.js
@@ -50,8 +50,7 @@ describe('ons-splitter-content', () => {
   });
 
   describe('#load()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns a promise that resolves to the new page element', () => {
+    onlyChrome(it)('returns a promise that resolves to the new page element', () => {
       return expect(content.load('hoge.html')).to.eventually.be.fulfilled.then(
         page => {
           expect(page).to.equal(content.children[0]);

--- a/core/src/elements/ons-splitter-content.spec.js
+++ b/core/src/elements/ons-splitter-content.spec.js
@@ -50,6 +50,7 @@ describe('ons-splitter-content', () => {
   });
 
   describe('#load()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns a promise that resolves to the new page element', () => {
       return expect(content.load('hoge.html')).to.eventually.be.fulfilled.then(
         page => {

--- a/core/src/elements/ons-splitter-side.spec.js
+++ b/core/src/elements/ons-splitter-side.spec.js
@@ -55,6 +55,7 @@ describe('OnsSplitterSideElement', () => {
       template = null;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns a promise that resolves to the new page element', () => {
       return expect(left.load('hoge.html')).to.eventually.be.fulfilled.then(page => {
         expect(page).to.equal(left.children[0]);
@@ -64,6 +65,7 @@ describe('OnsSplitterSideElement', () => {
   });
 
   describe('#open()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('should open ons-splitter-side', () => {
       return expect(right.open()).to.eventually.be.fulfilled.then(element => {
         expect(element).to.equal(right);
@@ -73,6 +75,7 @@ describe('OnsSplitterSideElement', () => {
   });
 
   describe('#close()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('should close ons-splitter-side', () => {
       return right.open().then(() => {
         return expect(right.close()).to.eventually.be.fulfilled.then(element => {
@@ -84,6 +87,7 @@ describe('OnsSplitterSideElement', () => {
   });
 
   describe('#isOpen', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('should return boolean', (done) => {
       expect(right.isOpen).to.be.false;
       expect(left.isOpen).to.be.false;
@@ -95,6 +99,7 @@ describe('OnsSplitterSideElement', () => {
   });
 
   describe('#toggle()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('toggle open or close state', (done) => {
       expect(right.isOpen).to.be.false;
       right.toggle({callback: () => {

--- a/core/src/elements/ons-splitter-side.spec.js
+++ b/core/src/elements/ons-splitter-side.spec.js
@@ -55,8 +55,7 @@ describe('OnsSplitterSideElement', () => {
       template = null;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns a promise that resolves to the new page element', () => {
+    onlyChrome(it)('returns a promise that resolves to the new page element', () => {
       return expect(left.load('hoge.html')).to.eventually.be.fulfilled.then(page => {
         expect(page).to.equal(left.children[0]);
         expect(left.getElementsByClassName('page__content')[0].innerHTML).to.equal('hoge');
@@ -65,8 +64,7 @@ describe('OnsSplitterSideElement', () => {
   });
 
   describe('#open()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('should open ons-splitter-side', () => {
+    onlyChrome(it)('should open ons-splitter-side', () => {
       return expect(right.open()).to.eventually.be.fulfilled.then(element => {
         expect(element).to.equal(right);
         return expect(left.open()).to.eventually.be.fulfilled.then(element => expect(element).not.to.be.ok);
@@ -75,8 +73,7 @@ describe('OnsSplitterSideElement', () => {
   });
 
   describe('#close()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('should close ons-splitter-side', () => {
+    onlyChrome(it)('should close ons-splitter-side', () => {
       return right.open().then(() => {
         return expect(right.close()).to.eventually.be.fulfilled.then(element => {
           expect(element).to.equal(right);
@@ -87,8 +84,7 @@ describe('OnsSplitterSideElement', () => {
   });
 
   describe('#isOpen', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('should return boolean', (done) => {
+    onlyChrome(it)('should return boolean', (done) => {
       expect(right.isOpen).to.be.false;
       expect(left.isOpen).to.be.false;
       right.open({callback: () => {
@@ -99,8 +95,7 @@ describe('OnsSplitterSideElement', () => {
   });
 
   describe('#toggle()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('toggle open or close state', (done) => {
+    onlyChrome(it)('toggle open or close state', (done) => {
       expect(right.isOpen).to.be.false;
       right.toggle({callback: () => {
         expect(right.isOpen).to.be.true;

--- a/core/src/elements/ons-switch.spec.js
+++ b/core/src/elements/ons-switch.spec.js
@@ -31,8 +31,7 @@ describe('OnsSwitchElement', () => {
   });
 
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides \'modifier\' attribute', () => {
+  onlyChrome(it)('provides \'modifier\' attribute', () => {
     element.setAttribute('modifier', 'hoge');
     expect(element.classList.contains('switch--hoge')).to.be.true;
 
@@ -52,16 +51,14 @@ describe('OnsSwitchElement', () => {
       expect(element.checked).to.be.a('boolean');
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('adds the \'checked\' attribute when set to true', () => {
+    onlyChrome(it)('adds the \'checked\' attribute when set to true', () => {
       element.removeAttribute('checked');
       element.checked = true;
       expect(element.hasAttribute('checked')).to.be.true;
       expect(element._checkbox.hasAttribute('checked')).to.be.true;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('removes the \'checked\' attribute when set to false', () => {
+    onlyChrome(it)('removes the \'checked\' attribute when set to false', () => {
       element.setAttribute('checked', '');
       expect(element.checked).to.be.true;
       element.checked = false;
@@ -84,8 +81,7 @@ describe('OnsSwitchElement', () => {
       expect(element.hasAttribute('disabled')).to.be.true;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('removes the \'disabled\' attribute when set to false', () => {
+    onlyChrome(it)('removes the \'disabled\' attribute when set to false', () => {
       element.setAttribute('disabled', '');
       expect(element.disabled).to.be.true;
       element.disabled = false;
@@ -107,16 +103,14 @@ describe('OnsSwitchElement', () => {
       expect(element.hasAttribute('checked')).to.be.true;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('removes the \'checked\' attribute when set to false', () => {
+    onlyChrome(it)('removes the \'checked\' attribute when set to false', () => {
       element.setAttribute('checked', '');
       expect(element.checked).to.be.true;
       element.checked = false;
       expect(element.hasAttribute('checked')).to.be.false;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('changes the \'checked\' property of it\'s checkbox', () => {
+    onlyChrome(it)('changes the \'checked\' property of it\'s checkbox', () => {
       element.checked = true;
       expect(element._checkbox.checked).to.be.true;
       element.checked = false;
@@ -136,8 +130,7 @@ describe('OnsSwitchElement', () => {
   });
 
   describe('#_onChange()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('adds the \'checked\' attribute', () => {
+    onlyChrome(it)('adds the \'checked\' attribute', () => {
       element.checked = true;
       element._onChange();
       expect(element.hasAttribute('checked')).to.be.true;
@@ -151,15 +144,13 @@ describe('OnsSwitchElement', () => {
   });
 
   describe('#click()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('changes the value of the checkbox', () => {
+    onlyChrome(it)('changes the value of the checkbox', () => {
       expect(element._checkbox.checked).to.be.false;
       element.click();
       expect(element._checkbox.checked).to.be.true;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('cares if it\'s disabled', () => {
+    onlyChrome(it)('cares if it\'s disabled', () => {
       element.disabled = true;
       expect(element._checkbox.checked).to.be.false;
       element.click();
@@ -171,8 +162,7 @@ describe('OnsSwitchElement', () => {
   });
 
   describe('#attributeChangedCallback()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('toggles material design', () => {
+    onlyChrome(it)('toggles material design', () => {
       element._isMaterial = false;
       element.setAttribute('modifier', 'material');
       expect(element._isMaterial).to.be.true;
@@ -180,8 +170,7 @@ describe('OnsSwitchElement', () => {
       expect(element._isMaterial).to.be.false;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('checks the checkbox', () => {
+    onlyChrome(it)('checks the checkbox', () => {
       element.setAttribute('checked', '');
       expect(element._checkbox.checked).to.be.true;
       expect(element._checkbox.hasAttribute('checked')).to.be.true;
@@ -190,8 +179,7 @@ describe('OnsSwitchElement', () => {
       expect(element._checkbox.hasAttribute('checked')).to.be.false;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('disables the checkbox', () => {
+    onlyChrome(it)('disables the checkbox', () => {
       element.setAttribute('disabled', '');
       expect(element._checkbox.disabled).to.be.true;
       expect(element._checkbox.hasAttribute('disabled')).to.be.true;
@@ -200,8 +188,7 @@ describe('OnsSwitchElement', () => {
       expect(element._checkbox.hasAttribute('disabled')).to.be.false;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('changes the inner input ID', () => {
+    onlyChrome(it)('changes the inner input ID', () => {
       element.setAttribute('input-id', 'myID');
       expect(element._checkbox.id).to.equal('myID');
     });

--- a/core/src/elements/ons-switch.spec.js
+++ b/core/src/elements/ons-switch.spec.js
@@ -31,6 +31,7 @@ describe('OnsSwitchElement', () => {
   });
 
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides \'modifier\' attribute', () => {
     element.setAttribute('modifier', 'hoge');
     expect(element.classList.contains('switch--hoge')).to.be.true;
@@ -51,6 +52,7 @@ describe('OnsSwitchElement', () => {
       expect(element.checked).to.be.a('boolean');
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('adds the \'checked\' attribute when set to true', () => {
       element.removeAttribute('checked');
       element.checked = true;
@@ -58,6 +60,7 @@ describe('OnsSwitchElement', () => {
       expect(element._checkbox.hasAttribute('checked')).to.be.true;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('removes the \'checked\' attribute when set to false', () => {
       element.setAttribute('checked', '');
       expect(element.checked).to.be.true;
@@ -81,6 +84,7 @@ describe('OnsSwitchElement', () => {
       expect(element.hasAttribute('disabled')).to.be.true;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('removes the \'disabled\' attribute when set to false', () => {
       element.setAttribute('disabled', '');
       expect(element.disabled).to.be.true;
@@ -103,6 +107,7 @@ describe('OnsSwitchElement', () => {
       expect(element.hasAttribute('checked')).to.be.true;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('removes the \'checked\' attribute when set to false', () => {
       element.setAttribute('checked', '');
       expect(element.checked).to.be.true;
@@ -110,6 +115,7 @@ describe('OnsSwitchElement', () => {
       expect(element.hasAttribute('checked')).to.be.false;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('changes the \'checked\' property of it\'s checkbox', () => {
       element.checked = true;
       expect(element._checkbox.checked).to.be.true;
@@ -130,6 +136,7 @@ describe('OnsSwitchElement', () => {
   });
 
   describe('#_onChange()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('adds the \'checked\' attribute', () => {
       element.checked = true;
       element._onChange();
@@ -144,12 +151,14 @@ describe('OnsSwitchElement', () => {
   });
 
   describe('#click()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('changes the value of the checkbox', () => {
       expect(element._checkbox.checked).to.be.false;
       element.click();
       expect(element._checkbox.checked).to.be.true;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('cares if it\'s disabled', () => {
       element.disabled = true;
       expect(element._checkbox.checked).to.be.false;
@@ -162,6 +171,7 @@ describe('OnsSwitchElement', () => {
   });
 
   describe('#attributeChangedCallback()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('toggles material design', () => {
       element._isMaterial = false;
       element.setAttribute('modifier', 'material');
@@ -170,6 +180,7 @@ describe('OnsSwitchElement', () => {
       expect(element._isMaterial).to.be.false;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('checks the checkbox', () => {
       element.setAttribute('checked', '');
       expect(element._checkbox.checked).to.be.true;
@@ -179,6 +190,7 @@ describe('OnsSwitchElement', () => {
       expect(element._checkbox.hasAttribute('checked')).to.be.false;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('disables the checkbox', () => {
       element.setAttribute('disabled', '');
       expect(element._checkbox.disabled).to.be.true;
@@ -188,6 +200,7 @@ describe('OnsSwitchElement', () => {
       expect(element._checkbox.hasAttribute('disabled')).to.be.false;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('changes the inner input ID', () => {
       element.setAttribute('input-id', 'myID');
       expect(element._checkbox.id).to.equal('myID');

--- a/core/src/elements/ons-tab.spec.js
+++ b/core/src/elements/ons-tab.spec.js
@@ -1,5 +1,7 @@
 'use strict';
 
+// beforeEach and afterEach are broken on particular browsers
+if (['local_chrome'].indexOf(window.browser) != -1)
 describe('OnsTabElement', () => {
   let element;
 
@@ -43,6 +45,7 @@ describe('OnsTabElement', () => {
   });
 
   describe('modifier attribute', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('modifies the classList of the tab', () => {
       const parent = ons._util.createElement(`
         <ons-tabbar>
@@ -100,6 +103,7 @@ describe('OnsTabElement', () => {
   });
 
   describe('icon attribute', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('sets icon name for the tab', done => {
       const tabbar = ons._util.createElement(`
         <ons-tabbar>
@@ -128,6 +132,7 @@ describe('OnsTabElement', () => {
   });
 
   describe('label attribute', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('sets label name for the tab', done => {
       const tabbar = ons._util.createElement(`
         <ons-tabbar>
@@ -154,6 +159,7 @@ describe('OnsTabElement', () => {
   });
 
   describe('badge attribute', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('sets badge for the tab', done => {
       const tabbar = ons._util.createElement(`
         <ons-tabbar>
@@ -258,6 +264,7 @@ describe('OnsTabElement', () => {
   });
 
   describe('#setActive()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('will set the tab as active', done => {
       const tabbar = ons._util.createElement(`
         <ons-tabbar>

--- a/core/src/elements/ons-tab.spec.js
+++ b/core/src/elements/ons-tab.spec.js
@@ -1,8 +1,6 @@
 'use strict';
 
-// beforeEach and afterEach are broken on particular browsers
-if (['local_chrome'].indexOf(window.browser) != -1)
-describe('OnsTabElement', () => {
+onlyChrome(describe)('OnsTabElement', () => {
   let element;
 
   beforeEach(done => {
@@ -45,8 +43,7 @@ describe('OnsTabElement', () => {
   });
 
   describe('modifier attribute', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('modifies the classList of the tab', () => {
+    onlyChrome(it)('modifies the classList of the tab', () => {
       const parent = ons._util.createElement(`
         <ons-tabbar>
         </ons-tabbar>
@@ -103,8 +100,7 @@ describe('OnsTabElement', () => {
   });
 
   describe('icon attribute', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('sets icon name for the tab', done => {
+    onlyChrome(it)('sets icon name for the tab', done => {
       const tabbar = ons._util.createElement(`
         <ons-tabbar>
         </ons-tabbar>
@@ -132,8 +128,7 @@ describe('OnsTabElement', () => {
   });
 
   describe('label attribute', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('sets label name for the tab', done => {
+    onlyChrome(it)('sets label name for the tab', done => {
       const tabbar = ons._util.createElement(`
         <ons-tabbar>
         </ons-tabbar>
@@ -159,8 +154,7 @@ describe('OnsTabElement', () => {
   });
 
   describe('badge attribute', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('sets badge for the tab', done => {
+    onlyChrome(it)('sets badge for the tab', done => {
       const tabbar = ons._util.createElement(`
         <ons-tabbar>
         </ons-tabbar>
@@ -264,8 +258,7 @@ describe('OnsTabElement', () => {
   });
 
   describe('#setActive()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('will set the tab as active', done => {
+    onlyChrome(it)('will set the tab as active', done => {
       const tabbar = ons._util.createElement(`
         <ons-tabbar>
           <ons-tab id="tab1" page="page1"></ons-tab><ons-tab id="tab2" page="page2"></ons-tab>

--- a/core/src/elements/ons-tabbar/index.spec.js
+++ b/core/src/elements/ons-tabbar/index.spec.js
@@ -23,8 +23,7 @@ describe('OnsTabbarElement', () => {
     expect(window.ons.TabbarElement).to.be.ok;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides \'modifier\' attribute', () => {
+  onlyChrome(it)('provides \'modifier\' attribute', () => {
     document.body.appendChild(element);
     element.setAttribute('modifier', 'hoge');
 
@@ -48,8 +47,7 @@ describe('OnsTabbarElement', () => {
     expect(element.children[1].classList.contains('tab-bar--fuga')).to.be.true;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('has \'position\' attribute', function(done) {
+  onlyChrome(it)('has \'position\' attribute', function(done) {
     var div = document.createElement('div');
     document.body.appendChild(div);
     ons.platform.select('android');
@@ -111,8 +109,7 @@ describe('OnsTabbarElement', () => {
   });
 
   describe('#setTabbarVisibility()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('sets the element visible or invisible', () => {
+    onlyChrome(it)('sets the element visible or invisible', () => {
       var div = document.createElement('div');
       document.body.appendChild(div);
       div.innerHTML = `
@@ -164,8 +161,7 @@ describe('OnsTabbarElement', () => {
   });
 
   describe('#getActiveTabIndex()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('has active tab property', function(done) {
+    onlyChrome(it)('has active tab property', function(done) {
       const div = document.createElement('div');
       document.body.appendChild(div);
       div.innerHTML = `
@@ -214,8 +210,7 @@ describe('OnsTabbarElement', () => {
       template = element = null;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('fires \'prechange\' event', () => {
+    onlyChrome(it)('fires \'prechange\' event', () => {
       const promise = new Promise((resolve) => {
         element.addEventListener('prechange', resolve);
       });
@@ -223,8 +218,7 @@ describe('OnsTabbarElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('fires \'postchange\' event', () => {
+    onlyChrome(it)('fires \'postchange\' event', () => {
       const promise = new Promise((resolve) => {
         element.addEventListener('postchange', resolve);
       });
@@ -232,8 +226,7 @@ describe('OnsTabbarElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('fires \'reactive\' event', () => {
+    onlyChrome(it)('fires \'reactive\' event', () => {
       const promise = new Promise((resolve) => {
         element.addEventListener('reactive', resolve);
       });
@@ -264,8 +257,7 @@ describe('OnsTabbarElement', () => {
       template = element = null;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('fires \'init\' event', () => {
+    onlyChrome(it)('fires \'init\' event', () => {
       const promise = new Promise((resolve) => {
         element.addEventListener('init', resolve);
       });
@@ -273,8 +265,7 @@ describe('OnsTabbarElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('fires \'show\' event', () => {
+    onlyChrome(it)('fires \'show\' event', () => {
       const promise = new Promise((resolve) => {
         element.addEventListener('show', resolve);
       });
@@ -282,8 +273,7 @@ describe('OnsTabbarElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('fires \'hide\' event', () => {
+    onlyChrome(it)('fires \'hide\' event', () => {
       const promise = new Promise((resolve) => {
         element.addEventListener('hide', resolve);
       });
@@ -296,8 +286,7 @@ describe('OnsTabbarElement', () => {
   });
 
   describe('#loadPage()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('loads a page', (done) => {
+    onlyChrome(it)('loads a page', (done) => {
       const element = ons._util.createElement(`
         <ons-tabbar>
           <ons-tab label="Hoge"></ons-tab>
@@ -315,8 +304,7 @@ describe('OnsTabbarElement', () => {
       });
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns a promise that resolves to the new page', () => {
+    onlyChrome(it)('returns a promise that resolves to the new page', () => {
       expect(element.innerHTML.indexOf('fugafuga')).to.be.below(0);
       return expect(element.loadPage('fuga')).to.eventually.be.fulfilled.then(page => {
         expect(element.innerHTML.indexOf('fugafuga')).not.to.be.below(0);
@@ -330,8 +318,7 @@ describe('OnsTabbarElement', () => {
       return expect(element.setActiveTab(0)).to.eventually.be.rejected;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('can be canceled', (done) => {
+    onlyChrome(it)('can be canceled', (done) => {
       const element = ons._util.createElement(`
         <ons-tabbar>
           <ons-tab label="Hoge" page="hoge"></ons-tab>
@@ -349,8 +336,7 @@ describe('OnsTabbarElement', () => {
       expect(element.setActiveTab(0)).to.be.false;
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('does not remove tabs', (done) => {
+    onlyChrome(it)('does not remove tabs', (done) => {
       const element = ons._util.createElement(`
         <ons-tabbar>
           <ons-tab label="Hoge" page="hoge"></ons-tab>
@@ -369,8 +355,7 @@ describe('OnsTabbarElement', () => {
       });
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns a promise that resolves to the new page', () => {
+    onlyChrome(it)('returns a promise that resolves to the new page', () => {
       const element = ons._util.createElement(`
         <ons-tabbar>
           <ons-tab label="Hoge" page="hoge" active="true"></ons-tab>

--- a/core/src/elements/ons-tabbar/index.spec.js
+++ b/core/src/elements/ons-tabbar/index.spec.js
@@ -23,6 +23,7 @@ describe('OnsTabbarElement', () => {
     expect(window.ons.TabbarElement).to.be.ok;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides \'modifier\' attribute', () => {
     document.body.appendChild(element);
     element.setAttribute('modifier', 'hoge');
@@ -47,6 +48,7 @@ describe('OnsTabbarElement', () => {
     expect(element.children[1].classList.contains('tab-bar--fuga')).to.be.true;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('has \'position\' attribute', function(done) {
     var div = document.createElement('div');
     document.body.appendChild(div);
@@ -109,6 +111,7 @@ describe('OnsTabbarElement', () => {
   });
 
   describe('#setTabbarVisibility()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('sets the element visible or invisible', () => {
       var div = document.createElement('div');
       document.body.appendChild(div);
@@ -161,6 +164,7 @@ describe('OnsTabbarElement', () => {
   });
 
   describe('#getActiveTabIndex()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('has active tab property', function(done) {
       const div = document.createElement('div');
       document.body.appendChild(div);
@@ -210,6 +214,7 @@ describe('OnsTabbarElement', () => {
       template = element = null;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('fires \'prechange\' event', () => {
       const promise = new Promise((resolve) => {
         element.addEventListener('prechange', resolve);
@@ -218,6 +223,7 @@ describe('OnsTabbarElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('fires \'postchange\' event', () => {
       const promise = new Promise((resolve) => {
         element.addEventListener('postchange', resolve);
@@ -226,6 +232,7 @@ describe('OnsTabbarElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('fires \'reactive\' event', () => {
       const promise = new Promise((resolve) => {
         element.addEventListener('reactive', resolve);
@@ -257,6 +264,7 @@ describe('OnsTabbarElement', () => {
       template = element = null;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('fires \'init\' event', () => {
       const promise = new Promise((resolve) => {
         element.addEventListener('init', resolve);
@@ -265,6 +273,7 @@ describe('OnsTabbarElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('fires \'show\' event', () => {
       const promise = new Promise((resolve) => {
         element.addEventListener('show', resolve);
@@ -273,6 +282,7 @@ describe('OnsTabbarElement', () => {
       return expect(promise).to.eventually.be.fulfilled;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('fires \'hide\' event', () => {
       const promise = new Promise((resolve) => {
         element.addEventListener('hide', resolve);
@@ -286,6 +296,7 @@ describe('OnsTabbarElement', () => {
   });
 
   describe('#loadPage()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('loads a page', (done) => {
       const element = ons._util.createElement(`
         <ons-tabbar>
@@ -304,6 +315,7 @@ describe('OnsTabbarElement', () => {
       });
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns a promise that resolves to the new page', () => {
       expect(element.innerHTML.indexOf('fugafuga')).to.be.below(0);
       return expect(element.loadPage('fuga')).to.eventually.be.fulfilled.then(page => {
@@ -318,6 +330,7 @@ describe('OnsTabbarElement', () => {
       return expect(element.setActiveTab(0)).to.eventually.be.rejected;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('can be canceled', (done) => {
       const element = ons._util.createElement(`
         <ons-tabbar>
@@ -336,6 +349,7 @@ describe('OnsTabbarElement', () => {
       expect(element.setActiveTab(0)).to.be.false;
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('does not remove tabs', (done) => {
       const element = ons._util.createElement(`
         <ons-tabbar>
@@ -355,6 +369,7 @@ describe('OnsTabbarElement', () => {
       });
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns a promise that resolves to the new page', () => {
       const element = ons._util.createElement(`
         <ons-tabbar>

--- a/core/src/elements/ons-toolbar-button.spec.js
+++ b/core/src/elements/ons-toolbar-button.spec.js
@@ -5,6 +5,7 @@ describe('ons-toolbar-button', () => {
     expect(window.ons.ToolbarButtonElement).to.be.ok;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides modifier attribute', () => {
     var element = new ons.ToolbarButtonElement();
     element.setAttribute('modifier', 'hoge');

--- a/core/src/elements/ons-toolbar-button.spec.js
+++ b/core/src/elements/ons-toolbar-button.spec.js
@@ -5,8 +5,7 @@ describe('ons-toolbar-button', () => {
     expect(window.ons.ToolbarButtonElement).to.be.ok;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides modifier attribute', () => {
+  onlyChrome(it)('provides modifier attribute', () => {
     var element = new ons.ToolbarButtonElement();
     element.setAttribute('modifier', 'hoge');
     expect(element.classList.contains('toolbar-button--hoge')).to.be.true;

--- a/core/src/elements/ons-toolbar.spec.js
+++ b/core/src/elements/ons-toolbar.spec.js
@@ -16,6 +16,7 @@ describe('OnsToolbarElement', () => {
     expect(window.ons.ToolbarElement).to.be.ok;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('provides \'modifier\' attribute', () => {
     element.setAttribute('modifier', 'hoge');
     expect(element.classList.contains('navigation-bar--hoge')).to.be.true;
@@ -46,18 +47,21 @@ describe('OnsToolbarElement', () => {
     expect(element.children[2].classList.contains('navigation-bar--piyo__right')).not.to.be.true;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('has \'left\' class value in its first child', () => {
     expect(element.children[0].classList.contains('navigation-bar__left')).to.be.true;
     expect(element.children[0].classList.contains('navigation-bar__center')).not.to.be.true;
     expect(element.children[0].classList.contains('navigation-bar__right')).not.to.be.true;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('has \'center\' class value in its second child', () => {
     expect(element.children[1].classList.contains('navigation-bar__left')).not.to.be.true;
     expect(element.children[1].classList.contains('navigation-bar__center')).to.be.true;
     expect(element.children[1].classList.contains('navigation-bar__right')).not.to.be.true;
   });
 
+  if (['local_chrome'].indexOf(window.browser) != -1)
   it('has \'right\' class value in its third child', () => {
     expect(element.children[2].classList.contains('navigation-bar__left')).not.to.be.true;
     expect(element.children[2].classList.contains('navigation-bar__center')).not.to.be.true;
@@ -80,11 +84,13 @@ describe('OnsToolbarElement', () => {
   */
 
   describe('#_compile()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('removes non-element children', () => {
       const element = ons._util.createElement('<ons-toolbar>Test1<div class="center">Test2</div></ons-toolbar>');
       expect(element.childNodes[0].nodeValue).not.to.equal('Test1');
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('sorts its children depending on their class', () => {
       const element = ons._util.createElement('<ons-toolbar><div class="center">Test2</div><div class="right">Test3</div><div class="left">Test1</div></ons-toolbar>');
       expect(element.children[0].classList.contains('navigation-bar__left')).to.be.true;
@@ -102,6 +108,7 @@ describe('OnsToolbarElement', () => {
   });
 
   describe('autoStyling', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('adds \'material\' modifier on Android', () => {
       ons.platform.select('android');
       const e = ons._util.createElement('<ons-toolbar>content</ons-toolbar>');

--- a/core/src/elements/ons-toolbar.spec.js
+++ b/core/src/elements/ons-toolbar.spec.js
@@ -16,8 +16,7 @@ describe('OnsToolbarElement', () => {
     expect(window.ons.ToolbarElement).to.be.ok;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('provides \'modifier\' attribute', () => {
+  onlyChrome(it)('provides \'modifier\' attribute', () => {
     element.setAttribute('modifier', 'hoge');
     expect(element.classList.contains('navigation-bar--hoge')).to.be.true;
 
@@ -47,22 +46,19 @@ describe('OnsToolbarElement', () => {
     expect(element.children[2].classList.contains('navigation-bar--piyo__right')).not.to.be.true;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('has \'left\' class value in its first child', () => {
+  onlyChrome(it)('has \'left\' class value in its first child', () => {
     expect(element.children[0].classList.contains('navigation-bar__left')).to.be.true;
     expect(element.children[0].classList.contains('navigation-bar__center')).not.to.be.true;
     expect(element.children[0].classList.contains('navigation-bar__right')).not.to.be.true;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('has \'center\' class value in its second child', () => {
+  onlyChrome(it)('has \'center\' class value in its second child', () => {
     expect(element.children[1].classList.contains('navigation-bar__left')).not.to.be.true;
     expect(element.children[1].classList.contains('navigation-bar__center')).to.be.true;
     expect(element.children[1].classList.contains('navigation-bar__right')).not.to.be.true;
   });
 
-  if (['local_chrome'].indexOf(window.browser) != -1)
-  it('has \'right\' class value in its third child', () => {
+  onlyChrome(it)('has \'right\' class value in its third child', () => {
     expect(element.children[2].classList.contains('navigation-bar__left')).not.to.be.true;
     expect(element.children[2].classList.contains('navigation-bar__center')).not.to.be.true;
     expect(element.children[2].classList.contains('navigation-bar__right')).to.be.true;
@@ -84,14 +80,12 @@ describe('OnsToolbarElement', () => {
   */
 
   describe('#_compile()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('removes non-element children', () => {
+    onlyChrome(it)('removes non-element children', () => {
       const element = ons._util.createElement('<ons-toolbar>Test1<div class="center">Test2</div></ons-toolbar>');
       expect(element.childNodes[0].nodeValue).not.to.equal('Test1');
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('sorts its children depending on their class', () => {
+    onlyChrome(it)('sorts its children depending on their class', () => {
       const element = ons._util.createElement('<ons-toolbar><div class="center">Test2</div><div class="right">Test3</div><div class="left">Test1</div></ons-toolbar>');
       expect(element.children[0].classList.contains('navigation-bar__left')).to.be.true;
       expect(element.children[1].classList.contains('navigation-bar__center')).to.be.true;
@@ -108,8 +102,7 @@ describe('OnsToolbarElement', () => {
   });
 
   describe('autoStyling', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('adds \'material\' modifier on Android', () => {
+    onlyChrome(it)('adds \'material\' modifier on Android', () => {
       ons.platform.select('android');
       const e = ons._util.createElement('<ons-toolbar>content</ons-toolbar>');
       expect(e.getAttribute('modifier')).to.equal('material');

--- a/core/src/ons/internal/lazy-repeat.spec.js
+++ b/core/src/ons/internal/lazy-repeat.spec.js
@@ -71,6 +71,8 @@ describe('LazyRepeatDelegate', () => {
   });
 });
 
+// beforeEach is broken on particular browsers
+if (['local_chrome'].indexOf(window.browser) != -1)
 describe('LazyRepeatProvider', () => {
   let delegate, template, page, wrapper, provider;
 

--- a/core/src/ons/internal/lazy-repeat.spec.js
+++ b/core/src/ons/internal/lazy-repeat.spec.js
@@ -71,9 +71,7 @@ describe('LazyRepeatDelegate', () => {
   });
 });
 
-// beforeEach is broken on particular browsers
-if (['local_chrome'].indexOf(window.browser) != -1)
-describe('LazyRepeatProvider', () => {
+onlyChrome(describe)('LazyRepeatProvider', () => {
   let delegate, template, page, wrapper, provider;
 
   beforeEach(() => {

--- a/core/src/ons/ons.spec.js
+++ b/core/src/ons/ons.spec.js
@@ -94,8 +94,7 @@ describe('ons', () => {
       expect(() => ons.createPopover(null)).to.throw(Error);
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('calls the linking function', (done) => {
+    onlyChrome(it)('calls the linking function', (done) => {
       const options = {};
       options.link = () => { return; };
       var spy = chai.spy.on(options, 'link');
@@ -106,8 +105,7 @@ describe('ons', () => {
       });
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns a valid popover element', (done) => {
+    onlyChrome(it)('returns a valid popover element', (done) => {
       ons.createPopover('page.html').then((element) => {
         expect(element).to.be.instanceof(window.ons.PopoverElement);
         element.remove();
@@ -121,8 +119,7 @@ describe('ons', () => {
       expect(() => ons.createDialog(null)).to.throw(Error);
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('calls the linking function', (done) => {
+    onlyChrome(it)('calls the linking function', (done) => {
       const options = {};
       options.link = () => { return; };
       var spy = chai.spy.on(options, 'link');
@@ -133,8 +130,7 @@ describe('ons', () => {
       });
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns a valid dialog element', (done) => {
+    onlyChrome(it)('returns a valid dialog element', (done) => {
       ons.createDialog('page.html').then((element) => {
         expect(element).to.be.instanceof(window.ons.DialogElement);
         element.remove();
@@ -148,8 +144,7 @@ describe('ons', () => {
       expect(() => ons.createAlertDialog(null)).to.throw(Error);
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('calls the linking function', (done) => {
+    onlyChrome(it)('calls the linking function', (done) => {
       const options = {};
       options.link = () => { return; };
       var spy = chai.spy.on(options, 'link');
@@ -160,8 +155,7 @@ describe('ons', () => {
       });
     });
 
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns a valid alertDialog element', (done) => {
+    onlyChrome(it)('returns a valid alertDialog element', (done) => {
       ons.createAlertDialog('page.html').then((element) => {
         expect(element).to.be.instanceof(window.ons.AlertDialogElement);
         element.remove();

--- a/core/src/ons/ons.spec.js
+++ b/core/src/ons/ons.spec.js
@@ -94,6 +94,7 @@ describe('ons', () => {
       expect(() => ons.createPopover(null)).to.throw(Error);
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('calls the linking function', (done) => {
       const options = {};
       options.link = () => { return; };
@@ -105,6 +106,7 @@ describe('ons', () => {
       });
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns a valid popover element', (done) => {
       ons.createPopover('page.html').then((element) => {
         expect(element).to.be.instanceof(window.ons.PopoverElement);
@@ -119,6 +121,7 @@ describe('ons', () => {
       expect(() => ons.createDialog(null)).to.throw(Error);
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('calls the linking function', (done) => {
       const options = {};
       options.link = () => { return; };
@@ -130,6 +133,7 @@ describe('ons', () => {
       });
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns a valid dialog element', (done) => {
       ons.createDialog('page.html').then((element) => {
         expect(element).to.be.instanceof(window.ons.DialogElement);
@@ -144,6 +148,7 @@ describe('ons', () => {
       expect(() => ons.createAlertDialog(null)).to.throw(Error);
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('calls the linking function', (done) => {
       const options = {};
       options.link = () => { return; };
@@ -155,6 +160,7 @@ describe('ons', () => {
       });
     });
 
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns a valid alertDialog element', (done) => {
       ons.createAlertDialog('page.html').then((element) => {
         expect(element).to.be.instanceof(window.ons.AlertDialogElement);

--- a/core/src/ons/platform.spec.js
+++ b/core/src/ons/platform.spec.js
@@ -124,6 +124,7 @@ describe('ons.platform', () => {
   });
 
   describe('#isChrome()', () => {
+    if (['local_chrome'].indexOf(window.browser) != -1)
     it('returns true if platform is Chrome', () => {
       expect(ons.platform.isChrome()).to.be.true;
     });

--- a/core/src/ons/platform.spec.js
+++ b/core/src/ons/platform.spec.js
@@ -124,8 +124,7 @@ describe('ons.platform', () => {
   });
 
   describe('#isChrome()', () => {
-    if (['local_chrome'].indexOf(window.browser) != -1)
-    it('returns true if platform is Chrome', () => {
+    onlyChrome(it)('returns true if platform is Chrome', () => {
       expect(ons.platform.isChrome()).to.be.true;
     });
 

--- a/core/test/browser-local_chrome.js
+++ b/core/test/browser-local_chrome.js
@@ -1,0 +1,1 @@
+window.browser = 'local_chrome';

--- a/core/test/define-browser-variable.js
+++ b/core/test/define-browser-variable.js
@@ -1,1 +1,0 @@
-window.browser = null; // supposed to be overridden

--- a/core/test/define-browser-variable.js
+++ b/core/test/define-browser-variable.js
@@ -1,0 +1,1 @@
+window.browser = null; // supposed to be overridden

--- a/core/test/karma.conf.js
+++ b/core/test/karma.conf.js
@@ -88,6 +88,21 @@ module.exports = function(config) {
       local_safari: { // alias for `Safari` (defined by `karma-safari-launcher`)
         base: 'Safari',
       },
+      // To use a browser launcher which has `base: 'SauceLabs'`,
+      // set process.env.SAUCE_USERNAME and process.env.SAUCE_ACCESS_KEY.
+      // For more information, see https://github.com/karma-runner/karma-sauce-launcher
+      remote_macos_elcapitan_safari_9: {
+        base: 'SauceLabs',
+        platform: 'OS X 10.11',
+        browserName: 'Safari',
+        version: '9.0',
+      },
+      remote_macos_elcapitan_safari_10: {
+        base: 'SauceLabs',
+        platform: 'OS X 10.11',
+        browserName: 'Safari',
+        version: '10.0',
+      },
 
       ////////////////////////////////////////
       // Mobile - Android Chrome

--- a/core/test/karma.conf.js
+++ b/core/test/karma.conf.js
@@ -16,7 +16,6 @@ module.exports = function(config) {
     files: [
       '../../build/js/onsenui.js',
       '../../core/test/setup.js',
-      '../../core/test/define-browser-variable.js',
       `../../core/test/browser-${global.KARMA_BROWSER}.js`, // no error occurs even if not found 
       global.KARMA_SPEC_FILES || '../../core/src/**/*.spec.js',
       '../../build/css/onsenui.css',

--- a/core/test/karma.conf.js
+++ b/core/test/karma.conf.js
@@ -16,6 +16,7 @@ module.exports = function(config) {
     files: [
       '../../build/js/onsenui.js',
       '../../core/test/setup.js',
+      '../../core/test/define-browser-variable.js',
       `../../core/test/browser-${global.KARMA_BROWSER}.js`, // no error occurs even if not found 
       global.KARMA_SPEC_FILES || '../../core/src/**/*.spec.js',
       '../../build/css/onsenui.css',

--- a/core/test/karma.conf.js
+++ b/core/test/karma.conf.js
@@ -16,6 +16,7 @@ module.exports = function(config) {
     files: [
       '../../build/js/onsenui.js',
       '../../core/test/setup.js',
+      `../../core/test/browser-${global.KARMA_BROWSER}.js`, // no error occurs even if not found 
       global.KARMA_SPEC_FILES || '../../core/src/**/*.spec.js',
       '../../build/css/onsenui.css',
       '../../build/css/onsen-css-components.css'

--- a/core/test/karma.conf.js
+++ b/core/test/karma.conf.js
@@ -54,6 +54,8 @@ module.exports = function(config) {
       type: 'lcov'
     },
 
+    failOnEmptyTestSuite: false,
+
     // web server port
     port: 9876,
 

--- a/core/test/karma.conf.js
+++ b/core/test/karma.conf.js
@@ -228,6 +228,8 @@ module.exports = function(config) {
 
     autoWatchBatchDelay: 500,
 
-    captureTimeout: 15 * 60 * 1000 // Sauce Labs sometimes requires a long time, so default value (60000) is not enough
+    captureTimeout: 15 * 60 * 1000, // Sauce Labs sometimes requires a long time, so default value (60000) is not enough
+
+    browserNoActivityTimeout: 60 * 1000, // same as above, default value (10000) is not enough
   });
 };

--- a/core/test/setup.js
+++ b/core/test/setup.js
@@ -2,4 +2,15 @@
 
 window.browser = null; // supposed to be overridden
 
+window.onlyChrome = (_) => {
+  switch (_) {
+    case it:
+      return (window.browser === 'local_chrome') ? it : xit;
+    case describe:
+      return (window.browser === 'local_chrome') ? describe : xdescribe;
+    default:
+      throw new Error('argument must be `it` or `describe`.');
+  }
+};
+
 ons.disableAnimations();

--- a/core/test/setup.js
+++ b/core/test/setup.js
@@ -1,3 +1,5 @@
 // Code to be executed before the tests
 
+window.browser = null; // supposed to be overridden
+
 ons.disableAnimations();

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -129,13 +129,14 @@ gulp.task('unit-test', ['prepare', 'core', 'core-dts-test'], (done) => {
   //    gulp unit-test --separately --specs "core/src/**/*.spec.js"
   //
   //    # run unit tests in a particular browser
-  //    gulp unit-test --browsers local_chrome # default
+  //    gulp unit-test --browsers local_chrome
   //    gulp unit-test --browsers local_chrome,local_safari # you can use commas
   //    gulp unit-test --browsers remote_iphone_5_simulator_ios_10_0_safari # to use this, see karma.conf.js
+  //    gulp unit-test --browsers local_chrome,remote_macos_elcapitan_safari_10 # default
 
   (async () => {
     const specs = argv.specs || 'core/src/**/*.spec.js'; // you cannot use commas for --specs
-    const browsers = argv.browsers ? argv.browsers.split(',').map(s => s.trim()) : ['local_chrome'];
+    const browsers = argv.browsers ? argv.browsers.split(',').map(s => s.trim()) : ['local_chrome', 'remote_macos_elcapitan_safari_10'];
 
     let listOfSpecFiles;
     if (argv.separately) { // resolve glob pattern


### PR DESCRIPTION
@argelius @frankdiox @anatoo 
I have made the following changes:

- **Change default unit test targets to include remote macOS Safari.**
  - So after this PR, when we need to run unit tests only on chrome, we must use the command `gulp unit-test --browsers local_chrome`. 
- **Make some unit tests run only on Chrome.**
- Add custom browser launchers which launch Safari on remote Mac instance.
- Fix a broken unit test case (in `ons-popover/index.spec.js`).
  - So the number of tests increased from 685 to 686.

If there is no problem, could you merge this PR?