### PR TITLE
fix(RouterNavigator): Fixes undefined variable error in RouterNavigator

### DIFF
--- a/bindings/react/src/components/RouterNavigator.jsx
+++ b/bindings/react/src/components/RouterNavigator.jsx
@@ -227,7 +227,7 @@ class RouterNavigator extends BasicComponent {
   }
 }
 
-Navigator.propTypes = {
+RouterNavigator.propTypes = {
   /**
    * @name renderPage
    * @type function


### PR DESCRIPTION
Attempts to fix:
```
[...]node_modules/react-onsenui/dist/react-onsenui.js:3849
Navigator.propTypes = {
^

ReferenceError: Navigator is not defined
```