### PR TITLE
test(ons-lazy-repeat): Avoid scrollTop limit issue.

### DIFF
--- a/core/src/ons/internal/lazy-repeat.spec.js
+++ b/core/src/ons/internal/lazy-repeat.spec.js
@@ -160,7 +160,8 @@ onlyChrome(describe)('LazyRepeatProvider', () => {
 
       const pageContent = page.querySelector('.page__content');
       pageContent.scrollTop = 10000;
-
+      provider._render();
+      pageContent.scrollTop = 10000;
       provider._render();
       expect(provider._renderedItems.hasOwnProperty(0)).to.be.false;
     });


### PR DESCRIPTION
Looks like in some environments the scrollTop limit is so low that LazyRepeat doesn't need to remove any element. This PR changes the scrollTop twice so LazyRepeat always needs to remove elements.