### PR TITLE
fix(react): 'swipeTargetWidth' type is now either number or string

### DIFF
--- a/bindings/react/src/components/SplitterSide.jsx
+++ b/bindings/react/src/components/SplitterSide.jsx
@@ -166,7 +166,7 @@ SplitterSide.propTypes = {
    *  [en]Specifies the width of the menu with a number (for pixels) or a string (e.g. "20%" for percentage).[/en]
    *  [jp] [/jp]
    */
-  swipeTargetWidth: React.PropTypes.number,
+  swipeTargetWidth: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string]),
 
   /**
    * @name width


### PR DESCRIPTION
Fixed a bug where `swipeTargetWidth` attribute of `SplitterSide` only accepted number type. I will merge it to master