### PR TITLE
fix(vue/test): E2E test returns non-zero exit code on error

### DIFF
--- a/bindings/vue/gulpfile.babel.js
+++ b/bindings/vue/gulpfile.babel.js
@@ -186,9 +186,9 @@ async function runWebdriverIO(standaloneSeleniumServer) {
 
     if (testsPassed) {
       $.util.log($.util.colors.green('Passed E2E tests on all browsers!'));
-      Promise.resolve();
+      return 0;
     } else {
       $.util.log($.util.colors.red('Failed to pass E2E tests on some browsers.'));
-      Promise.reject('e2e-test-webdriverio has failed');
+      return 1;
     }
 }


### PR DESCRIPTION
The test script returns 0 as exit code even if the WebdriverIO test fails.
This causes the test by Circle CI always succeeds.

```
$ npm test
...
[22:42:59] WebdriverIO has exited with 1
[22:42:59] Failed to pass some E2E tests. (Otherwise, the E2E testing itself is broken)
[22:42:59] Failed to pass E2E tests on some browsers.
$ echo $?
0
```

After this commit, `npm test` returns non-zero exit code if the WebdriverIO test fails.

```
$ npm run test
...
[22:41:01] WebdriverIO has exited with 1
[22:41:01] Failed to pass some E2E tests. (Otherwise, the E2E testing itself is broken)
[22:41:01] Failed to pass E2E tests on some browsers.
$ echo $?
1
```