### PR TITLE
fix(util): Replace `Element#children` with `Node#childNodes`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ dev
  * css-components: Fixed broken popover components.
  * css-components: Fixed [#1653](https://github.com/OnsenUI/OnsenUI/issues/1653).
  * core: Fix `autoprefixer` settings for `onsenui.css`.
+ * core: Fixed [#1700](https://github.com/OnsenUI/OnsenUI/issues/1700).
  * ons-select: Fix width of the inner element.
  * ons-popover: Fixed behavior on device back button.
  * ons-splitter: Checks if content exists before removing.
  * ons-lazy-repeat: Clean first item scope.
+ * ons-progress-circular: Fixed [#1860](https://github.com/OnsenUI/OnsenUI/issues/1860).
  * ons.notification: Fixed [#1787](https://github.com/OnsenUI/OnsenUI/issues/1787).
  * ons-row: Fixed [#1858](https://github.com/OnsenUI/OnsenUI/issues/1858).
  * angular1: `number input` retains number type variable with `ngModel`.

--- a/core/src/ons/util.js
+++ b/core/src/ons/util.js
@@ -44,8 +44,12 @@ util.match = (e, s) => (e.matches || e.webkitMatchesSelector || e.mozMatchesSele
 util.findChild = (element, query) => {
   const match = util.prepareQuery(query);
 
-  for (let i = 0; i < element.children.length; i++) {
-    const node = element.children[i];
+  // Caution: `element.children` is `undefined` in some environments if `element` is `svg`
+  for (let i = 0; i < element.childNodes.length; i++) {
+    const node = element.childNodes[i];
+    if (node.nodeType !== Node.ELEMENT_NODE) { // process only element nodes
+      continue;
+    }
     if (match(node)) {
       return node;
     }


### PR DESCRIPTION
@misterjunio @frandiox 
This PR fixes #1700 and #1860.

I have replaced this code (in `util.js`)
```js
  for (let i = 0; i < element.children.length; i++) {
    const node = element.children[i];
    if (match(node)) {
      return node;
    }
  }
```
with
```js
  // Caution: `element.children` is `undefined` in some environments if `element` is `svg`
  for (let i = 0; i < element.childNodes.length; i++) {
    const node = element.childNodes[i];
    if (node.nodeType !== Node.ELEMENT_NODE) { // process only element nodes
      continue;
    }
    if (match(node)) {
      return node;
    }
  }
```
because `element.children` is `undefined` in some environments if `element` is `svg`.

I will merge this.