### PR TITLE
feat ons-navigator: add get listener on device back button dispatcher

### DIFF
--- a/core/src/ons/device-back-button-dispatcher.js
+++ b/core/src/ons/device-back-button-dispatcher.js
@@ -178,6 +178,10 @@ class DeviceBackButtonDispatcher {
         this._callback = callback;
       },
 
+      getListener: function() {
+        return this._callback;
+      },
+
       enable: function() {
         HandlerRepository.set(element, this);
       },

--- a/core/src/ons/ons.js
+++ b/core/src/ons/ons.js
@@ -110,6 +110,16 @@ ons.ready = callback => {
 };
 
 /**
+ * @method getDefaultDeviceBackButtonListener
+ * @signature getDefaultDeviceBackButtonListener()
+ * @description
+ *   [en]Returns default handler for device back button.[/en]
+ */
+ons.getDefaultDeviceBackButtonListener = function() {
+  return ons._defaultDeviceBackButtonHandler.getListener();
+};
+
+/**
  * @method setDefaultDeviceBackButtonListener
  * @signature setDefaultDeviceBackButtonListener(listener)
  * @param {Function} listener


### PR DESCRIPTION
I Added a getter for the device back button handler. It could be useful for reset the listener to the original one. I'm using it in a React Application with this use case: In a Page I want a different back management, but after changing the page I want to reset the default behavior.