### PR TITLE
Fix angular2 params

### DIFF
--- a/bindings/angular2/CHANGELOG.md
+++ b/bindings/angular2/CHANGELOG.md
@@ -12,6 +12,9 @@ CHANGELOG
 1.0.0-rc.4 (Work In Progress)
 ----
 
+### Bug Fixes
+ * Navigator params should accept any type.
+
 -->
 
 1.0.0-rc.3 (2016-11-15)

--- a/bindings/angular2/src/ons/params.ts
+++ b/bindings/angular2/src/ons/params.ts
@@ -6,7 +6,7 @@ export class Params {
     return this._data[key];
   }
 
-  get data(): Object {
+  get data(): any {
     return this._data;
   }
 }


### PR DESCRIPTION
@anatoo @asial-matagawa 

I think this is nice in order to accept things other than objects in the parameters. What do you think?

This failed before:

```
const foo = new Foo();
this._navigator.element.pushPage(PageComponent, {animation: 'slide', data: {foo}});
```