### PR TITLE
Fix angular2 navigator init

### DIFF
--- a/bindings/angular2/CHANGELOG.md
+++ b/bindings/angular2/CHANGELOG.md
@@ -12,6 +12,9 @@ CHANGELOG
 1.0.0-rc.4 (Work In Progress)
 ----
 
+### Bug fixes
+ * Force change detection when pushing pages to correctly refresh view.
+
 -->
 
 1.0.0-rc.3 (2016-11-15)

--- a/bindings/angular2/src/directives/ons-navigator.ts
+++ b/bindings/angular2/src/directives/ons-navigator.ts
@@ -107,6 +107,11 @@ export class OnsNavigator implements OnDestroy {
 
         this.element.appendChild(pageElement); // dirty fix to insert in correct position
 
+        /**
+         * Force change detection to refresh view.
+         */
+        pageComponentRef.changeDetectorRef.detectChanges();
+
         done(pageElement);
       },
       element => {


### PR DESCRIPTION
@anatoo @asial-matagawa 

I think we need to force change detection when loading a page for the navigator. Otherwise, the view won't be updated. I had an issue where the first page was not displayed correctly and this changed fixed it. 

Maybe it's because the first page is pushed outside the zone. :question: 

EDIT: Actually, with this fix I am still having an issue with change detection not happening inside asynchronous callbacks. Zone.js is supposed to take care of that but maybe it doesn't work in dynamically created components?