### PR TITLE
feat(vue): VOnsModel supports v-for with object literal syntax.

### DIFF
--- a/bindings/vue/examples/components/Forms.vue
+++ b/bindings/vue/examples/components/Forms.vue
@@ -25,11 +25,11 @@
       </v-ons-list-header>
       <v-ons-list-item>
         <label class="center" for="switch1">
-          Switch ({{ switchOn ? 'on' : 'off' }})
+          Switch ({{ switchOn.a.b ? 'on' : 'off' }})
         </label>
         <div class="right">
           <v-ons-switch
-            v-ons-model="switchOn"
+            v-ons-model="switchOn.a.b"
             input-id="switch1"
           >
           </v-ons-switch>
@@ -37,11 +37,11 @@
       </v-ons-list-item>
       <v-ons-list-item>
         <label class="center" for="switch2">
-          {{ switchOn ? 'Enabled switch' : 'Disabled switch' }}
+          {{ switchOn.a.b ? 'Enabled switch' : 'Disabled switch' }}
         </label>
         <div class="right">
           <v-ons-switch
-            :disabled="!switchOn"
+            :disabled="!switchOn.a.b"
             input-id="switch2"
           >
           </v-ons-switch>
@@ -131,6 +131,16 @@
         Volume: {{ volume }} <span v-show="volume > 80">&nbsp;(careful, that's loud)</span>
       </v-ons-list-item>
     </v-ons-list>
+
+    <br><br>
+    <v-ons-list-title>Object Literal: {{ vForItems }}</v-ons-list-title>
+    <v-ons-list>
+      <v-ons-list-item v-for="(item, index) in vForItems" :key="item">
+        <div class="left"><v-ons-input type="checkbox" v-ons-model="{ container: item, key: 'checked' }"></v-ons-input></div>
+        <div class="center">Index: #{{ index }}</div>
+        <div class="right">{{ item.checked }}</div>
+      </v-ons-list-item>
+    </v-ons-list>
   </v-ons-page>
 </template>
 
@@ -146,11 +156,12 @@
           { text: 'Underbar', value: 'underbar' }
         ],
         selectedModifier: 'material',
-        switchOn: true,
+        switchOn: {a:{b:true}},
         vegetables: ['Tomato', 'Cabbage', 'Cucumber'],
         selectedVegetable: 'Cabbage',
         colors: ['Red', 'Blue', 'Yellow', 'Green'],
         checkedColors: ['Blue', 'Yellow'],
+        vForItems: [{checked: true}, {checked: false}, {checked: true}],
         volume: 25
       };
     },
@@ -162,7 +173,7 @@
             this.name += ' Rambo';
             break;
           case 'switch':
-            this.switchOn = !this.switchOn;
+            this.switchOn.a.b = !this.switchOn.a.b;
             break;
           case 'radio':
             this.selectedVegetable = 'Tomato';

--- a/bindings/vue/src/directives/VOnsModel.js
+++ b/bindings/vue/src/directives/VOnsModel.js
@@ -1,7 +1,28 @@
 /* Private */
+const _isLiteral = e => e.trim().charAt(0) === '{';
+const _validateLiteral = o => {
+  if (!Object.hasOwnProperty.call(o, 'container')
+   || !Object.hasOwnProperty.call(o, 'key')
+  ) {
+    throw Error(`Object literals in VOnsModel must include 'key' and 'container' properties.`);
+  }
+}
 
-const _getModel = (modelPath, context, newValue) => {
-  const path = modelPath.trim().split('.');
+const _getModel = (binding, context, newValue) => {
+  const expression = (binding.expression || '').trim();
+
+  // Object literal
+  if (_isLiteral(expression)) {
+    _validateLiteral(binding.value);
+
+    if (newValue !== undefined && binding.value.container[binding.value.key] !== newValue) {
+      context.$set(binding.value.container, binding.value.key, newValue); // Setter
+    }
+
+    return binding.value.container[binding.value.key]; // Getter
+  }
+
+  const path = expression.split('.');
   const lastKey = path.pop();
 
   let key, model = context;
@@ -13,7 +34,7 @@ const _getModel = (modelPath, context, newValue) => {
     model[lastKey] = newValue; // Setter
   }
 
-  return model[lastKey]; // Getter
+  return model[lastKey] || binding.value; // Getter
 };
 
 const _setModel = _getModel;
@@ -28,27 +49,28 @@ const _formatOutput = (modifiers = {}, output) => {
   return output;
 };
 
-const _bindOn = (eventName, modelKey, vnode, handler) => {
-  if (vnode.context.hasOwnProperty(modelKey.split('.')[0])) {
+const _bindOn = (eventName, binding, vnode, handler) => {
+  const expression = (binding.expression || '').trim();
+  if (_isLiteral(expression) || vnode.context.hasOwnProperty(expression.split('.')[0])) {
     vnode.child.$on(eventName, handler);
   }
 };
 
-const _bindSimpleInputOn = (eventName, modelKey, vnode, propName) => {
-  _bindOn(eventName, modelKey, vnode, event => {
-    _setModel(modelKey, vnode.context, event.target[propName]);
+const _bindSimpleInputOn = (eventName, binding, vnode, propName) => {
+  _bindOn(eventName, binding, vnode, event => {
+    _setModel(binding, vnode.context, event.target[propName]);
   });
 };
 
-const _bindModifierInputOn = (eventName, modelKey, vnode, modifiers) => {
-  _bindOn(eventName, modelKey, vnode, event => {
-    _setModel(modelKey, vnode.context, _formatOutput(modifiers, event.target.value));
+const _bindModifierInputOn = (eventName, binding, vnode) => {
+  _bindOn(eventName, binding, vnode, event => {
+    _setModel(binding, vnode.context, _formatOutput(binding.modifiers, event.target.value));
   });
 };
 
-const _bindArrayInputOn = (eventName, modelKey, vnode) => {
-  _bindOn(eventName, modelKey, vnode, event => {
-    const modelValue = _getModel(modelKey, vnode.context);
+const _bindArrayInputOn = (eventName, binding, vnode) => {
+  _bindOn(eventName, binding, vnode, event => {
+    const modelValue = _getModel(binding, vnode.context);
     if (modelValue.indexOf(event.target.value) >= 0) {
       !event.target.checked && modelValue.splice(modelValue.indexOf(event.target.value), 1);
     } else {
@@ -57,21 +79,23 @@ const _bindArrayInputOn = (eventName, modelKey, vnode) => {
   });
 };
 
-const _bindCheckbox = (el, binding, vnode, modelKey) => {
-  if (binding.value instanceof Array) {
-    el.checked = binding.value.indexOf(el.value) >= 0;
-    _bindArrayInputOn('change', modelKey, vnode);
+const _bindCheckbox = (el, binding, vnode) => {
+  const value = _getModel(binding, vnode.context);
+  if (value instanceof Array) {
+    el.checked = value.indexOf(el.value) >= 0;
+    _bindArrayInputOn('change', binding, vnode);
   } else {
-    el.checked = !!binding.value;
-    _bindSimpleInputOn('change', modelKey, vnode, 'checked');
+    el.checked = !!value;
+    _bindSimpleInputOn('change', binding, vnode, 'checked');
   }
 };
 
-const _updateCheckbox = (el, binding, vnode, modelKey) => {
-  if (binding.value instanceof Array) {
-    el.checked = (_getModel(modelKey, vnode.context) || []).indexOf(el.value) >= 0;
+const _updateCheckbox = (el, binding, vnode) => {
+  const value = _getModel(binding, vnode.context);
+  if (value instanceof Array) {
+    el.checked = value.indexOf(el.value) >= 0;
   } else {
-    el.checked = !!binding.value;
+    el.checked = !!value;
   }
 };
 
@@ -81,38 +105,38 @@ const _updateCheckbox = (el, binding, vnode, modelKey) => {
 // VOnsModel directive
 export default {
   bind(el, binding, vnode) {
-    const modelKey = binding.expression.trim();
     const tag = el.tagName.toLowerCase();
+    const value = _getModel(binding, vnode.context);
 
     switch (tag) {
       case 'ons-select':
-        el.querySelector('option[value=' + binding.value + ']').setAttribute('selected', '');
-        _bindSimpleInputOn('change', modelKey, vnode, 'value');
+        el.querySelector('option[value=' + value + ']').setAttribute('selected', '');
+        _bindSimpleInputOn('change', binding, vnode, 'value');
         break;
 
       case 'ons-switch':
-        _bindCheckbox(el, binding, vnode, modelKey);
+        _bindCheckbox(el, binding, vnode);
         break;
 
       case 'ons-range':
-        el.value = binding.value;
-        _bindModifierInputOn(Object.hasOwnProperty.call(binding.modifiers, 'lazy') ? 'change' : 'input', modelKey, vnode, binding.modifiers);
+        el.value = value;
+        _bindModifierInputOn(Object.hasOwnProperty.call(binding.modifiers, 'lazy') ? 'change' : 'input', binding, vnode);
         break;
 
       case 'ons-input':
         switch (el.type) {
           case 'radio':
-            el.checked = el.value === binding.value;
-            _bindSimpleInputOn('change', modelKey, vnode, 'value');
+            el.checked = el.value === value;
+            _bindSimpleInputOn('change', binding, vnode, 'value');
             break;
 
           case 'checkbox':
-            _bindCheckbox(el, binding, vnode, modelKey);
+            _bindCheckbox(el, binding, vnode);
             break;
 
           default:
-            el.value = binding.value;
-            _bindModifierInputOn(Object.hasOwnProperty.call(binding.modifiers, 'lazy') ? 'change' : 'input', modelKey, vnode, binding.modifiers);
+            el.value = value;
+            _bindModifierInputOn(Object.hasOwnProperty.call(binding.modifiers, 'lazy') ? 'change' : 'input', binding, vnode);
         }
         break;
 
@@ -131,34 +155,34 @@ export default {
    * component using this directive is updated.
    */
   update(el, binding, vnode) {
-    const modelKey = binding.expression.trim();
     const tag = el.tagName.toLowerCase();
+    const value = _getModel(binding, vnode.context);
 
     switch (tag) {
       case 'ons-select':
-        el.value = binding.value;
+        el.value = value;
         break;
 
       case 'ons-switch':
-        _updateCheckbox(el, binding, vnode, modelKey);
+        _updateCheckbox(el, binding, vnode);
         break;
 
       case 'ons-range':
-        el.value = binding.value;
+        el.value = value;
         break;
 
       case 'ons-input':
         switch (el.type) {
           case 'radio':
-            el.checked = _getModel(modelKey, vnode.context) === el.value;
+            el.checked = value === el.value;
             break;
 
           case 'checkbox':
-            _updateCheckbox(el, binding, vnode, modelKey);
+            _updateCheckbox(el, binding, vnode);
             break;
 
           default:
-            el.value !== binding.value && (el.value = binding.value);
+            el.value !== value && (el.value = value);
         }
         break;
     }


### PR DESCRIPTION
This implements `v-ons-model="{ container: myArrayOrObject, key: myIndexOrKey }"` syntax in order to support `v-for="item in myArrayOrObject"` where `item` is not directly part of `vnode.context`.