### PR TITLE
Allow change the defaultPageloader

### DIFF
--- a/core/src/ons/ons.js
+++ b/core/src/ons/ons.js
@@ -55,7 +55,9 @@ ons._animationOptionsParser = animationOptionsParser;
 ons._autoStyle = autoStyle;
 ons._DoorLock = DoorLock;
 ons._contentReady = contentReady;
-ons.defaultPageLoader = defaultPageLoader;
+ons.defaultPageLoader = (pageLoader)=>{
+   return defaultPageLoader=pageLoader;
+};
 ons.PageLoader = PageLoader;
 ons._BaseAnimator = BaseAnimator;
 


### PR DESCRIPTION
Now for change the default page loader, we can write :
```js
ons.defaultPageLoader(new ons.PageLoader(myLoader, myUnLoader));
```

instead of :

```js
ons.defaultPageLoader._loader = myLoader;
ons.defaultPageLoader._unloader = myUnLoader;
```