### PR TITLE
fix(ons-splitter): Fixes #1717.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ dev
 
  ### Bug Fixes
  * ons-input: text selection in Firefox.
+ * ons-splitter: mask is hidden only if all splitter-sides are in split mode.
 
 v2.2.0
 ----

--- a/core/css/common.css
+++ b/core/css/common.css
@@ -202,10 +202,6 @@ ons-splitter-side[side="right"][mode="collapse"] {
   left: 100%;
 }
 
-ons-splitter-side[mode="split"] ~ ons-splitter-mask {
-  display: none !important;
-}
-
 ons-splitter-side[mode="split"] {
   transform: none !important;
   transition: none !important;

--- a/core/src/elements/ons-splitter-mask.js
+++ b/core/src/elements/ons-splitter-mask.js
@@ -24,10 +24,7 @@ export default class SplitterMaskElement extends BaseElement {
   init() {
     this._boundOnClick = this._onClick.bind(this);
     contentReady(this, () => {
-      console.log(this.parentNode._sides);
-      if (this.parentNode._sides.every(side => {
-        return side.mode === 'split';
-      })) {
+      if (this.parentNode._sides.every(side => side.mode === 'split')) {
         this.setAttribute('style', 'display: none !important');
       }
     });

--- a/core/src/elements/ons-splitter-mask.js
+++ b/core/src/elements/ons-splitter-mask.js
@@ -17,11 +17,20 @@ limitations under the License.
 
 import BaseElement from '../ons/base-element';
 import util from '../ons/util';
+import contentReady from '../ons/content-ready';
 
 export default class SplitterMaskElement extends BaseElement {
 
   init() {
     this._boundOnClick = this._onClick.bind(this);
+    contentReady(this, () => {
+      console.log(this.parentNode._sides);
+      if (this.parentNode._sides.every(side => {
+        return side.mode === 'split';
+      })) {
+        this.setAttribute('style', 'display: none !important');
+      }
+    });
   }
 
   _onClick(event) {


### PR DESCRIPTION
@asial-matagawa Think I found the problem of #1717. The mask was being hidden in CSS if there was one `ons-splitter-side` sibling in `split` mode, which was wrong in case there was another `collapse`-mode `ons-splitter-side`. Instead I'm hiding the mask after the content is ready only if *all* `ons-splitters` are in `split` mode. Please take a look when you can 🙂 