### PR TITLE
docs(README): Update `Browser Support` section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ There are lots of sample applications written using Onsen UI. Here are some exam
 
 Onsen UI is tested with the following browsers and mobile OS.
 
- * Android 4.4+ (and Android 4.0+ with Crosswalk engine)
- * iOS8+
- * Google Chrome
+ * Android 4.4.4+ (and Android 4.0+ with Crosswalk engine)
+ * iOS 8+
+ * Chrome
  * Safari
 
 ## What's Included


### PR DESCRIPTION
Android 4.4 - 4.4.3 have Chrome 30 like environment as their WebView, but Custom Elements v0 implementation has been shipped since Chrome 33. Therefore we have to change the supported browser version from `Android 4.4+ WebView` to `Android 4.4.4+ WebView`.

I will merge this.