### PR TITLE
fix(ons-icon): MD icons don't overwrite FA sizes. Closes #1890.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ dev
  * ons-fab: Hide animation on popPage is now visible.
  * ons-speed-dial: Hide items animation on popPage is now visible.
  * ons-tab: It shows the last visible page instead of the initial one when reattached.
+ * ons-icon: Fixed [#1890](https://github.com/OnsenUI/OnsenUI/issues/1890).
 
 v2.2.0
 ----

--- a/core/css/common.css
+++ b/core/css/common.css
@@ -15,9 +15,9 @@ limitations under the License.
 
  */
 
-@import url("font_awesome/css/font-awesome.min.css");
 @import url("ionicons/css/ionicons.min.css");
 @import url("material-design-iconic-font/css/material-design-iconic-font.min.css");
+@import url("font_awesome/css/font-awesome.min.css");
 
 /* custom elements */
 ons-page, ons-navigator,


### PR DESCRIPTION
@asial-matagawa Simplest fix ever :sweat_smile: 
