### PR TITLE
Show warning when ons-template is not located just under document.body.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 CHANGELOG
 ====
 
+v2.1.1
+----
+ * ons-template: Show warning when ons-template is nested.
+
 v2.1.0
 ----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 
 v2.1.1
 ----
- * ons-template: Show warning when ons-template is nested.
+ * ons-template: Show warning when ons-template is not located just under document.body.
 
 v2.1.0
 ----

--- a/core/src/elements/ons-tabbar/index.js
+++ b/core/src/elements/ons-tabbar/index.js
@@ -287,7 +287,7 @@ export default class TabbarElement extends BaseElement {
    *   [ja][/ja]
    */
   loadPage(page, options = {}) {
-    console.warn('The loadPage method has been deprecated and will be removed in the next minor version.');
+    util.warn('The loadPage method has been deprecated and will be removed in the next minor version.');
 
     return new Promise(resolve => {
       const tab = this._tabbarElement.children[0] || new TabElement();

--- a/core/src/elements/ons-template.js
+++ b/core/src/elements/ons-template.js
@@ -69,9 +69,11 @@ export default class TemplateElement extends BaseElement {
   }
 
   connectedCallback() {
-    // Show warning when the ons-template is not located just under document.body
-    if (!/body/i.test(this.parentNode.tagName)) { // if the parent is not document.body
-      util.warn(`ons-template (id = ${this.getAttribute('id')}) must be located just under document.body${ this.parentNode.outerHTML ? `:\n\n${this.parentNode.outerHTML}` : '.' }`);
+    if (this.parentNode) { // Note: this.parentNode is not set in some CE0/CE1 polyfills.
+      // Show warning when the ons-template is not located just under document.body
+      if (!/body/i.test(this.parentNode.tagName)) { // if the parent is not document.body
+        util.warn(`ons-template (id = ${this.getAttribute('id')}) must be located just under document.body${ this.parentNode.outerHTML ? `:\n\n${this.parentNode.outerHTML}` : '.' }`);
+      }
     }
 
     var event = new CustomEvent('_templateloaded', {bubbles: true, cancelable: true});

--- a/core/src/elements/ons-template.js
+++ b/core/src/elements/ons-template.js
@@ -15,6 +15,7 @@ limitations under the License.
 
 */
 
+import util from '../ons/util';
 import BaseElement from '../ons/base-element';
 
 /**
@@ -70,7 +71,7 @@ export default class TemplateElement extends BaseElement {
   connectedCallback() {
     // Show warning when the ons-template is not located just under document.body
     if (!/body/i.test(this.parentNode.tagName)) { // if the parent is not document.body
-      console.warn(`ons-template (id = ${this.getAttribute('id')}) must be located just under document.body${ this.parentNode.outerHTML ? `:\n\n${this.parentNode.outerHTML}` : '.' }`);
+      util.warn(`ons-template (id = ${this.getAttribute('id')}) must be located just under document.body${ this.parentNode.outerHTML ? `:\n\n${this.parentNode.outerHTML}` : '.' }`);
     }
 
     var event = new CustomEvent('_templateloaded', {bubbles: true, cancelable: true});

--- a/core/src/elements/ons-template.js
+++ b/core/src/elements/ons-template.js
@@ -62,17 +62,17 @@ export default class TemplateElement extends BaseElement {
   init() {
     this.template = this.innerHTML;
 
-    // Show warning when the ons-template is not located just under document.body
-    if (!/body/i.test(this.parentNode.tagName)) { // if the parent is not document.body
-      console.warn(`ons-template (id = ${this.getAttribute('id')}) must be located just under document.body${ this.parentNode.outerHTML ? `:\n\n${this.parentNode.outerHTML}` : '.' }`);
-    }
-
     while (this.firstChild) {
       this.removeChild(this.firstChild);
     }
   }
 
   connectedCallback() {
+    // Show warning when the ons-template is not located just under document.body
+    if (!/body/i.test(this.parentNode.tagName)) { // if the parent is not document.body
+      console.warn(`ons-template (id = ${this.getAttribute('id')}) must be located just under document.body${ this.parentNode.outerHTML ? `:\n\n${this.parentNode.outerHTML}` : '.' }`);
+    }
+
     var event = new CustomEvent('_templateloaded', {bubbles: true, cancelable: true});
     event.template = this.template;
     event.templateId = this.getAttribute('id');

--- a/core/src/elements/ons-template.js
+++ b/core/src/elements/ons-template.js
@@ -62,6 +62,11 @@ export default class TemplateElement extends BaseElement {
   init() {
     this.template = this.innerHTML;
 
+    // Show warning when ons-template is nested
+    if (this.querySelector('ons-template') != null) {
+      console.warn(`ons-template cannot be nested (id: ${this.getAttribute('id')}): ${this.template}`);
+    }
+
     while (this.firstChild) {
       this.removeChild(this.firstChild);
     }

--- a/core/src/elements/ons-template.js
+++ b/core/src/elements/ons-template.js
@@ -71,7 +71,7 @@ export default class TemplateElement extends BaseElement {
   connectedCallback() {
     if (this.parentNode) { // Note: this.parentNode is not set in some CE0/CE1 polyfills.
       // Show warning when the ons-template is not located just under document.body
-      if (!/body/i.test(this.parentNode.tagName)) { // if the parent is not document.body
+      if (this.parentNode !== document.body) { // if the parent is not document.body
         util.warn(`ons-template (id = ${this.getAttribute('id')}) must be located just under document.body${ this.parentNode.outerHTML ? `:\n\n${this.parentNode.outerHTML}` : '.' }`);
       }
     }

--- a/core/src/elements/ons-template.js
+++ b/core/src/elements/ons-template.js
@@ -62,9 +62,9 @@ export default class TemplateElement extends BaseElement {
   init() {
     this.template = this.innerHTML;
 
-    // Show warning when ons-template is nested
-    if (this.querySelector('ons-template') != null) {
-      console.warn(`ons-template cannot be nested (id: ${this.getAttribute('id')}): ${this.template}`);
+    // Show warning when the ons-template is not located just under document.body
+    if (!/body/i.test(this.parentNode.tagName)) { // if the parent is not document.body
+      console.warn(`ons-template (id = ${this.getAttribute('id')}) must be located just under document.body${ this.parentNode.outerHTML ? `:\n\n${this.parentNode.outerHTML}` : '.' }`);
     }
 
     while (this.firstChild) {

--- a/core/src/lib/styler.js
+++ b/core/src/lib/styler.js
@@ -37,7 +37,7 @@ styler.css = function(element, styles) {
     } else if (styler._prefix(key) in element.style) {
       element.style[styler._prefix(key)] = styles[key];
     } else {
-      console.warn('No such style property: ' + key);
+      util.warn('No such style property: ' + key);
     }
   });
   return element;

--- a/core/src/ons/internal/internal.js
+++ b/core/src/ons/internal/internal.js
@@ -22,7 +22,8 @@ const internal = {};
 
 internal.config = {
   autoStatusBarFill: true,
-  animationsDisabled: false
+  animationsDisabled: false,
+  warningsDisabled: false
 };
 
 internal.nullElement = window.document.createElement('div');

--- a/core/src/ons/ons.js
+++ b/core/src/ons/ons.js
@@ -196,6 +196,14 @@ ons.enableAnimations = () => {
   ons._internal.config.animationsDisabled = false;
 };
 
+ons._disableWarnings = () => {
+  ons._internal.config.warningsDisabled = true;
+};
+
+ons._enableWarnings = () => {
+  ons._internal.config.warningsDisabled = false;
+};
+
 /**
  * @method disableAutoStyling
  * @signature disableAutoStyling()

--- a/core/src/ons/software-keyboard.js
+++ b/core/src/ons/software-keyboard.js
@@ -49,7 +49,7 @@ const bindEvents = () => {
 };
 
 const noPluginError = () => {
-  console.warn('ons-keyboard: Cordova Keyboard plugin is not present.');
+  util.warn('ons-keyboard: Cordova Keyboard plugin is not present.');
 };
 
 document.addEventListener('deviceready', () => {

--- a/core/src/ons/util.js
+++ b/core/src/ons/util.js
@@ -15,6 +15,7 @@ limitations under the License.
 
 */
 
+import internal from './internal';
 import animationOptionsParse from './animation-options-parser';
 
 const util = {};
@@ -357,6 +358,17 @@ util.defer = () => {
     deferred.reject = reject;
   });
   return deferred;
+};
+
+/**
+ * Show warnings when they are enabled.
+ *
+ * @param {*} arguments to console.warn
+ */
+util.warn = (...args) => {
+  if (!internal.config.warningsDisabled) {
+    console.warn(...args);
+  }
 };
 
 export default util;

--- a/core/test/unit/disable-warnings.js
+++ b/core/test/unit/disable-warnings.js
@@ -1,0 +1,1 @@
+ons._disableWarnings();

--- a/core/test/unit/karma.conf.js
+++ b/core/test/unit/karma.conf.js
@@ -17,10 +17,11 @@ module.exports = function(config) {
       '../../../build/js/onsenui.js',
       'setup.js',
       `browser-${global.KARMA_BROWSER}.js`, // no error occurs even if not found 
+      global.KARMA_DISABLE_WARNINGS ? 'disable-warnings.js' : null,
       global.KARMA_SPEC_FILES || '../../../core/src/**/*.spec.js',
       '../../../build/css/onsenui.css',
       '../../../build/css/onsen-css-components.css'
-    ],
+    ].filter(v => v != null),
 
     preprocessors: {
       'setup.js': ['babel'],

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -112,7 +112,7 @@ gulp.task('core-dts-test', () => {
 ////////////////////////////////////////
 // unit-test
 ////////////////////////////////////////
-gulp.task('unit-test', ['prepare', 'core', 'core-dts-test'], (done) => {
+gulp.task('unit-test', ['watch-core', 'core-dts-test'], (done) => {
   // Usage:
   //     # run all unit tests in just one Karma server
   //     gulp unit-test
@@ -138,6 +138,9 @@ gulp.task('unit-test', ['prepare', 'core', 'core-dts-test'], (done) => {
   //
   //     # run unit tests without Onsen UI warnings
   //     gulp unit-test --disable-warnings
+  //
+  //     # watch unit tests
+  //     gulp unit-test --watch
 
   (async () => {
     const specs = argv.specs || 'core/src/**/*.spec.js'; // you cannot use commas for --specs
@@ -177,8 +180,8 @@ gulp.task('unit-test', ['prepare', 'core', 'core-dts-test'], (done) => {
               new karma.Server(
                 {
                   configFile: path.join(__dirname, 'core/test/unit/karma.conf.js'),
-                  singleRun: true, // overrides the corresponding option in config file
-                  autoWatch: false // same as above
+                  singleRun: argv.watch ? false : true, // overrides the corresponding option in config file
+                  autoWatch: argv.watch ? true : false // same as above
                 },
                 (exitCode) => {
                   const exitMessage = `Karma server has exited with ${exitCode}`;
@@ -220,31 +223,6 @@ gulp.task('unit-test', ['prepare', 'core', 'core-dts-test'], (done) => {
       done('unit-test has failed');
     }
   })();
-});
-
-////////////////////////////////////////
-// watch-unit-test
-////////////////////////////////////////
-gulp.task('watch-unit-test', ['watch-core'], (done) => {
-  new karma.Server(
-    {
-      configFile: path.join(__dirname, 'core/test/unit/karma.conf.js'),
-      singleRun: false, // overrides the corresponding option in config file
-      autoWatch: true // same as above
-    },
-    (exitCode) => {
-      const exitMessage = `Karma server has exited with ${exitCode}`;
-
-      switch (exitCode) {
-        case 0: // success
-          $.util.log($.util.colors.green(exitMessage));
-          break;
-        default: // error
-          $.util.log($.util.colors.red(exitMessage));
-      }
-      done();
-    }
-  ).start();
 });
 
 ////////////////////////////////////////

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -118,117 +118,118 @@ gulp.task('unit-test',
     ['core-dts-test']
   ),
   (done) => {
-  // Usage:
-  //     # run all unit tests in just one Karma server
-  //     gulp unit-test
-  //
-  //     # run only specified unit tests in just one Karma server
-  //     gulp unit-test --specs core/src/elements/ons-navigator/index.spec.js
-  //     gulp unit-test --specs "core/src/**/index.spec.js"
-  //     gulp unit-test --specs "core/src/**/*.spec.js"
-  //
-  //     # run all unit tests separately
-  //     gulp unit-test --separately
-  //
-  //     # run only specified unit tests separately
-  //     gulp unit-test --separately --specs core/src/elements/ons-navigator/index.spec.js
-  //     gulp unit-test --separately --specs "core/src/**/index.spec.js"
-  //     gulp unit-test --separately --specs "core/src/**/*.spec.js"
-  //
-  //     # run unit tests in a particular browser
-  //     gulp unit-test --browsers local_chrome
-  //     gulp unit-test --browsers local_chrome,local_safari # you can use commas
-  //     gulp unit-test --browsers remote_iphone_5_simulator_ios_10_0_safari # to use this, see karma.conf.js
-  //     gulp unit-test --browsers local_chrome,remote_macos_elcapitan_safari_10 # default
-  //
-  //     # run unit tests without Onsen UI warnings
-  //     gulp unit-test --disable-warnings
-  //
-  //     # watch unit tests
-  //     gulp unit-test --watch
+    // Usage:
+    //     # run all unit tests in just one Karma server
+    //     gulp unit-test
+    //
+    //     # run only specified unit tests in just one Karma server
+    //     gulp unit-test --specs core/src/elements/ons-navigator/index.spec.js
+    //     gulp unit-test --specs "core/src/**/index.spec.js"
+    //     gulp unit-test --specs "core/src/**/*.spec.js"
+    //
+    //     # run all unit tests separately
+    //     gulp unit-test --separately
+    //
+    //     # run only specified unit tests separately
+    //     gulp unit-test --separately --specs core/src/elements/ons-navigator/index.spec.js
+    //     gulp unit-test --separately --specs "core/src/**/index.spec.js"
+    //     gulp unit-test --separately --specs "core/src/**/*.spec.js"
+    //
+    //     # run unit tests in a particular browser
+    //     gulp unit-test --browsers local_chrome
+    //     gulp unit-test --browsers local_chrome,local_safari # you can use commas
+    //     gulp unit-test --browsers remote_iphone_5_simulator_ios_10_0_safari # to use this, see karma.conf.js
+    //     gulp unit-test --browsers local_chrome,remote_macos_elcapitan_safari_10 # default
+    //
+    //     # run unit tests without Onsen UI warnings
+    //     gulp unit-test --disable-warnings
+    //
+    //     # watch unit tests
+    //     gulp unit-test --watch
 
-  (async () => {
-    const specs = argv.specs || 'core/src/**/*.spec.js'; // you cannot use commas for --specs
-    const browsers = argv.browsers ? argv.browsers.split(',').map(s => s.trim()) : ['local_chrome', 'remote_macos_elcapitan_safari_10'];
+    (async () => {
+      const specs = argv.specs || 'core/src/**/*.spec.js'; // you cannot use commas for --specs
+      const browsers = argv.browsers ? argv.browsers.split(',').map(s => s.trim()) : ['local_chrome', 'remote_macos_elcapitan_safari_10'];
 
-    let listOfSpecFiles;
-    if (argv.separately) { // resolve glob pattern
-      listOfSpecFiles = glob.sync( path.join(__dirname, specs) );
-    } else { // do not resolve glob pattern
-      listOfSpecFiles = new Array( path.join(__dirname, specs) );
-    }
+      let listOfSpecFiles;
+      if (argv.separately) { // resolve glob pattern
+        listOfSpecFiles = glob.sync( path.join(__dirname, specs) );
+      } else { // do not resolve glob pattern
+        listOfSpecFiles = new Array( path.join(__dirname, specs) );
+      }
 
-    // if --disable-warnings is specified, suppress warnings from Onsen UI
-    if (argv['disable-warnings']) {
-      global.KARMA_DISABLE_WARNINGS = true;
-    }
+      // if --disable-warnings is specified, suppress warnings from Onsen UI
+      if (argv['disable-warnings']) {
+        global.KARMA_DISABLE_WARNINGS = true;
+      }
 
-    let testsPassed = true; // error flag
+      let testsPassed = true; // error flag
 
-    // Separately launch Karma server for each browser and each set of spec files
-    try {
-      for (let j = 0 ; j < browsers.length ; j++) {
-        $.util.log($.util.colors.blue(`Start unit testing on ${browsers[j]}...`));
-
-        // Pass parameters to Karma config file via `global`
-        global.KARMA_BROWSER = browsers[j];
-
-        for (let i = 0 ; i < listOfSpecFiles.length ; i++) {
-          $.util.log($.util.colors.blue(path.relative(__dirname, listOfSpecFiles[i])));
+      // Separately launch Karma server for each browser and each set of spec files
+      try {
+        for (let j = 0 ; j < browsers.length ; j++) {
+          $.util.log($.util.colors.blue(`Start unit testing on ${browsers[j]}...`));
 
           // Pass parameters to Karma config file via `global`
-          global.KARMA_SPEC_FILES = listOfSpecFiles[i];
+          global.KARMA_BROWSER = browsers[j];
 
-          // Launch Karma server and wait until it exits
-          await (async () => {
-            return new Promise((resolve, reject) => {
-              new karma.Server(
-                {
-                  configFile: path.join(__dirname, 'core/test/unit/karma.conf.js'),
-                  singleRun: argv.watch ? false : true, // overrides the corresponding option in config file
-                  autoWatch: argv.watch ? true : false // same as above
-                },
-                (exitCode) => {
-                  const exitMessage = `Karma server has exited with ${exitCode}`;
+          for (let i = 0 ; i < listOfSpecFiles.length ; i++) {
+            $.util.log($.util.colors.blue(path.relative(__dirname, listOfSpecFiles[i])));
 
-                  switch (exitCode) {
-                    case 0: // success
-                      $.util.log($.util.colors.green(exitMessage));
-                      $.util.log($.util.colors.green('Passed unit tests successfully.'));
-                      break;
-                    default: // error
-                      $.util.log($.util.colors.red(exitMessage));
-                      $.util.log($.util.colors.red('Failed to pass some unit tests. (Otherwise, the unit testing itself is broken)'));
-                      testsPassed = false;
+            // Pass parameters to Karma config file via `global`
+            global.KARMA_SPEC_FILES = listOfSpecFiles[i];
+
+            // Launch Karma server and wait until it exits
+            await (async () => {
+              return new Promise((resolve, reject) => {
+                new karma.Server(
+                  {
+                    configFile: path.join(__dirname, 'core/test/unit/karma.conf.js'),
+                    singleRun: argv.watch ? false : true, // overrides the corresponding option in config file
+                    autoWatch: argv.watch ? true : false // same as above
+                  },
+                  (exitCode) => {
+                    const exitMessage = `Karma server has exited with ${exitCode}`;
+
+                    switch (exitCode) {
+                      case 0: // success
+                        $.util.log($.util.colors.green(exitMessage));
+                        $.util.log($.util.colors.green('Passed unit tests successfully.'));
+                        break;
+                      default: // error
+                        $.util.log($.util.colors.red(exitMessage));
+                        $.util.log($.util.colors.red('Failed to pass some unit tests. (Otherwise, the unit testing itself is broken)'));
+                        testsPassed = false;
+                    }
+                    resolve();
                   }
-                  resolve();
-                }
-              ).start();
-            });
-          })();
+                ).start();
+              });
+            })();
 
-          // Wait for 500 ms before next iteration to avoid crashes
-          await (async () => {
-            return new Promise((resolve, reject) => {
-              setTimeout(() => { resolve(); }, 500 );
-            });
-          })();
+            // Wait for 500 ms before next iteration to avoid crashes
+            await (async () => {
+              return new Promise((resolve, reject) => {
+                setTimeout(() => { resolve(); }, 500 );
+              });
+            })();
+          }
         }
+      } finally {
+        global.KARMA_BROWSER = undefined;
+        global.KARMA_SPEC_FILES = undefined;
       }
-    } finally {
-      global.KARMA_BROWSER = undefined;
-      global.KARMA_SPEC_FILES = undefined;
-    }
 
-    if (testsPassed) {
-      $.util.log($.util.colors.green('Passed unit tests on all browsers!'));
-      done();
-    } else {
-      $.util.log($.util.colors.red('Failed to pass unit tests on some browsers.'));
-      done('unit-test has failed');
-    }
-  })();
-});
+      if (testsPassed) {
+        $.util.log($.util.colors.green('Passed unit tests on all browsers!'));
+        done();
+      } else {
+        $.util.log($.util.colors.red('Failed to pass unit tests on some browsers.'));
+        done('unit-test has failed');
+      }
+    })();
+  }
+);
 
 ////////////////////////////////////////
 // html2js

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -112,7 +112,12 @@ gulp.task('core-dts-test', () => {
 ////////////////////////////////////////
 // unit-test
 ////////////////////////////////////////
-gulp.task('unit-test', ['prepare', 'core', 'core-dts-test'], (done) => {
+gulp.task('unit-test',
+  [].concat(
+    (argv.watch ? ['watch-core'] : ['prepare', 'core']),
+    ['core-dts-test']
+  ),
+  (done) => {
   // Usage:
   //     # run all unit tests in just one Karma server
   //     gulp unit-test

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -135,6 +135,9 @@ gulp.task('unit-test', ['prepare', 'core', 'core-dts-test'], (done) => {
   //     gulp unit-test --browsers local_chrome,local_safari # you can use commas
   //     gulp unit-test --browsers remote_iphone_5_simulator_ios_10_0_safari # to use this, see karma.conf.js
   //     gulp unit-test --browsers local_chrome,remote_macos_elcapitan_safari_10 # default
+  //
+  //     # run unit tests without Onsen UI warnings
+  //     gulp unit-test --disable-warnings
 
   (async () => {
     const specs = argv.specs || 'core/src/**/*.spec.js'; // you cannot use commas for --specs
@@ -145,6 +148,11 @@ gulp.task('unit-test', ['prepare', 'core', 'core-dts-test'], (done) => {
       listOfSpecFiles = glob.sync( path.join(__dirname, specs) );
     } else { // do not resolve glob pattern
       listOfSpecFiles = new Array( path.join(__dirname, specs) );
+    }
+
+    // if --disable-warnings is specified, suppress warnings from Onsen UI
+    if (argv['disable-warnings']) {
+      global.KARMA_DISABLE_WARNINGS = true;
     }
 
     let testsPassed = true; // error flag

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -112,7 +112,7 @@ gulp.task('core-dts-test', () => {
 ////////////////////////////////////////
 // unit-test
 ////////////////////////////////////////
-gulp.task('unit-test', ['watch-core', 'core-dts-test'], (done) => {
+gulp.task('unit-test', ['prepare', 'core', 'core-dts-test'], (done) => {
   // Usage:
   //     # run all unit tests in just one Karma server
   //     gulp unit-test

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     }
   ],
   "scripts": {
-    "test": "gulp test"
+    "test": "gulp test --disable-warnings"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
@anatoo @frankdiox 

This PR enables `ons-template` to detect nested `ons-template` elements.
Nested `ons-template` elements cause unexpected behaviors like #1801, so I think we should show warning when they are used.

This feature works like:
![2017-02-04 2 02 34](https://cloud.githubusercontent.com/assets/19771915/22600652/d77975d8-ea7e-11e6-8a35-cc28b98e6a93.png)

Is there any problem with this?