### PR TITLE
refactor(ons-tab): Sets 'active' attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ dev
  * ons-fab: Covers the toolbar.
  * ons-fab: Hide animation on popPage is now visible.
  * ons-speed-dial: Hide items animation on popPage is now visible.
+ * ons-tab: It shows the last visible page instead of the initial one when reattached.
 
 v2.2.0
 ----

--- a/core/src/elements/ons-tab.js
+++ b/core/src/elements/ons-tab.js
@@ -326,6 +326,7 @@ export default class TabElement extends BaseElement {
   setActive() {
     this._input.checked = true;
     this.classList.add('active');
+    this.setAttribute('active', '');
 
     if (this.hasAttribute('icon') && this.hasAttribute('active-icon')) {
       const icon = this.getAttribute('active-icon');
@@ -342,6 +343,7 @@ export default class TabElement extends BaseElement {
   setInactive() {
     this._input.checked = false;
     this.classList.remove('active');
+    this.removeAttribute('active');
 
     if (this.hasAttribute('icon')) {
       const icon = this.getAttribute('icon');


### PR DESCRIPTION
@asial-matagawa When a tabbar is reattached it shows again the original page instead of the last visible one due to this `active` attribute. That's troublesome in Vue bindings. Navigator or Splitter don't show the first page when they are reattached so I think tabbar should do the same.