### PR TITLE
fix(ons-popover): Device back button behavior.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ dev
  * ons-switch: Supports 'value' attribute.
  * angular1: `number input` retains number type variable with `ngModel`.
  * ons-tab: Supports 'active-icon' attribute.
+ * ons-popover: Fixed behavior on device back button.
 
 v2.1.0
 ----

--- a/core/src/elements/ons-popover/index.js
+++ b/core/src/elements/ons-popover/index.js
@@ -544,7 +544,7 @@ export default class PopoverElement extends BaseElement {
       this._backButtonHandler.destroy();
     }
 
-    this._backButtonHandler = deviceBackButtonDispatcher.createHandler(this, callback);
+    this._backButtonHandler = deviceBackButtonDispatcher.createHandler(this._popover, callback);
   }
 
   _resetBackButtonHandler() { // do we need this twice?

--- a/core/src/elements/ons-popover/index.spec.js
+++ b/core/src/elements/ons-popover/index.spec.js
@@ -9,9 +9,11 @@ describe('OnsPopoverElement', () => {
     target = ons._util.createElement('<div>Target</div>');
 
     document.body.appendChild(target);
-    document.body.appendChild(popover);
 
-    ons._contentReady(popover, done);
+    ons._contentReady(popover, () => {
+      document.body.appendChild(popover);
+      done();
+    });
   });
 
   afterEach(() => {

--- a/core/src/ons/device-back-button-dispatcher.js
+++ b/core/src/ons/device-back-button-dispatcher.js
@@ -230,7 +230,7 @@ class DeviceBackButtonDispatcher {
     return createTree(document.body);
 
     function createTree(element) {
-      return {
+      const tree = {
         element: element,
         children: Array.prototype.concat.apply([], arrayOf(element.children).map(function(childElement) {
 
@@ -251,6 +251,16 @@ class DeviceBackButtonDispatcher {
           return [result];
         }))
       };
+
+      if (!HandlerRepository.has(tree.element)) {
+        for (const subTree of tree.children) {
+          if (HandlerRepository.has(subTree.element)) {
+            return subTree;
+          }
+        }
+      }
+
+      return tree;
     }
 
     function arrayOf(target) {


### PR DESCRIPTION
@anatoo I think we can fix the deviceBackButton behavior in this way. Now the tree only contains the nodes that can be used for the comparison, not always the parents. It's the first time I modify this algorithm so please have a quick look at the changes.

The tree with navigator + popover would be: `[ons-navigator, div.popover]`. Before it was `[ons-navigator, ons-popover]`. And if the popover was located inside a span, for example, it was `[ons-navigator, span]`.

Do you think this is fine or it could break something?