### PR TITLE
fix(ons-splitter-side): Fixes #1876.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ v2.2.0
  * angular1: `number input` retains number type variable with `ngModel`.
  * angular1: Fixed [#1843](https://github.com/OnsenUI/OnsenUI/issues/1843).
  * angular1: Fixed [#1799](https://github.com/OnsenUI/OnsenUI/issues/1799).
+ * core: Fixed [#1876](https://github.com/OnsenUI/OnsenUI/issues/1876).
 
 ### Misc
 

--- a/core/src/elements/ons-splitter-side.js
+++ b/core/src/elements/ons-splitter-side.js
@@ -539,7 +539,12 @@ export default class SplitterSideElement extends BaseElement {
       this._collapseMode[mode === COLLAPSE_MODE ? 'enterMode' : 'exitMode']();
       this.setAttribute('mode', mode);
 
-      util.triggerElementEvent(this, 'modechange', {side: this, mode: mode});
+      for (let i = 0; i < this.parentElement.children.length; i++) {
+        if (this.parentElement.children[i].tagName.toLowerCase() === 'ons-splitter-content') {
+          util.triggerElementEvent(this, 'modechange', {side: this, mode: mode});
+          break;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
@asial-matagawa I found another workaround for #1876: checking the children of the `ons-splitter` for `ons-splitter-content` before emitting the `modechange` event. The check is very simple but a little dirty since it's handling an HTML Collection. Since `_updateMode` is called again after all the elements are there I expect there are no problems, locally I didn't get any but I can't run the tests on Safari so let's see.