### PR TITLE
fix(ons-fab): Execute this.show() and some statements before contentR…

### DIFF
--- a/core/src/elements/ons-fab.js
+++ b/core/src/elements/ons-fab.js
@@ -72,6 +72,13 @@ export default class FabElement extends BaseElement {
    */
 
   init() {
+    // The following statements can be executed before contentReady
+    // since these do not access the children
+    {
+      this.show();
+      this.classList.add(defaultClassName);
+    }
+
     contentReady(this, () => {
       this._compile();
     });
@@ -79,8 +86,6 @@ export default class FabElement extends BaseElement {
 
   _compile() {
     autoStyle.prepare(this);
-
-    this.classList.add(defaultClassName);
 
     if (!util.findChild(this, '.fab__icon')) {
       const content = document.createElement('span');
@@ -99,8 +104,6 @@ export default class FabElement extends BaseElement {
     ModifierUtil.initModifier(this, scheme);
 
     this._updatePosition();
-
-    this.show();
   }
 
   static get observedAttributes() {


### PR DESCRIPTION
@frankdiox 
This PR fixes the following problem and some related problems:
```js
  describe('#_onClick()', () => {
    it('should call #toggleItems()', () => {
      const spy = chai.spy.on(speedDial, 'toggleItems');
      return speedDial._onClick() // <---- in Safari, when _onClick is called speedDial is not yet initialized
      .then(() => expect(spy).to.have.been.called.once);
    });
  });
```
(in `ons-speed-dial.spec.js`)