### PR TITLE
fix(ons-action-sheet): Glitch when hiding on iOS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ dev
 
 ### Bug Fixes
 
+* ons-action-sheet: Fixed glitch when hiding on iOS.
 
 ### Misc
 
@@ -57,7 +58,7 @@ v2.3.0
  * ons-splitter: Fixed `animation` attribute issue.
  * angular1: Page loader now throws `destroy` event when page is unloaded.
  * angular1: `myNavigator.topPage.data` should now be ready by the time the controller runs. Fixed [#1854](https://github.com/OnsenUI/OnsenUI/issues/1854).
- 
+
 ### Misc
 
  * core: Removed polyfill for `Element.prototype.remove`.

--- a/core/src/elements/ons-action-sheet/animator.js
+++ b/core/src/elements/ons-action-sheet/animator.js
@@ -230,7 +230,7 @@ export class IOSActionSheetAnimator extends ActionSheetAnimator {
       .wait(this.delay)
       .queue({
         css: {
-          transform: `translate3d(0, ${this.bodyHeight / 2.0 - 1}px, 0)`
+          transform: `translate3d(0, 100%, 0)`
         },
         duration: this.duration,
         timing: this.timing


### PR DESCRIPTION
@asial-matagawa The bug on iOS 8.0 was visible when moving things inside the view, right? Not when they are moving outside the view. This should fix a [glitch](http://tutorial.onsen.io/?framework=vanilla&category=reference&module=action-sheet) and hopefully won't break the iOS 8.0 thing again.