### PR TITLE
chore(ons-navigator): Remove `options.refresh`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ dev
  * core: Added new method `ons.createElement(...)` that allows creating new elements from templates or inline HTML ([#1941](https://github.com/OnsenUI/OnsenUI/issues/1941)).
  * core: Added `ons-card` element.
  * core: A fake device back button event is now fired on ESC press.
+ * ons-navigator: Added `removePage` method.
  * angular1: Added `ons-action-sheet` bindings.
  * angular1: Added `ons-card` bindings.
  * angular1: Added `ons-list-title` bindings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,10 @@ dev
  
 ### BREAKING CHANGES
 
-* ons.createDialog, ons.createPopover, ons.createAlertDialog: Tags like `<ons-dialog>`, `<ons-alert-dialog>` or `<ons-popover>` are not added automatically anymore to the target template, they must be specified instead.
-* ons-template, external files: `ons-page` tag is not added automatically anymore as a wrapper of the target template. It must be manually specified.
-* ons.notification: Canceled notifications do not reject the returned promise anymore. Instead, when canceled they resolve to `-1` for `alert` and `confirm`, or `null` for `prompt`.
+ * ons-navigator: Removed `options.refresh`.
+ * ons.createDialog, ons.createPopover, ons.createAlertDialog: Tags like `<ons-dialog>`, `<ons-alert-dialog>` or `<ons-popover>` are not added automatically anymore to the target template, they must be specified instead.
+ * ons-template, external files: `ons-page` tag is not added automatically anymore as a wrapper of the target template. It must be manually specified.
+ * ons.notification: Canceled notifications do not reject the returned promise anymore. Instead, when canceled they resolve to `-1` for `alert` and `confirm`, or `null` for `prompt`.
 
 v2.2.6
 ----

--- a/bindings/angular1/test/e2e/navigator/index.html
+++ b/bindings/angular1/test/e2e/navigator/index.html
@@ -39,6 +39,7 @@
           <ons-button id="btn6-reset" ng-click="myNavigator.resetToPage()">Reset To Page</ons-button>
           <ons-button id="btn-insert1" ng-click="myNavigator.insertPage(-1, 'background_1.html', {hoge: 'hoge'})"> Insert Background (Front)</ons-button>
           <ons-button id="btn-insert2" ng-click="myNavigator.insertPage(0, 'background_2.html')"> Insert Background (Back)</ons-button>
+          <ons-button id="btn-remove" ng-click="myNavigator.removePage(0)"> Remove Background</ons-button>
         </div>
       </ons-page>
     </ons-template>

--- a/bindings/angular1/test/e2e/navigator/index.html
+++ b/bindings/angular1/test/e2e/navigator/index.html
@@ -36,7 +36,6 @@
           <ons-button id="btn2" ng-click="myNavigator.popPage()">Pop Page</ons-button>
           <ons-button id="btn3" ng-click="myNavigator.replacePage('page3.html')">Replace Page</ons-button>
           <ons-button id="btn4-device-backbutton" ng-click="ons._deviceBackButtonDispatcher.fireDeviceBackButtonEvent()">Fire 'backbutton' event.</ons-button>
-          <ons-button id="btn5" ng-click="myNavigator.popPage({'refresh': true})">Pop and Refresh Page</ons-button>
           <ons-button id="btn6-reset" ng-click="myNavigator.resetToPage()">Reset To Page</ons-button>
           <ons-button id="btn-insert1" ng-click="myNavigator.insertPage(-1, 'background_1.html', {hoge: 'hoge'})"> Insert Background (Front)</ons-button>
           <ons-button id="btn-insert2" ng-click="myNavigator.insertPage(0, 'background_2.html')"> Insert Background (Back)</ons-button>

--- a/bindings/angular1/test/e2e/navigator/scenarios.js
+++ b/bindings/angular1/test/e2e/navigator/scenarios.js
@@ -163,35 +163,6 @@
       });
     });
 
-    describe('pop and refresh page', function () {
-      it('should refresh previous page when a button is clicked', function () {
-        var page1 = element(by.id('page1'));
-        var page2 = element(by.id('page2'));
-        var status = element(by.id('status'));
-
-        expect(status.getText()).toBe('init');
-
-        element(by.id('btn1')).click();
-        browser.wait(EC.visibilityOf(page2));
-        expect((page2).isDisplayed()).toBeTruthy();
-        var lastElement = element.all(by.xpath('//ons-navigator/ons-page')).last();
-        expect(lastElement.equals(page2)).toBeTruthy();
-        expect((page1).isPresent()).toBeTruthy();
-
-        browser.sleep(500); // Wait for the animation
-
-        element(by.id('btn5')).click();
-        browser.wait(EC.stalenessOf(page2));
-
-        // Check that page2 was destroyed.
-        expect((page1).isDisplayed()).toBeTruthy();
-        expect((page2).isPresent()).not.toBeTruthy();
-
-        // Check that page1 object is a new unmodified object.
-        expect(status.getText()).toBe('init');
-      });
-    });
-
     it('should emit events', function() {
       var pops = element(by.id('pops')),
         pushes = element(by.id('pushes'));

--- a/bindings/angular1/test/e2e/navigator/scenarios.js
+++ b/bindings/angular1/test/e2e/navigator/scenarios.js
@@ -140,6 +140,29 @@
       });
     });
 
+    describe('page remove', function () {
+      it('should remove in background', function () {
+        var page1 = element(by.id('page1'));
+        var page2 = element(by.id('page2'));
+
+        element(by.id('btn1')).click();
+        browser.wait(EC.visibilityOf(page2));
+        expect((page2).isDisplayed()).toBeTruthy();
+
+        var lastElement = element.all(by.xpath('//ons-navigator/ons-page')).last();
+        expect(lastElement.equals(page2)).toBeTruthy();
+        expect((page1).isPresent()).toBeTruthy();
+
+        browser.sleep(500); // Wait for the animation
+
+        element(by.id('btn-remove')).click();
+        browser.wait(EC.stalenessOf(page1));
+
+        var elements = element.all(by.xpath('//ons-navigator/ons-page'));
+        expect(elements.get(0).equals(page2)).toBeTruthy();
+      });
+    });
+
     describe('backbutton handler', function () {
       it('should work on \'backbutton\' event', function() {
         var page1 = element(by.id('page1'));

--- a/bindings/angular1/views/navigator.js
+++ b/bindings/angular1/views/navigator.js
@@ -73,6 +73,7 @@ limitations under the License.
 
         this._clearDerivingMethods = $onsen.deriveMethods(this, element[0], [
           'insertPage',
+          'removePage',
           'pushPage',
           'bringPageTop',
           'popPage',

--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -341,8 +341,8 @@ export default class NavigatorElement extends BaseElement {
    *   [en]Specify the animation's duration, delay and timing. E.g. `{duration: 0.2, delay: 0.4, timing: 'ease-in'}`.[/en]
    *   [ja]アニメーション時のduration, delay, timingを指定します。e.g. {duration: 0.2, delay: 0.4, timing: 'ease-in'}[/ja]
    * @param {Boolean} [options.refresh]
-   *   [en]The previous page will be refreshed (destroyed and created again) before popPage action.[/en]
-   *   [ja]popPageする前に、前にあるページを生成しなおして更新する場合にtrueを指定します。[/ja]
+   *   [en]This option has been removed in Onsen UI 2.3.0. The previous page will be refreshed (destroyed and created again) before popPage action.[/en]
+   *   [ja]このオプションは Onsen UI 2.3.0 で削除されました。popPageする前に、前にあるページを生成しなおして更新する場合にtrueを指定します。[/ja]
    * @param {Function} [options.callback]
    *   [en]Function that is called when the transition has ended.[/en]
    *   [ja]このメソッドによる画面遷移が終了した際に呼び出される関数オブジェクトを指定します。[/ja]
@@ -364,47 +364,7 @@ export default class NavigatorElement extends BaseElement {
       resolve();
     });
 
-    if (!options.refresh) {
-      return this._popPage(options, popUpdate);
-    } else {
-      return this._popPageAndRefresh(options, popUpdate);
-    }
-  }
-
-  _popPageAndRefresh(options, popUpdate) {
-    util.warn('\'refresh\' option for pushPage has been deprecated and will be removed in the next release.');
-
-    const index = this.pages.length - 2;
-    const oldPage = this.pages[index];
-
-    if (!this._pageMap.has(oldPage)) {
-      throw new Error('Refresh option cannot be used with pages directly inside the Navigator. Use ons-template instead.');
-    }
-
-    const page = this._pageMap.get(oldPage);
-
-    return new Promise(resolve => {
-      const options = {
-        page: page,
-        parent: this,
-        params: oldPage.pushedOptions ? oldPage.pushedOptions.data : {}
-      };
-
-      this._pageLoader.load(options, pageElement => {
-        this._pageMap.set(pageElement, page);
-
-        pageElement = util.extend(pageElement, {
-          data: oldPage.data,
-          pushedOptions: oldPage.pushedOptions || {}
-        });
-
-        this.insertBefore(pageElement, oldPage ? oldPage : null);
-        this._pageLoader.unload(oldPage);
-        resolve();
-      });
-
-    }).then(() => this._popPage(options, popUpdate));
-
+    return this._popPage(options, popUpdate);
   }
 
   _popPage(options, update = () => Promise.resolve()) {
@@ -911,8 +871,8 @@ export default class NavigatorElement extends BaseElement {
    * @default  false
    * @type {Boolean}
    * @description
-   *   [en]If this parameter is `true`, the previous page will be refreshed (destroyed and created again) before `popPage()` action.[/en]
-   *   [ja]popPageする前に、前にあるページを生成しなおして更新する場合にtrueを指定します。[/ja]
+   *   [en]This option has been removed in Onsen UI 2.3.0. If this parameter is `true`, the previous page will be refreshed (destroyed and created again) before `popPage()` action.[/en]
+   *   [ja]このオプションは Onsen UI 2.3.0 で削除されました。popPageする前に、前にあるページを生成しなおして更新する場合にtrueを指定します。[/ja]
    */
   get options() {
     return this._options;

--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -623,6 +623,40 @@ export default class NavigatorElement extends BaseElement {
   }
 
   /**
+   * @method removePage
+   * @signature removePage(index, [options])
+   * @param {Number} index
+   *   [en]The index where it should be removed.[/en]
+   *   [ja]スタックから削除するページのインデックスを指定します。[/ja]
+   * @return {Promise}
+   *   [en]Promise which resolves to the revealed page.[/en]
+   *   [ja]削除によって表示されたページを解決するPromiseを返します。[/ja]
+   * @description
+   *   [en]Remove the specified page at a position in the stack defined by the `index` argument. Extends `popPage()` parameters.[/en]
+   *   [ja]指定したインデックスにあるページを削除します。[/ja]
+   */
+  removePage(index, options = {}) {
+    index = this._normalizeIndex(index);
+
+    if (index < this.pages.length - 1) {
+      return new Promise(resolve => {
+        const leavePage = this.pages[index];
+        const enterPage = this.topPage;
+
+        this._pageMap.delete(leavePage);
+        this._pageLoader.unload(leavePage);
+        if (this.pages.length === 1) { // edge case
+          this.topPage.updateBackButton(false);
+        }
+
+        resolve(enterPage);
+      });
+    } else {
+      return this.popPage(options);
+    }
+  }
+
+  /**
    * @method resetToPage
    * @signature resetToPage(page, [options])
    * @return {Promise}

--- a/core/src/elements/ons-navigator/index.spec.js
+++ b/core/src/elements/ons-navigator/index.spec.js
@@ -410,6 +410,60 @@ describe('OnsNavigatorElement', () => {
     });
   });
 
+  describe('#removePage()', () => {
+    it('removes the page on a given index', (done) => {
+      nav.pushPage('info', {
+        callback: () => {
+          expect(nav.pages.length).to.equal(2); // ['hoge', 'info']
+          
+          nav.removePage(0).then(() => {
+            expect(nav.pages.length).to.equal(1); // ['info']
+
+            const content = nav.pages[0]._getContentElement();
+            expect(content.innerHTML).to.equal('info');
+
+            done();
+          });
+        }
+      });
+    });
+
+    it('only accepts object options', (done) => {
+      nav.pushPage('info', {
+        callback: () => {
+          nav.removePage(0).then(() => {
+            expect(() => nav.removePage(0, 'string')).to.throw(Error);
+
+            done();
+          });
+        }
+      });
+    });
+
+    it('redirects to pushPage if the removal is at the top', () => {
+      var spy = chai.spy.on(nav, 'popPage');
+      nav.removePage(0, {});
+      expect(spy).to.have.been.called.once;
+    });
+
+    it('normalizes the index', (done) => {
+      nav.pushPage('info', {
+        callback: () => {
+          expect(nav.pages.length).to.equal(2); // ['hoge', 'info']
+
+          nav.removePage(-2).then(() => {
+            expect(nav.pages.length).to.equal(1); // ['info']
+
+            const content = nav.pages[0]._getContentElement();
+            expect(content.innerHTML).to.equal('info');
+
+            done();
+          });
+        }
+      });
+    });
+  });
+
   describe('#replacePage()', () => {
     it('only accepts object options', () => {
       expect(() => nav.replacePage('hoge', 'string')).to.throw(Error);

--- a/core/src/elements/ons-navigator/index.spec.js
+++ b/core/src/elements/ons-navigator/index.spec.js
@@ -184,40 +184,6 @@ describe('OnsNavigatorElement', () => {
       });
     });
 
-    it('can refresh the previous page', (done) => {
-      nav.pushPage('info', {
-        callback: () => {
-          var content = nav.topPage._getContentElement();
-          content.innerHTML = 'piyo';
-
-          nav.pushPage('fuga', {
-            callback: () => {
-              nav.popPage({
-                refresh: true,
-                callback: () => {
-                  var content = nav.topPage._getContentElement();
-                  expect(content.innerHTML).to.equal('info');
-                  done();
-                }
-              });
-            }
-          });
-        }
-      });
-    });
-
-    it('throws error when refreshing pages directly inside the navigator', (done) => {
-      nav.innerHTML = '<ons-page> Test </ons-page>';
-
-      return nav.pushPage('hoge').then(() => {
-        try {
-          nav.popPage({ refresh: true });
-        } catch(err) {
-          done();
-        }
-      });
-    });
-
     it('emits \'prepop\' event', () => {
       const promise = new Promise((resolve) => {
         nav.addEventListener('prepop', (event) => { resolve(event); });


### PR DESCRIPTION
Related issue: #1831

@frandiox 
This PR removes `options.refresh` for `ons-navigator#popPage`.
Is it safe to remove?