### PR TITLE
fix(ons-splitter-content): Fixes #1772.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ dev
 
 ### Bug Fixes
 
- * core: Fixed [#1772](https://github.com/OnsenUI/OnsenUI/issues/1772).
+ * ons-splitter-content: Fixed [#1772](https://github.com/OnsenUI/OnsenUI/issues/1772) and [#1930](https://github.com/OnsenUI/OnsenUI/issues/1930).
 
 v2.2.3
 ----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 CHANGELOG
 ====
 
+dev
+----
+
+### Bug Fixes
+
+ * core: Fixed [#1772](https://github.com/OnsenUI/OnsenUI/issues/1772).
+
 v2.2.3
 ----
 

--- a/core/src/elements/ons-splitter-content.js
+++ b/core/src/elements/ons-splitter-content.js
@@ -83,11 +83,13 @@ export default class SplitterContentElement extends BaseElement {
     this._pageLoader = defaultPageLoader;
 
     contentReady(this, () => {
-      const page = this._getPageTarget();
+      rewritables.ready(this, () => {
+        const page = this._getPageTarget();
 
-      if (page) {
-        this.load(page);
-      }
+        if (page) {
+          this.load(page);
+        }
+      });
     });
   }
 


### PR DESCRIPTION
@asial-matagawa This is a pull request to fix a bug in `ons-splitter-content` (which solves #1772). Basically we weren't waiting for the rewritables necessary to wait for page load in the `ons-splitter-content` like we do in `ons-splitter-side`.