### PR TITLE
Remove `module` property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ dev
 
 ### Misc
 
+ * Remove `module` property from `package.json` temporarily.
  * core: Excluded test cases from `onsenui` package.
 
 v2.3.0

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "test": "gulp test --disable-warnings"
   },
   "main": "js/onsenui.js",
-  "module": "core-src/setup.js",
   "typings": "js/onsenui.d.ts",
   "files": [
     "bower.json",


### PR DESCRIPTION
@frandiox 
We provided the raw source code of the Onsen UI Core in `2.3.0` since webpack 2 has not been supporting `unbundled ES Modules -> bundled ES Modules` feature unlike Rollup, but this resulted in:
 - Hard to use: Since we use ES2016, ES2017 and even Stage-3 features for the core, users who use ES Modules-ready environments such as webpack 2 and Rollup have to set up their environments to enable those latest ES features.
 - Long build time: Unbundled ES Modules enables tree-shaking but makes build time much longer.

Even if `module` property is not provided, users who want to use `onsenui` as an ES Module could write as follows:
```js
import 'onsenui/core-src/setup.js';
```