### PR TITLE
Bugfix/relative img paths and angular 2 update

### DIFF
--- a/bindings/angular2/package.json
+++ b/bindings/angular2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-onsenui",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "private": false,
   "author": "Mitsunori Kubota <mitsunori@asial.co.jp>",
   "scripts": {
@@ -64,7 +64,7 @@
     "@angular/platform-browser": "^2.4.1",
     "@angular/platform-browser-dynamic": "^2.4.1",
     "core-js": "^2.4.0",
-    "onsenui": "2.2.x",
+    "onsenui": "2.3.x",
     "rxjs": "^5.0.1",
     "zone.js": "^0.7.2"
   },

--- a/css-components/src/components/search-input.css
+++ b/css-components/src/components/search-input.css
@@ -1,5 +1,5 @@
 :root {
-  --search-icon: url('img/ios-search-input-icon.svg');
+  --search-icon: url('../img/ios-search-input-icon.svg');
   --search-input-background-image: var(--search-icon);
   --search-input-background-color: rgba(3, 3, 3, 0.09);
   --search-input-color: var(--input-text-color);
@@ -9,7 +9,7 @@
   --search-input-font-size: 14px;
   --search-input-placeholder-color: #7a797b;
 
-  --material-search-icon: url('img/android-search-input-icon.svg');
+  --material-search-icon: url('../img/android-search-input-icon.svg');
 
   --search-input: {
     @apply(--reset-input);

--- a/css-components/src/components/select.css
+++ b/css-components/src/components/select.css
@@ -69,7 +69,7 @@
   @apply(--select-input);
   padding: 0 20px 0 0;
   background-color: transparent;
-  background-image: url('img/select-arrow.svg');
+  background-image: url('../img/select-arrow.svg');
   background-repeat: no-repeat;
   background-position: right center;
   border-bottom: none;
@@ -122,7 +122,7 @@
   @apply(--material-font);
   color: var(--material-select-input-color);
   font-size: var(--material-select-input-font-size);
-  background-image: url('img/select-arrow.svg'), linear-gradient(to top, rgba(0, 0, 0, 0.12) 50%, rgba(0, 0, 0, 0.12) 50%);
+  background-image: url('../img/select-arrow.svg'), linear-gradient(to top, rgba(0, 0, 0, 0.12) 50%, rgba(0, 0, 0, 0.12) 50%);
   background-size: auto, 100% 1px;
   background-repeat: no-repeat;
   background-position: right center, left bottom;


### PR DESCRIPTION
I recently found out that the ons-card visual styling isn't available in the rc.6 version of the angular2 binding.
While implementing a custom upgrade to the newest onsen-ui version I found out that some of the used img paths are incorrect.
Since the select.ccs and search-input.css both use resources from the img while being located in the components directory.

Directory structure:
-css-components
-----src
---------components
-------------search-input.css
-------------select.css
---------img
-------------android-search-input-icon.svg
-------------ios-search-input-icon.svg
-------------select.arrow.svg

so the paths should be relative e.g.
"../img/<resource>"

instead of
"img/<resource>"

furthermore, I upgraded angular to use the newest onsen-ui (core) version.
So, that angular2 binding users can benefit of the ons-card component.