### PR TITLE
Vue scroll fix

### DIFF
--- a/core/src/elements/ons-page.js
+++ b/core/src/elements/ons-page.js
@@ -270,6 +270,14 @@ export default class PageElement extends BaseElement {
     this._backButtonHandler = deviceBackButtonDispatcher.createHandler(this, callback);
   }
 
+  get scrollTop() {
+    return this._contentElement.scrollTop;
+  }
+
+  set scrollTop(newValue) {
+    this._contentElement.scrollTop = newValue;
+  }
+
   /**
    * @return {HTMLElement}
    */
@@ -310,7 +318,6 @@ export default class PageElement extends BaseElement {
   _getBottomToolbarElement() {
     return util.findChild(this, 'ons-bottom-toolbar') || internal.nullElement;
   }
-
 
   /**
    * @return {HTMLElement}


### PR DESCRIPTION
@asial-matagawa What do you think about mapping `pageElement.scrollTop` to `pageElement._contentElement.scrollTop` (81bf4e9)? I think we should provide a cleaner API for our own bindings even if it is not documented. I don't like too much accessing "private" variables (like `_contentElement`) from the bindings. Other solution would be `pageElement.content.scrollTop`.