### PR TITLE
fix(ons-input): Fixes #1603.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 CHANGELOG
 ====
 
+dev
+----
+
+### Bug Fixes
+
+ * ons-input: Added initial date value support. Fixed [#1603](https://github.com/OnsenUI/OnsenUI/issues/1603).
+
 v2.2.2
 ----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ dev
 
  * ons-input: Added initial date value support. Fixed [#1603](https://github.com/OnsenUI/OnsenUI/issues/1603).
 
+v2.2.3
+----
+
+### Bug Fixes
+
+ * core: Improve overall stability of the core on iOS by replacing Custom Elements v1 polyfill.
+
 v2.2.2
 ----
 

--- a/bindings/react/CHANGELOG.md
+++ b/bindings/react/CHANGELOG.md
@@ -2,6 +2,10 @@
 CHANGELOG
 ====
 
+dev
+----
+* input: Added initial date value support.
+
 v1.2.0
 ----
 * Fixed [#1768](https://github.com/OnsenUI/OnsenUI/pull/1768).

--- a/bindings/react/src/components/Input.jsx
+++ b/bindings/react/src/components/Input.jsx
@@ -36,6 +36,10 @@ class Input extends BasicComponent {
     super.componentDidMount();
     var node = ReactDOM.findDOMNode(this);
 
+    if (this.props.value !== undefined) {
+      node.value = this.props.value;
+    }
+
     EVENT_TYPES.forEach((eventType) => {
       node.addEventListener(eventType, this.onChange);
     });
@@ -111,7 +115,10 @@ Input.propTypes = {
    *  [en] Content of the input.[/en]
    *  [jp][/jp]
    */
-  value: React.PropTypes.string,
+  value: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.instanceOf(Date)
+  ]),
 
   /**
    * @name checked

--- a/core/src/elements/ons-input.js
+++ b/core/src/elements/ons-input.js
@@ -330,6 +330,9 @@ export default class InputElement extends BaseElement {
 
   set value(val) {
     contentReady(this, () => {
+      if (val instanceof Date) {
+        val = val.toISOString().substring(0, 10);
+      }
       this._input.value = val;
       this._onInput();
     });


### PR DESCRIPTION
@frandiox @asial-matagawa This allows for initialization of date inputs for the core and all bindings (with a special fix in React). It closes #1603.