### PR TITLE
Fix settings for `autoprefixer`.

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -376,7 +376,16 @@ gulp.task('prepare', ['html2js'], () =>  {
       'core/css/*.css'
     ])
       .pipe($.concat('onsenui.css'))
-      .pipe($.autoprefixer('> 1%', 'last 2 version', 'ff 12', 'ie 8', 'opera 12', 'chrome 12', 'safari 12', 'android 2', 'ios 6'))
+      .pipe($.autoprefixer({
+        browsers: [ // enable CSS properties which require prefixes
+          'Android >= 4.4',
+          'iOS >= 8.0',
+          'Chrome >= 30', // equivalent to Android 4.4 WebView
+          'Safari >= 9',
+        ],
+        add: true,
+        remove: false, // removing prefixes can cause a bug
+      }))
       .pipe($.header('/*! <%= pkg.name %> - v<%= pkg.version %> - ' + dateformat(new Date(), 'yyyy-mm-dd') + ' */\n', {pkg: pkg}))
       .pipe(gulp.dest('build/css/'))
       .pipe(gulpIf(CORDOVA_APP, gulp.dest('cordova-app/www/lib/onsen/css'))),


### PR DESCRIPTION
@misterjunio @fran 
This PR fixes #1858.

This new settings prevent `autoprefixer` deleting required lines and support Android 4.4+, iOS 8.0+, Chrome 30+ and Safari 9+ correctly.
(Chrome 30 is equivalent to Android 4.4 WebView)
Also, we can use new CSS properties without handling prefixes manually.

After this PR, `onsenui.css` will have more lines (which use prefixed properties).
Since no lines in `onsenui.css` will be deleted, don't worry.