### PR TITLE
fix(react): Fix broken context in dialogs (#1758)

### DIFF
--- a/bindings/react/src/components/BaseDialog.jsx
+++ b/bindings/react/src/components/BaseDialog.jsx
@@ -75,16 +75,18 @@ class BaseDialog extends React.Component {
     Util.convert(newProps, 'maskColor', {newName: 'mask-color'});
     Util.convert(newProps, 'animationOptions', {fun: Util.animationOptionsConverter, newName: 'animation-options'});
 
-    var element = React.createElement(this._getDomNodeName(), newProps);
-    ReactDOM.render(element, this.node, this._update.bind(this, isShown));
-  }
+    var DomNodeName = this._getDomNodeName();
 
-  shouldComponentUpdate() {
-    return false;
+    ReactDOM.unstable_renderSubtreeIntoContainer(
+      this,
+      <DomNodeName {...newProps} />,
+      this.node,
+      this._update.bind(this, isShown)
+    );
   }
 
   render() {
-    return React.DOM.noscript();
+    return null;
   }
 }
 


### PR DESCRIPTION
This PR fixes the issue mentioned in #1758, where elements within dialogs have a different context than the React application itself. 

`renderSubtreeIntoContainer` is currently marked as unstable because the API might change in the future but it will not be removed any time soon. This is according to one of the core team members  https://twitter.com/soprano/status/737316379712331776. This is currently the only way I know of how to render elements outside the application root and to preserve the context at the same time.