### PR TITLE
chore(react-binding): Replace string refs with callbacks.

### DIFF
--- a/bindings/react/src/components/Carousel.jsx
+++ b/bindings/react/src/components/Carousel.jsx
@@ -17,7 +17,13 @@ import Util from './Util.js';
           onPostChange={() => console.log('onPostChange')}
           onOverscroll={() => console.log('onOverscroll')}
           onRefresh={() => console.log('onRefresh')}
-          ref='carousel' swipeable overscrollable autoScroll fullscreen autoScrollRatio={0.2}>
+          ref={(carousel) => { this.carousel = carousel; }}
+          swipeable
+          overscrollable
+          autoScroll
+          fullscreen
+          autoScrollRatio={0.2}
+      >
           <CarouselItem style={{backgroundColor: 'gray'}}>
             <div className='item-label'>GRAY</div>
           </CarouselItem>

--- a/bindings/react/src/components/LazyList.jsx
+++ b/bindings/react/src/components/LazyList.jsx
@@ -50,7 +50,7 @@ class LazyList extends BasicComponent {
   update(props) {
     var self = this;
 
-    this.refs.lazyRepeat.delegate = {
+    this._lazyRepeat.delegate = {
       calculateItemHeight: function(index) {
         return props.calculateItemHeight(index);
       },
@@ -62,7 +62,7 @@ class LazyList extends BasicComponent {
         var el = items.map(createElement);
         self.setState({children: el, height: newHeight},
                       () => {
-                        var list = this.refs.list;
+                        var list = this._list;
                         // ignore i=0 <lazy repat
                         for (var i = 1; i < list.children.length; i++) {
                           list.children[i].style.position = 'absolute';
@@ -93,10 +93,10 @@ class LazyList extends BasicComponent {
 
   render() {
     return (
-      <ons-list {...this.props} ref='list'
+      <ons-list {...this.props} ref={(list) => { this._list = list; }}
         class='list' style={{position: 'relative', height: this.state.height}}
         >
-        <ons-lazy-repeat ref='lazyRepeat' />
+        <ons-lazy-repeat ref={(lazyRepeat) => { this._lazyRepeat = lazyRepeat; }} />
         {this.state.children}
        </ons-list>
     );

--- a/bindings/react/src/components/List.jsx
+++ b/bindings/react/src/components/List.jsx
@@ -27,7 +27,7 @@ class List extends BasicComponent {
     var pages = this.props.dataSource.map((data, idx) => this.props.renderRow(data, idx));
 
     return (
-      <ons-list {...this.props} ref='list'>
+      <ons-list {...this.props} ref={(list) => { this._list = list; }}>
         {this.props.renderHeader()}
         {pages}
         {this.props.children}

--- a/bindings/react/src/components/Navigator.jsx
+++ b/bindings/react/src/components/Navigator.jsx
@@ -86,7 +86,7 @@ class Navigator extends BasicComponent {
         return new Promise((resolve) => this.forceUpdate(resolve));
       };
 
-      this.refs.navi._pushPage(options, update).then(() => {
+      this._navi._pushPage(options, update).then(() => {
         this.routes = routes;
 
         var renderPage = (route) => {
@@ -126,7 +126,7 @@ class Navigator extends BasicComponent {
       };
 
       this.routes.push(route);
-      this.refs.navi
+      this._navi
         ._pushPage(
           options,
           update
@@ -141,7 +141,7 @@ class Navigator extends BasicComponent {
   }
 
   isRunning() {
-    return this.refs.navi._isRunning;
+    return this._navi._isRunning;
   }
 
   /*
@@ -166,7 +166,7 @@ class Navigator extends BasicComponent {
       const pos = this.pages.length - 2;
       this.pages.splice(pos, 1);
       this.routes.splice(pos, 1);
-      this.refs.navi.topPage.updateBackButton(this.pages.length > 1);
+      this._navi.topPage.updateBackButton(this.pages.length > 1);
       this.forceUpdate();
     });
   }
@@ -197,11 +197,11 @@ class Navigator extends BasicComponent {
       });
     };
 
-    return this.refs.navi._popPage(options, update);
+    return this._navi._popPage(options, update);
   }
 
   _prePop(event) {
-    if (event.target !== this.refs.navi) {
+    if (event.target !== this._navi) {
       return;
     }
 
@@ -214,7 +214,7 @@ class Navigator extends BasicComponent {
   }
 
   _postPop(event) {
-    if (event.target !== this.refs.navi) {
+    if (event.target !== this._navi) {
       return;
     }
 
@@ -227,7 +227,7 @@ class Navigator extends BasicComponent {
   }
 
   _prePush(event) {
-    if (event.target !== this.refs.navi) {
+    if (event.target !== this._navi) {
       return;
     }
 
@@ -240,7 +240,7 @@ class Navigator extends BasicComponent {
   }
 
   _postPush(event) {
-    if (event.target !== this.refs.navi) {
+    if (event.target !== this._navi) {
       return;
     }
 
@@ -253,7 +253,7 @@ class Navigator extends BasicComponent {
   }
 
   componentDidMount() {
-    const node = this.refs.navi;
+    const node = this._navi;
     node.popPage = this.popPage.bind(this);
 
     node.addEventListener('prepush', this._prePush);
@@ -280,7 +280,7 @@ class Navigator extends BasicComponent {
   }
 
   componentWillUnmount() {
-    const node = this.refs.navi;
+    const node = this._navi;
     node.removeEventListener('prepush', this.props.onPrePush);
     node.removeEventListener('postpush', this.props.onPostPush);
     node.removeEventListener('prepop', this.props.onPrePop);
@@ -293,7 +293,7 @@ class Navigator extends BasicComponent {
     const pages = this.routes ? this.routes.map((route) => this.props.renderPage(route, this)) : null;
 
     return (
-      <ons-navigator {...others} ref='navi'>
+      <ons-navigator {...others} ref={(navi) => { this._navi = navi; }}>
         {pages}
       </ons-navigator>
     );

--- a/bindings/react/src/components/Popover.jsx
+++ b/bindings/react/src/components/Popover.jsx
@@ -14,12 +14,17 @@ import ReactDOM from 'react-dom';
  * [jp][/jp]
  * @example
  * <Page>
- *  <Button ref='btn'
-  *  onClick={() => this.setState({target: this.refs.btn, isOpen: true})}/>
+ *  <Button
+ *    ref={(btn) => { this.btn = btn; }}
+ *    onClick={() =>
+ *      this.setState({target: this.btn, isOpen: true})
+ *    }
+ *  />
     <Popover
       isOpen={this.state.isOpen}
       onCancel={() => this.setState({isOpen: false})}
-      getTarget={() => this.state.target} >
+      getTarget={() => this.state.target}
+    >
       <div style={{textAlign: 'center', opacity: 0.5}}>
         <p>This is a popover!</p>
           <p><small>Click the background to remove the popover.</small></p>

--- a/bindings/react/src/components/PullHook.jsx
+++ b/bindings/react/src/components/PullHook.jsx
@@ -38,7 +38,7 @@ class PullHook extends BasicComponent {
     super.componentDidMount();
     var node = ReactDOM.findDOMNode(this);
     node.addEventListener('changestate', this.props.onChange);
-    this.refs.pullHook.onAction = this.props.onLoad;
+    this._pullHook.onAction = this.props.onLoad;
   }
 
   componentWillUnmount() {
@@ -57,7 +57,7 @@ class PullHook extends BasicComponent {
     Util.convert(others, 'thresholdHeight', {fun: Util.sizeConverter, newName: 'threshold-height'});
     Util.convert(others, 'fixedContent', {newName: 'fixed-content'});
 
-    return <ons-pull-hook ref='pullHook' {...others} />;
+    return <ons-pull-hook ref={(pullHook) => { this._pullHook = pullHook; }} {...others} />;
   }
 }
 

--- a/bindings/react/src/components/RouterNavigator.jsx
+++ b/bindings/react/src/components/RouterNavigator.jsx
@@ -48,7 +48,7 @@ class RouterNavigator extends BasicComponent {
       });
     };
 
-    return this.refs.navi._pushPage(options, update)
+    return this._navi._pushPage(options, update)
       .then(() => {
         this.pages = routes.map(route => this.props.renderPage(route));
         this.update();
@@ -80,7 +80,7 @@ class RouterNavigator extends BasicComponent {
       });
     };
 
-    return this.refs.navi._pushPage(options, update)
+    return this._navi._pushPage(options, update)
       .then(() => {
         this.page = null;
         this.update();
@@ -88,7 +88,7 @@ class RouterNavigator extends BasicComponent {
   }
 
   isRunning() {
-    return this.refs.navi._isRunning;
+    return this._navi._isRunning;
   }
 
   /*
@@ -113,7 +113,7 @@ class RouterNavigator extends BasicComponent {
       });
     };
 
-    return this.refs.navi._pushPage(options, update)
+    return this._navi._pushPage(options, update)
       .then(() => {
         this.pages.splice(this.pages.length - 2, 1);
         this.update();
@@ -142,11 +142,11 @@ class RouterNavigator extends BasicComponent {
       });
     };
 
-    return this.refs.navi._popPage(options, update);
+    return this._navi._popPage(options, update);
   }
 
   componentDidMount() {
-    const node = this.refs.navi;
+    const node = this._navi;
 
     this.cancelUpdate = false;
 
@@ -206,7 +206,7 @@ class RouterNavigator extends BasicComponent {
   }
 
   componentWillUnmount() {
-    const node = this.refs.navi;
+    const node = this._navi;
     node.removeEventListener('prepush', this.props.onPrePush);
     node.removeEventListener('postpush', this.props.onPostPush);
     node.removeEventListener('prepop', this.props.onPrePop);
@@ -219,7 +219,7 @@ class RouterNavigator extends BasicComponent {
     Util.convert(others, 'animationOptions', {fun: Util.animationOptionsConverter, newName: 'animation-options'});
 
     return (
-      <ons-navigator {...others} ref='navi'>
+      <ons-navigator {...others} ref={(navi) => { this._navi = navi; }}>
         {this.props.routeConfig.routeStack.map(route => this.props.renderPage(route))}
         {this.page}
       </ons-navigator>

--- a/bindings/react/src/components/Switch.jsx
+++ b/bindings/react/src/components/Switch.jsx
@@ -18,11 +18,11 @@ class Switch extends BasicComponent {
 
   componentDidMount() {
     super.componentDidMount();
-    this.refs.switch.addEventListener('change', this.props.onChange);
+    this._switch.addEventListener('change', this.props.onChange);
   }
 
   componentWillUnmount() {
-    this.refs.switch.removeEventListener('change', this.props.onChange);
+    this._switch.removeEventListener('change', this.props.onChange);
   }
 
   render() {
@@ -34,7 +34,7 @@ class Switch extends BasicComponent {
       other['input-id'] = inputId;
     }
     return (
-      <ons-switch ref='switch' checked={checked ? '' : null} {...other} />
+      <ons-switch ref={(switchElement) => { this._switch = switchElement; }} checked={checked ? '' : null} {...other} />
     );
   }
 }

--- a/bindings/react/src/components/Tabbar.jsx
+++ b/bindings/react/src/components/Tabbar.jsx
@@ -36,7 +36,7 @@ class Tabbar extends BasicComponent {
 
   componentDidMount() {
     super.componentDidMount();
-    const node = this.refs.tabbar;
+    const node = this._tabbar;
     node.addEventListener('prechange', this.props.onPreChange);
     node.addEventListener('postchange', this.props.onPostChange);
     node.addEventListener('reactive', this.props.onReactive);
@@ -47,7 +47,7 @@ class Tabbar extends BasicComponent {
   }
 
   componentWillUnmount() {
-    const node = this.refs.tabbar;
+    const node = this._tabbar;
     node.removeEventListener('prechange', this.props.onPreChange);
     node.removeEventListener('postchange', this.props.onPostChange);
     node.removeEventListener('reactive', this.props.onReactive);
@@ -56,7 +56,7 @@ class Tabbar extends BasicComponent {
   componentDidUpdate(prevProps) {
     super.componentDidUpdate(prevProps);
     if (prevProps.index !== this.props.index) {
-      this.refs.tabbar.setActiveTab(this.props.index);
+      this._tabbar.setActiveTab(this.props.index);
     }
   }
 
@@ -78,7 +78,7 @@ class Tabbar extends BasicComponent {
     Util.convert(others, 'animationOptions', {fun: Util.animationOptionsConverter, newName: 'animation-options'});
 
     return (
-      <ons-tabbar {...this.props} ref='tabbar'>
+      <ons-tabbar {...this.props} ref={(tabbar) => { this._tabbar = tabbar; }}>
         <div className={'ons-tab-bar__content tab-bar__content' + (this.props.position === 'top' ? ' tab-bar--top__content' : '')}>
           {this.tabPages}
         </div>


### PR DESCRIPTION
String refs are considered legacy and are likely to be removed in one of the future releases of React (see https://facebook.github.io/react/docs/refs-and-the-dom.html#the-ref-callback-attribute). This pull request replaces all string refs with callbacks.