### PR TITLE
feat(core): Show warning when Onsen UI is loaded more than once.

### DIFF
--- a/core/src/setup.js
+++ b/core/src/setup.js
@@ -49,6 +49,10 @@ import ToolbarElement from './elements/ons-toolbar';
 import RangeElement from './elements/ons-range';
 import CardElement from './elements/ons-card';
 
+if (window.ons) {
+  ons._util.warn('Onsen UI is loaded more than once.');
+}
+
 ons.TemplateElement = TemplateElement;
 ons.IfElement = IfElement;
 ons.ActionSheetElement = ActionSheetElement;


### PR DESCRIPTION
@frandiox @misterjunio 
This PR is required for the next version of Angular 2+ binding (`ngx-onsenui@1.0.0-rc.7`).

Previously Angular 2+ binding users had to load `onsenui.js` outside of module bundlers (= with global namespace pollution), but the next version loads `onsenui` internally if module bundlers are used.
This breaking change can cause Onsen UI loaded more than once, so I added this warning.

I will merge this.