### PR TITLE
feat(onsenui): `onsenui` is now available as ES Modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ dev
  * core: Added new method `ons.createElement(...)` that allows creating new elements from templates or inline HTML.
  * core: Added new method `ons.createElement(...)` that allows creating new elements from templates or inline HTML ([#1941](https://github.com/OnsenUI/OnsenUI/issues/1941)).
  * core: Added `ons-card` element.
+ * core: `onsenui` is now available as ES Modules.
  * core: A fake device back button event is now fired on ESC press.
  * ons-input: Added styling support for `type='search'`.
  * angular1: Added `ons-action-sheet` bindings.

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -469,6 +469,10 @@ gulp.task('prepare', ['html2js'], () =>  {
       .pipe(gulp.dest('build/css/'))
       .pipe(gulpIf(CORDOVA_APP, gulp.dest('cordova-app/www/lib/onsen/css'))),
 
+    // ES Modules (raw ES source codes)
+    gulp.src('core/src/**/*')
+      .pipe(gulp.dest('build/core-src/')),
+
     // angular.js copy
     gulp.src('bindings/angular1/lib/angular/*.*')
       .pipe(gulp.dest('build/js/angular/')),

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test": "gulp test --disable-warnings"
   },
   "main": "js/onsenui.js",
+  "module": "core-src/setup.js",
   "typings": "js/onsenui.d.ts",
   "files": [
     "bower.json",
@@ -34,7 +35,8 @@
     "css-components-src/README.md",
     "css-components-src/styielint.config.js",
     "css-components-src/yarn.lock",
-    "js"
+    "js",
+    "core-src"
   ],
   "repository": {
     "type": "git",
@@ -66,7 +68,6 @@
   ],
   "homepage": "https://onsen.io/",
   "devDependencies": {
-    "@webcomponents/custom-elements": "OnsenUI/custom-elements#1.0.0-rc.3+mod.20170410.1",
     "babel-core": "^6.24.1",
     "babel-eslint": "^6.0.3",
     "babel-loader": "^6.4.1",
@@ -128,5 +129,9 @@
     "wdio-jasmine-framework": "^0.2.16",
     "webdriverio": "^4.4.0",
     "webpack": "^2.4.1"
+  },
+  "dependencies": {
+    "@webcomponents/custom-elements": "OnsenUI/custom-elements#1.0.0-rc.3+mod.20170410.1",
+    "core-js": "2.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1936,13 +1936,13 @@ cookie@0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.1.3.tgz#e734a5c1417fce472d5aef82c381cabb64d1a435"
 
+core-js@2.4.1, core-js@^2.1.0, core-js@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-
-core-js@^2.1.0, core-js@^2.4.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
 core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Related issue: #2001

@frandiox @misterjunio 
This PR enables users to use `onsenui` as ES Modules by providing the raw source codes of Onsen UI and `module` property in `package.json`.
I set `core-src/setup.js` as the entry point of ES Module since we already have `css-components-src` as the name for the raw source code directory of CSS Components.

----
**Usage:**

If a user writes `entry.js` as follows,
```js
import ons from 'onsenui';

ons.disableAutoStyling();

```
and run `webpack entry.js bundle.js`, the user will get:
```sh
$ webpack entry.js bundle.js
Hash: 44e9014d7fd88990db94
Version: webpack 2.5.1
Time: 17127ms
    Asset     Size  Chunks                    Chunk Names
bundle.js  1.67 MB       0  [emitted]  [big]  main
  [70] ./~/onsenui/core-src/elements/ons-toolbar.js 16.5 kB {0} [built]
  [76] ./~/onsenui/core-src/setup.js 9.26 kB {0} [built]
  [78] ./entry.js 238 bytes {0} [built]
 [154] ./~/onsenui/core-src/elements/ons-row.js 10.8 kB {0} [built]
 [155] ./~/onsenui/core-src/elements/ons-select.js 17.8 kB {0} [built]
 [156] ./~/onsenui/core-src/elements/ons-speed-dial-item.js 11.5 kB {0} [built]
 [157] ./~/onsenui/core-src/elements/ons-speed-dial.js 21.6 kB {0} [built]
 [158] ./~/onsenui/core-src/elements/ons-splitter-content.js 16.3 kB {0} [built]
 [159] ./~/onsenui/core-src/elements/ons-splitter-mask.js 11.8 kB {0} [built]
 [160] ./~/onsenui/core-src/elements/ons-splitter-side.js 38.7 kB {0} [built]
 [164] ./~/onsenui/core-src/elements/ons-switch.js 21.6 kB {0} [built]
 [166] ./~/onsenui/core-src/elements/ons-template.js 12.6 kB {0} [built]
 [170] ./~/onsenui/core-src/elements/ons-toast/index.js 19.9 kB {0} [built]
 [172] ./~/onsenui/core-src/elements/ons-toolbar-button.js 13.4 kB {0} [built]
 [177] ./~/onsenui/core-src/ons/ons.js 21.2 kB {0} [built]
    + 182 hidden modules
```

----
**Known issue:**
By default, webpack 2 automatically injects `setImmediate` polyfill (and `process` polyfill + timers polyfill) unless the user set `node` option in `webpack.config.js` to suppress the automatic polyfill injection.
This results in duplicate `setImmediate` polyfills in the same bundle (one is `core-src/polyfills/setImmediate@1.0.2+mod/setImmediate.js` and the other one is injected by webpack 2) and makes the bundle a bit bigger.
(But since both of two `setImmediate` polyfills are loaded after `core-src/polyfills/MutationObserver@0.7.22/MutationObserver.js` (which also polyfills `setImmediate`), the problem explained in https://github.com/OnsenUI/OnsenUI/pull/2005#issuecomment-301691981 cannot occur)

At this moment, I have no idea about how to deal with problem...