### PR TITLE
fix(angular1): Page loader fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ dev
 
 ### Bug Fixes
 
+ * angular1: Page loader now throws `destroy` event when page is unloaded.
 
 ~~v2.2.4~~ (unstable)
 ----

--- a/bindings/angular1/services/onsen.js
+++ b/bindings/angular1/services/onsen.js
@@ -172,10 +172,10 @@ limitations under the License.
               });
             },
             element => {
+              element._destroy();
               if (angular.element(element).data('_scope')) {
                 angular.element(element).data('_scope').$destroy();
               }
-              element.remove();
             }
           );
         },


### PR DESCRIPTION
Page loader now throws 'destroy' event when page is unloaded.