### PR TITLE
refactor(core): Rename `init` to `_init`.

### DIFF
--- a/core/src/elements/base/base-dialog.js
+++ b/core/src/elements/base/base-dialog.js
@@ -37,7 +37,7 @@ export default class BaseDialogElement extends BaseElement {
     this.style.display = shouldShow ? 'block' : 'none';
   }
 
-  init() {
+  _init() {
     this._visible = false;
     this._doorLock = new DoorLock();
     this._boundCancel = () => this._cancel();

--- a/core/src/elements/base/base-element.js
+++ b/core/src/elements/base/base-element.js
@@ -28,8 +28,8 @@ function getElementClass() {
 export default class BaseElement extends getElementClass() {
   constructor() {
     super();
-    this.init();
+    this._init();
   }
 
-  init() { }
+  _init() { }
 }

--- a/core/src/elements/ons-action-sheet-button.js
+++ b/core/src/elements/ons-action-sheet-button.js
@@ -78,7 +78,7 @@ export default class ActionSheetButtonElement extends BaseElement {
    *   [ja][/ja]
    */
 
-  init() {
+  _init() {
     contentReady(this, () => this._compile());
   }
 

--- a/core/src/elements/ons-action-sheet/index.js
+++ b/core/src/elements/ons-action-sheet/index.js
@@ -181,8 +181,8 @@ export default class ActionSheetElement extends BaseDialogElement {
    *  [ja]背景のマスクの色を指定します。"rgba(0, 0, 0, 0.2)"がデフォルト値です。[/ja]
    */
 
-  init() {
-    super.init();
+  _init() {
+    super._init();
     contentReady(this, () => this._compile());
   }
 

--- a/core/src/elements/ons-alert-dialog/index.js
+++ b/core/src/elements/ons-alert-dialog/index.js
@@ -188,8 +188,8 @@ export default class AlertDialogElement extends BaseDialogElement {
    *  [ja]背景のマスクの色を指定します。"rgba(0, 0, 0, 0.2)"がデフォルト値です。[/ja]
    */
 
-  init() {
-    super.init();
+  _init() {
+    super._init();
     contentReady(this, () => this._compile());
   }
 

--- a/core/src/elements/ons-back-button.js
+++ b/core/src/elements/ons-back-button.js
@@ -70,7 +70,7 @@ export default class BackButtonElement extends BaseElement {
    *  [ja]バックボタンの見た目を指定します。[/ja]
    */
 
-  init() {
+  _init() {
     contentReady(this, () => {
       this._compile();
     });

--- a/core/src/elements/ons-bottom-toolbar.js
+++ b/core/src/elements/ons-bottom-toolbar.js
@@ -47,7 +47,7 @@ export default class BottomToolbarElement extends BaseElement {
    *   [ja]ツールバーの見た目の表現を指定します。[/ja]
    */
 
-  init() {
+  _init() {
     this.classList.add(defaultClassName);
     ModifierUtil.initModifier(this, scheme);
   }

--- a/core/src/elements/ons-button.js
+++ b/core/src/elements/ons-button.js
@@ -95,7 +95,7 @@ export default class ButtonElement extends BaseElement {
    *   [ja]ボタンを無効化する場合は指定します。[/ja]
    */
 
-  init() {
+  _init() {
     this._compile();
   }
 

--- a/core/src/elements/ons-card.js
+++ b/core/src/elements/ons-card.js
@@ -55,7 +55,7 @@ export default class CardElement extends BaseElement {
    *   [ja]リストの表現を指定します。[/ja]
    */
 
-  init() {
+  _init() {
     contentReady(this, () => {
       this._compile();
     });

--- a/core/src/elements/ons-carousel-item.js
+++ b/core/src/elements/ons-carousel-item.js
@@ -45,7 +45,7 @@ const scheme = {'': 'carousel-item--*'};
  */
 export default class CarouselItemElement extends BaseElement {
 
-  init() {
+  _init() {
     this.style.width = '100%';
     ModifierUtil.initModifier(this, scheme);
   }

--- a/core/src/elements/ons-carousel.js
+++ b/core/src/elements/ons-carousel.js
@@ -318,7 +318,7 @@ export default class CarouselElement extends BaseElement {
    *   [ja]アニメーション時のduration, timing, delayをオブジェクトリテラルで指定します。例：{duration: 0.2, delay: 1, timing: 'ease-in'}[/ja]
    */
 
-  init() {
+  _init() {
     this._doorLock = new DoorLock();
     this._scroll = 0;
     this._offset = 0;

--- a/core/src/elements/ons-col.js
+++ b/core/src/elements/ons-col.js
@@ -55,7 +55,7 @@ import BaseElement from './base/base-element';
  */
 export default class ColElement extends BaseElement {
 
-  init() {
+  _init() {
     if (this.getAttribute('width')) {
       this._updateWidth();
     }

--- a/core/src/elements/ons-dialog/index.js
+++ b/core/src/elements/ons-dialog/index.js
@@ -177,8 +177,8 @@ export default class DialogElement extends BaseDialogElement {
    *  [ja]背景のマスクの色を指定します。"rgba(0, 0, 0, 0.2)"がデフォルト値です。[/ja]
    */
 
-  init() {
-    super.init();
+  _init() {
+    super._init();
     contentReady(this, () => this._compile());
   }
 

--- a/core/src/elements/ons-fab.js
+++ b/core/src/elements/ons-fab.js
@@ -72,7 +72,7 @@ export default class FabElement extends BaseElement {
    *   [ja]ボタンを無効化する場合は指定します。[/ja]
    */
 
-  init() {
+  _init() {
     // The following statements can be executed before contentReady
     // since these do not access the children
     this.hide();

--- a/core/src/elements/ons-gesture-detector.js
+++ b/core/src/elements/ons-gesture-detector.js
@@ -51,7 +51,7 @@ import GestureDetector from '../ons/gesture-detector';
  * </script>
  */
 export default class GestureDetectorElement extends BaseElement {
-  init() {
+  _init() {
     this._gestureDetector = new GestureDetector(this);
   }
 }

--- a/core/src/elements/ons-icon.js
+++ b/core/src/elements/ons-icon.js
@@ -122,7 +122,7 @@ export default class IconElement extends BaseElement {
    *   [ja]アイコンを回転するかどうかを指定します。[/ja]
    */
 
-  init() {
+  _init() {
     this._compile();
   }
 

--- a/core/src/elements/ons-if.js
+++ b/core/src/elements/ons-if.js
@@ -64,7 +64,7 @@ export default class IfElement extends BaseElement {
    *  [ja]portraitもしくはlandscapeを指定します[/ja]
    */
 
-  init() {
+  _init() {
     contentReady(this, () => {
       if (platform._renderPlatform !== null) {
         this._platformUpdate();

--- a/core/src/elements/ons-input.js
+++ b/core/src/elements/ons-input.js
@@ -132,7 +132,7 @@ export default class InputElement extends BaseElement {
    *  [ja][/ja]
    */
 
-  init() {
+  _init() {
     contentReady(this, () => {
       this._compile();
       this.attributeChangedCallback('checked', null, this.getAttribute('checked'));

--- a/core/src/elements/ons-list-header.js
+++ b/core/src/elements/ons-list-header.js
@@ -58,7 +58,7 @@ export default class ListHeaderElement extends BaseElement {
    *   [ja]ヘッダーの表現を指定します。[/ja]
    */
 
-  init() {
+  _init() {
     this._compile();
   }
 

--- a/core/src/elements/ons-list-item.js
+++ b/core/src/elements/ons-list-item.js
@@ -126,7 +126,7 @@ export default class ListItemElement extends BaseElement {
    *   [ja][/ja]
    */
 
-  init() {
+  _init() {
     contentReady(this, () => {
       this._compile();
     });

--- a/core/src/elements/ons-list-title.js
+++ b/core/src/elements/ons-list-title.js
@@ -41,7 +41,7 @@ const scheme = {'': 'list-title--*'};
 
 export default class ListTitleElement extends BaseElement {
 
-  init() {
+  _init() {
     this._compile();
   }
 

--- a/core/src/elements/ons-list.js
+++ b/core/src/elements/ons-list.js
@@ -68,7 +68,7 @@ export default class ListElement extends BaseElement {
    *   [ja]リストの表現を指定します。[/ja]
    */
 
-  init() {
+  _init() {
     this._compile();
   }
 

--- a/core/src/elements/ons-modal/index.js
+++ b/core/src/elements/ons-modal/index.js
@@ -86,8 +86,8 @@ export default class ModalElement extends BaseDialogElement {
    *  [ja]アニメーション時のduration, timing, delayをオブジェクトリテラルで指定します。e.g. <code>{duration: 0.2, delay: 1, timing: 'ease-in'}</code>[/ja]
    */
 
-  init() {
-    super.init();
+  _init() {
+    super._init();
     this._defaultDBB = () => undefined;
     contentReady(this, () => this._compile());
   }

--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -217,7 +217,7 @@ export default class NavigatorElement extends BaseElement {
     return this._animatorFactory;
   }
 
-  init() {
+  _init() {
     this._isRunning = false;
     this._initialized = false;
     this._pageLoader = defaultPageLoader;

--- a/core/src/elements/ons-page.js
+++ b/core/src/elements/ons-page.js
@@ -148,7 +148,7 @@ export default class PageElement extends BaseElement {
    *   [ja][/ja]
    */
 
-  init() {
+  _init() {
     this.classList.add(defaultClassName);
     this._initialized = false;
 

--- a/core/src/elements/ons-popover/index.js
+++ b/core/src/elements/ons-popover/index.js
@@ -201,8 +201,8 @@ export default class PopoverElement extends BaseDialogElement {
    *   [ja]背景のマスクの色を指定します。デフォルトは"rgba(0, 0, 0, 0.2)"です。[/ja]
    */
 
-  init() {
-    super.init();
+  _init() {
+    super._init();
     this._boundOnChange = this._onChange.bind(this);
 
     contentReady(this, () => {

--- a/core/src/elements/ons-progress-bar.js
+++ b/core/src/elements/ons-progress-bar.js
@@ -89,7 +89,7 @@ export default class ProgressBarElement extends BaseElement {
    *   [ja]この属性が設定された場合、ループするアニメーションが表示されます。[/ja]
    */
 
-  init() {
+  _init() {
     contentReady(this, () => this._compile());
   }
 

--- a/core/src/elements/ons-progress-circular.js
+++ b/core/src/elements/ons-progress-circular.js
@@ -89,7 +89,7 @@ export default class ProgressCircularElement extends BaseElement {
    *   [ja]この属性が設定された場合、ループするアニメーションが表示されます。[/ja]
    */
 
-  init() {
+  _init() {
     contentReady(this, () => this._compile());
   }
 

--- a/core/src/elements/ons-pull-hook.js
+++ b/core/src/elements/ons-pull-hook.js
@@ -105,7 +105,7 @@ export default class PullHookElement extends BaseElement {
    *   [ja]この属性がある時、プルフックが引き出されている時にもコンテンツは動きません。[/ja]
    */
 
-  init() {
+  _init() {
     this._boundOnDrag = this._onDrag.bind(this);
     this._boundOnDragStart = this._onDragStart.bind(this);
     this._boundOnDragEnd = this._onDragEnd.bind(this);

--- a/core/src/elements/ons-range.js
+++ b/core/src/elements/ons-range.js
@@ -72,7 +72,7 @@ const INPUT_ATTRIBUTES = [
 
 export default class RangeElement extends BaseElement {
 
-  init() {
+  _init() {
     contentReady(this, () => {
       this._compile();
       this._updateBoundAttributes();

--- a/core/src/elements/ons-ripple/index.js
+++ b/core/src/elements/ons-ripple/index.js
@@ -71,7 +71,7 @@ export default class RippleElement extends BaseElement {
    *   [ja]この属性が設定された場合、リップルエフェクトは無効になります。[/ja]
    */
 
-  init() {
+  _init() {
     contentReady(this, () => this._compile());
 
     this._animator = new Animator();

--- a/core/src/elements/ons-select.js
+++ b/core/src/elements/ons-select.js
@@ -138,7 +138,7 @@ export default class SelectElement extends BaseElement {
    *   [ja]一度に表示する選択肢の個数を指定します。選択肢がこの属性で指定した個数よりも多い場合、スクロールが有効になります。[/ja]
    */
 
-  init() {
+  _init() {
     contentReady(this, () => {
       this._compile();
     });

--- a/core/src/elements/ons-speed-dial-item.js
+++ b/core/src/elements/ons-speed-dial-item.js
@@ -60,7 +60,7 @@ export default class SpeedDialItemElement extends BaseElement {
    *   [ja]このコンポーネントの表現を指定します。[/ja]
    */
 
-  init() {
+  _init() {
     this._compile();
     this._boundOnClick = this._onClick.bind(this);
   }

--- a/core/src/elements/ons-speed-dial.js
+++ b/core/src/elements/ons-speed-dial.js
@@ -108,7 +108,7 @@ export default class SpeedDialElement extends BaseElement {
    *   [ja]無効化する場合に指定します。[/ja]
    */
 
-  init() {
+  _init() {
     contentReady(this, () => {
       this._compile();
     });

--- a/core/src/elements/ons-splitter-content.js
+++ b/core/src/elements/ons-splitter-content.js
@@ -78,7 +78,7 @@ export default class SplitterContentElement extends BaseElement {
    *   [ja]ons-splitter-content要素に表示するページのURLを指定します。[/ja]
    */
 
-  init() {
+  _init() {
     this._page = null;
     this._pageLoader = defaultPageLoader;
 

--- a/core/src/elements/ons-splitter-mask.js
+++ b/core/src/elements/ons-splitter-mask.js
@@ -21,7 +21,7 @@ import contentReady from '../ons/content-ready';
 
 export default class SplitterMaskElement extends BaseElement {
 
-  init() {
+  _init() {
     this._boundOnClick = this._onClick.bind(this);
     contentReady(this, () => {
       if (this.parentNode._sides.every(side => side.mode === 'split')) {

--- a/core/src/elements/ons-splitter-side.js
+++ b/core/src/elements/ons-splitter-side.js
@@ -440,7 +440,7 @@ export default class SplitterSideElement extends BaseElement {
    *   [ja]collapseモード時にスワイプ操作を有効にする場合に指定します。[/ja]
    */
 
-  init() {
+  _init() {
     this._page = null;
     this._pageLoader = defaultPageLoader;
     this._collapseMode = new CollapseMode(this);

--- a/core/src/elements/ons-splitter/index.js
+++ b/core/src/elements/ons-splitter/index.js
@@ -175,7 +175,7 @@ export default class SplitterElement extends BaseElement {
     });
   }
 
-  init() {
+  _init() {
     this._boundOnModeChange = this._onModeChange.bind(this);
 
     contentReady(this, () => {

--- a/core/src/elements/ons-switch.js
+++ b/core/src/elements/ons-switch.js
@@ -169,7 +169,7 @@ export default class SwitchElement extends BaseElement {
     return this._checkbox;
   }
 
-  init() {
+  _init() {
     this._checked = false;
     this._disabled = false;
 

--- a/core/src/elements/ons-tab.js
+++ b/core/src/elements/ons-tab.js
@@ -153,7 +153,7 @@ export default class TabElement extends BaseElement {
    *   [ja][/ja]
    */
 
-  init() {
+  _init() {
     this._pageLoader = defaultPageLoader;
     this._page = null;
 

--- a/core/src/elements/ons-tabbar/index.js
+++ b/core/src/elements/ons-tabbar/index.js
@@ -175,7 +175,7 @@ export default class TabbarElement extends BaseElement {
    *   [ja]タブバーの位置を指定します。"bottom"もしくは"top"を選択できます。デフォルトは"bottom"です。[/ja]
    */
 
-  init() {
+  _init() {
     this._tabbarId = generateId();
 
     contentReady(this, () => {

--- a/core/src/elements/ons-template.js
+++ b/core/src/elements/ons-template.js
@@ -60,7 +60,7 @@ export default class TemplateElement extends BaseElement {
    *  [ja][/ja]
    */
 
-  init() {
+  _init() {
     this.template = this.innerHTML;
 
     while (this.firstChild) {

--- a/core/src/elements/ons-toast/index.js
+++ b/core/src/elements/ons-toast/index.js
@@ -81,8 +81,8 @@ export default class ToastElement extends BaseDialogElement {
    *  [ja]アニメーション時のduration, timing, delayをオブジェクトリテラルで指定します。e.g. <code>{duration: 0.2, delay: 1, timing: 'ease-in'}</code>[/ja]
    */
 
-  init() {
-    super.init();
+  _init() {
+    super._init();
     this._defaultDBB = e => e.callParentHandler();
     contentReady(this, () => this._compile());
   }

--- a/core/src/elements/ons-toolbar-button.js
+++ b/core/src/elements/ons-toolbar-button.js
@@ -81,7 +81,7 @@ export default class ToolbarButtonElement extends BaseElement {
    *   [ja]ボタンを無効化する場合は指定してください。[/ja]
    */
 
-  init() {
+  _init() {
     this._compile();
   }
 

--- a/core/src/elements/ons-toolbar.js
+++ b/core/src/elements/ons-toolbar.js
@@ -101,7 +101,7 @@ export default class ToolbarElement extends BaseElement {
    *   [ja]ツールバーの表現を指定します。[/ja]
    */
 
-  init() {
+  _init() {
     contentReady(this, () => {
       this._compile();
     });


### PR DESCRIPTION
@frandiox @misterjunio 
All the custom element definition classes in the core have `init` method, but it is used as a private method.
Also, @anatoo said that `Maybe we forgot to add the underbar` in Dec 18, 2016.
So I renamed it to `_init`.

I will merge this, but if `init` is a meaningful name I will revert this PR.