### PR TITLE
fix(ons-carousel): `refresh` event is now triggered when resized.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ dev
 
 ### Bug Fixes
 
+ * ons-carousel: `refresh` event is now triggered when resized.
  
 ### BREAKING CHANGES
 

--- a/core/src/elements/ons-carousel.js
+++ b/core/src/elements/ons-carousel.js
@@ -335,6 +335,8 @@ export default class CarouselElement extends BaseElement {
     const i = this._scroll / this._currentElementSize;
     delete this._currentElementSize;
     this.setActiveIndex(i);
+
+    this.refresh();
   }
 
   _onDirectionChange() {

--- a/core/src/elements/ons-carousel.spec.js
+++ b/core/src/elements/ons-carousel.spec.js
@@ -3,7 +3,7 @@
 describe('OnsCarouselElement', () => {
   let carousel;
 
-  beforeEach(() => {
+  beforeEach((done) => {
     carousel = ons._util.createElement(`
       <ons-carousel>
         <ons-carousel-item>Item 1</ons-carousel-item>
@@ -12,6 +12,7 @@ describe('OnsCarouselElement', () => {
       </ons-carousel>
     `);
     document.body.appendChild(carousel);
+    setImmediate(done); // wait for `refresh` event triggered by connectedCallback
   });
 
   afterEach(() => {


### PR DESCRIPTION
@frandiox @misterjunio 
This PR fixes the annoying errors on CircleCI like [this](https://circleci.com/gh/OnsenUI/OnsenUI/4496?utm_campaign=chatroom-integration&utm_medium=referral&utm_source=slack).