### PR TITLE
fix(ons-splitter-side): Fixes #1876.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ v2.2.0
  * angular1: `number input` retains number type variable with `ngModel`.
  * angular1: Fixed [#1843](https://github.com/OnsenUI/OnsenUI/issues/1843).
  * angular1: Fixed [#1799](https://github.com/OnsenUI/OnsenUI/issues/1799).
+ * core: Fixed [#1876](https://github.com/OnsenUI/OnsenUI/issues/1876).
 
 ### Misc
 

--- a/core/src/elements/ons-splitter-side.js
+++ b/core/src/elements/ons-splitter-side.js
@@ -497,7 +497,9 @@ export default class SplitterSideElement extends BaseElement {
   }
 
   attributeChangedCallback(name, last, current) {
-    this._update(name, current);
+    contentReady(this, () => {
+      this._update(name, current);
+    });
   }
 
   _update(name, value) {


### PR DESCRIPTION
Small fix so that `ons-splitter-side` waits for `contentReady` to correct error in Angular2.