### PR TITLE
fix(platform): ons.platform.isSafari() doesn't work in Safari 10

### DIFF
--- a/core/src/ons/platform.js
+++ b/core/src/ons/platform.js
@@ -230,7 +230,7 @@ class Platform {
     if (this._renderPlatform) {
       return this._renderPlatform === 'safari';
     } else {
-      return (Object.prototype.toString.call(window.HTMLElement).indexOf('Constructor') > 0);
+      return (Object.prototype.toString.call(window.HTMLElement).indexOf('Constructor') > 0) || (function (p) { return p.toString() === '[object SafariRemoteNotification]' })(!window['safari'] || safari.pushNotification);
     }
   }
 


### PR DESCRIPTION
ons.platform.isSafari() doesn't work in Safari 10, this method returns `false` in it.

I've tested this solution in last Chrome, Firefox, Safari 10 and Safari Tech Preview.
My solution based on it: http://stackoverflow.com/a/9851769/1474569
