### PR TITLE
Fix broken slide animation in iOS 9 and iOS 10.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ dev
  * core: Fix `autoprefixer` settings for `onsenui.css`.
  * core: Fixed [#1700](https://github.com/OnsenUI/OnsenUI/issues/1700).
  * ons-select: Fix width of the inner element.
- * ons-dialog: Fix broken slide animation in iOS 9 and iOS 10.
+ * ons-dialog: Fix broken `default` animation in iOS 9 and iOS 10.
  * ons-popover: Fixed behavior on device back button.
  * ons-splitter: Checks if content exists before removing.
  * ons-lazy-repeat: Clean first item scope.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ dev
  * core: Fix `autoprefixer` settings for `onsenui.css`.
  * core: Fixed [#1700](https://github.com/OnsenUI/OnsenUI/issues/1700).
  * ons-select: Fix width of the inner element.
+ * ons-dialog: Fix broken slide animation in iOS 9 and iOS 10.
  * ons-popover: Fixed behavior on device back button.
  * ons-splitter: Checks if content exists before removing.
  * ons-lazy-repeat: Clean first item scope.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ dev
  * core: Fix `autoprefixer` settings for `onsenui.css`.
  * core: Fixed [#1700](https://github.com/OnsenUI/OnsenUI/issues/1700).
  * ons-select: Fix width of the inner element.
- * ons-dialog: Fix broken `default` animation in iOS 9 and iOS 10.
+ * ons-dialog: Fix broken `default` and `slide` animation in iOS 9 and iOS 10.
  * ons-popover: Fixed behavior on device back button.
  * ons-splitter: Checks if content exists before removing.
  * ons-lazy-repeat: Clean first item scope.

--- a/core/src/elements/ons-dialog/animator.js
+++ b/core/src/elements/ons-dialog/animator.js
@@ -153,6 +153,8 @@ export class IOSDialogAnimator extends DialogAnimator {
 
   constructor({timing = 'ease-in-out', delay = 0, duration = 0.3} = {}) {
     super({timing, delay, duration});
+
+    this.bodyHeight = document.body.clientHeight; // avoid Forced Synchronous Layout
   }
 
   /**
@@ -180,7 +182,7 @@ export class IOSDialogAnimator extends DialogAnimator {
         .saveStyle()
         .queue({
           css: {
-            transform: `translate3d(-50%, ${document.body.clientHeight / 2.0 - 1}px, 0)`
+            transform: `translate3d(-50%, ${this.bodyHeight / 2.0 - 1}px, 0)`
           },
           duration: 0
         })
@@ -232,7 +234,7 @@ export class IOSDialogAnimator extends DialogAnimator {
         .wait(this.delay)
         .queue({
           css: {
-            transform: `translate3d(-50%, ${document.body.clientHeight / 2.0 - 1}px, 0)`
+            transform: `translate3d(-50%, ${this.bodyHeight / 2.0 - 1}px, 0)`
           },
           duration: this.duration,
           timing: this.timing

--- a/core/src/elements/ons-dialog/animator.js
+++ b/core/src/elements/ons-dialog/animator.js
@@ -256,6 +256,8 @@ export class SlideDialogAnimator extends DialogAnimator {
 
   constructor({timing = 'cubic-bezier(.1, .7, .4, 1)', delay = 0, duration = 0.2} = {}) {
     super({timing, delay, duration});
+
+    this.bodyHeight = document.body.clientHeight; // avoid Forced Synchronous Layout
   }
 
   /**
@@ -283,7 +285,8 @@ export class SlideDialogAnimator extends DialogAnimator {
         .saveStyle()
         .queue({
           css: {
-            transform: 'translate3D(-50%, -350%, 0)',
+            // FIXME: This should avoid Forced Synchronous Layout. Otherwise, fade animation of mask will be broken.
+            transform: `translate3d(-50%, ${- (this.bodyHeight / 2.0) + 1 - dialog._dialog.clientHeight}px, 0)`
           },
           duration: 0
         })
@@ -335,7 +338,8 @@ export class SlideDialogAnimator extends DialogAnimator {
         .wait(this.delay)
         .queue({
           css: {
-            transform: 'translate3D(-50%, -350%, 0)'
+            // FIXME: This should avoid Forced Synchronous Layout. Otherwise, fade animation of mask will be broken.
+            transform: `translate3d(-50%, ${- (this.bodyHeight / 2.0) + 1 - dialog._dialog.clientHeight}px, 0)`
           },
           duration: this.duration,
           timing: this.timing

--- a/core/src/elements/ons-dialog/animator.js
+++ b/core/src/elements/ons-dialog/animator.js
@@ -180,7 +180,7 @@ export class IOSDialogAnimator extends DialogAnimator {
         .saveStyle()
         .queue({
           css: {
-            transform: 'translate3d(-50%, 300%, 0)'
+            transform: `translate3d(-50%, ${document.body.clientHeight / 2.0 - 1}px, 0)`
           },
           duration: 0
         })
@@ -232,7 +232,7 @@ export class IOSDialogAnimator extends DialogAnimator {
         .wait(this.delay)
         .queue({
           css: {
-            transform: 'translate3d(-50%, 300%, 0)'
+            transform: `translate3d(-50%, ${document.body.clientHeight / 2.0 - 1}px, 0)`
           },
           duration: this.duration,
           timing: this.timing

--- a/core/src/elements/ons-dialog/animator.js
+++ b/core/src/elements/ons-dialog/animator.js
@@ -151,7 +151,7 @@ export class AndroidDialogAnimator extends DialogAnimator {
  */
 export class IOSDialogAnimator extends DialogAnimator {
 
-  constructor({timing = 'ease-in-out', delay = 0, duration = 0.3} = {}) {
+  constructor({timing = 'ease-in-out', delay = 0, duration = 0.2} = {}) {
     super({timing, delay, duration});
 
     this.bodyHeight = document.body.clientHeight; // avoid Forced Synchronous Layout

--- a/core/src/elements/ons-dialog/index.js
+++ b/core/src/elements/ons-dialog/index.js
@@ -251,7 +251,7 @@ export default class DialogElement extends BaseElement {
       iosWorkaround.classList.add('dialog-ios-workaround');
       iosWorkaround.style.position = 'absolute';
       iosWorkaround.style.width = '1px';
-      iosWorkaround.style.height = '8192px';
+      iosWorkaround.style.height = '4096px';
       iosWorkaround.style.top = '-2048px';
       this._dialog.appendChild(iosWorkaround);
 

--- a/core/src/elements/ons-dialog/index.js
+++ b/core/src/elements/ons-dialog/index.js
@@ -227,12 +227,10 @@ export default class DialogElement extends BaseElement {
 
       const container = document.createElement('div');
       container.classList.add('dialog-container');
-
-      dialog.appendChild(container);
-
       while (this.firstChild) {
         container.appendChild(this.firstChild);
       }
+      dialog.appendChild(container);
 
       this.appendChild(dialog);
     }

--- a/core/src/elements/ons-dialog/index.js
+++ b/core/src/elements/ons-dialog/index.js
@@ -241,24 +241,6 @@ export default class DialogElement extends BaseElement {
       this.insertBefore(mask, this.firstChild);
     }
 
-    // In iOS 9 and iOS 10,
-    // when translate3d animation starts from outside of viewport,
-    // the element warps to the destination.
-    // To prevent that, we have to put a vertically long element into `this._dialog` element.
-    if (platform.isIOS() && !util.findChild(this, '.dialog-ios-workaround')) {
-      // Vertically long element
-      const iosWorkaround = document.createElement('div');
-      iosWorkaround.classList.add('dialog-ios-workaround');
-      iosWorkaround.style.position = 'absolute';
-      iosWorkaround.style.width = '1px';
-      iosWorkaround.style.height = '8192px';
-      iosWorkaround.style.top = '-2048px';
-      this._dialog.appendChild(iosWorkaround);
-
-      // Expose the long element to outside of `this._dialog`
-      this._dialog.style['overflow'] = 'visible';
-    }
-
     this._dialog.style.zIndex = 20001;
     this._mask.style.zIndex = 20000;
 

--- a/core/src/elements/ons-dialog/index.js
+++ b/core/src/elements/ons-dialog/index.js
@@ -241,6 +241,24 @@ export default class DialogElement extends BaseElement {
       this.insertBefore(mask, this.firstChild);
     }
 
+    // In iOS 9 and iOS 10,
+    // when translate3d animation starts from outside of viewport,
+    // the element warps to the destination.
+    // To prevent that, we have to put a vertically long element into `this._dialog` element.
+    if (platform.isIOS() && !util.findChild(this, '.dialog-ios-workaround')) {
+      // Vertically long element
+      const iosWorkaround = document.createElement('div');
+      iosWorkaround.classList.add('dialog-ios-workaround');
+      iosWorkaround.style.position = 'absolute';
+      iosWorkaround.style.width = '1px';
+      iosWorkaround.style.height = '8192px';
+      iosWorkaround.style.top = '-2048px';
+      this._dialog.appendChild(iosWorkaround);
+
+      // Expose the long element to outside of `this._dialog`
+      this._dialog.style['overflow'] = 'visible';
+    }
+
     this._dialog.style.zIndex = 20001;
     this._mask.style.zIndex = 20000;
 

--- a/core/src/elements/ons-dialog/index.js
+++ b/core/src/elements/ons-dialog/index.js
@@ -251,7 +251,7 @@ export default class DialogElement extends BaseElement {
       iosWorkaround.classList.add('dialog-ios-workaround');
       iosWorkaround.style.position = 'absolute';
       iosWorkaround.style.width = '1px';
-      iosWorkaround.style.height = '4096px';
+      iosWorkaround.style.height = '8192px';
       iosWorkaround.style.top = '-2048px';
       this._dialog.appendChild(iosWorkaround);
 


### PR DESCRIPTION
@frandiox
In iOS 9 and iOS 10, when translate3d animation starts from outside of viewport, the element immediately warps to the destination (maybe a bug of iOS Safari).
To prevent that, we have to put a vertically long element into ons-dialog element.

This PR fixes it by putting a vertically long element into .dialog element.
This solution worked in both of iOS 9 and iOS 10.

Could you review this?