### PR TITLE
fix(ons-pull-hook): Fixes #1970.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ dev
  * angular1: Page loader now throws `destroy` event when page is unloaded.
  * angular1: `myNavigator.topPage.data` should now be ready by the time the controller runs. Fixed [#1854](https://github.com/OnsenUI/OnsenUI/issues/1854).
  * ons-carousel: Fixed [#1952](https://github.com/OnsenUI/OnsenUI/issues/1952).
+ * ons-pull-hook: Fixed [#1970](https://github.com/OnsenUI/OnsenUI/issues/1970).
 
 ### BREAKING CHANGES
 

--- a/core/src/elements/ons-pull-hook.js
+++ b/core/src/elements/ons-pull-hook.js
@@ -459,7 +459,7 @@ export default class PullHookElement extends BaseElement {
   }
 
   attributeChangedCallback(name, last, current) {
-    if (name === 'height') {
+    if (name === 'height' && this._pageElement) {
       this._setStyle();
     }
   }


### PR DESCRIPTION
Small fix for #1970. The problem is probably that the new polyfill caused the `attributeChangedCallback` to run before `connectedCallback` in AngularJS, thus causing the error.
@frandiox can you do a brief check and merge it please?