### PR TITLE
Perf toast ascend animator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ dev
 
  * css-components: Refined the appearance of `button` on Android.
  * core: Updated `font-awesome` icon library.
+ * ons-toast: Improved 'ascend' animator performance.
 
 ### BREAKING CHANGES
 

--- a/core/src/elements/ons-fab.js
+++ b/core/src/elements/ons-fab.js
@@ -185,6 +185,12 @@ export default class FabElement extends BaseElement {
     }
   }
 
+  _getTranslate() {
+    const isBottom = (this.getAttribute('position') || '').indexOf('bottom') >= 0;
+    const translate = isBottom ? `translate3d(0px, -${util.globals.fabOffset || 0}px, 0px) ` : '';
+    return translate;
+  }
+
   /**
    * @method show
    * @signature show()
@@ -193,8 +199,9 @@ export default class FabElement extends BaseElement {
    *  [ja][/ja]
    */
   show(options = {}) {
-    this.style.transform = 'scale(1)';
-    this.style.webkitTransform = 'scale(1)';
+    const translate = this._getTranslate();
+    this.style.transform = translate + 'scale(1)';
+    this.style.webkitTransform = translate + 'scale(1)';
   }
 
   /**
@@ -205,8 +212,9 @@ export default class FabElement extends BaseElement {
    *  [ja][/ja]
    */
   hide(options = {}) {
-    this.style.transform = 'scale(0)';
-    this.style.webkitTransform = 'scale(0)';
+    const translate = this._getTranslate();
+    this.style.transform = translate + 'scale(0)';
+    this.style.webkitTransform = translate + 'scale(0)';
   }
 
   /**
@@ -233,7 +241,7 @@ export default class FabElement extends BaseElement {
    *   [ja]要素が見える場合に`true`。[/ja]
    */
   get visible() {
-    return this.style.transform === 'scale(1)' && this.style.display !== 'none';
+    return this.style.transform.indexOf('scale(0)') === -1 && this.style.display !== 'none';
   }
 
   /**

--- a/core/src/elements/ons-speed-dial.js
+++ b/core/src/elements/ons-speed-dial.js
@@ -288,6 +288,12 @@ export default class SpeedDialElement extends BaseElement {
     }
   }
 
+  _getTranslate() {
+    const isBottom = (this.getAttribute('position') || '').indexOf('bottom') >= 0;
+    const translate = isBottom ? `translate3d(0px, -${util.globals.fabOffset || 0}px, 0px) ` : '';
+    return translate;
+  }
+
   /**
    * @method show
    * @signature show()
@@ -297,6 +303,7 @@ export default class SpeedDialElement extends BaseElement {
    */
   show() {
     this._fab.show();
+    this.style.webkitTransform = this.style.transform =  this._getTranslate();
     return Promise.resolve();
   }
 

--- a/core/src/elements/ons-toast/ascend-animator.js
+++ b/core/src/elements/ons-toast/ascend-animator.js
@@ -138,6 +138,6 @@ export default class AscendToastAnimator extends ToastAnimator {
   }
 
   _getFabs() {
-    return util.arrayFrom(document.querySelectorAll('ons-fab[position~=bottom]')).filter(fab => fab.visible);
+    return util.arrayFrom(document.querySelectorAll('ons-fab[position~=bottom], ons-speed-dial[position~=bottom]')).filter(fab => fab.visible);
   }
 }

--- a/core/src/elements/ons-toast/ascend-animator.js
+++ b/core/src/elements/ons-toast/ascend-animator.js
@@ -18,6 +18,7 @@ limitations under the License.
 
 import util from '../../ons/util';
 import animit from '../../ons/animit';
+import platform from '../../ons/platform';
 import ToastAnimator from './animator';
 
 /**
@@ -29,7 +30,7 @@ export default class AscendToastAnimator extends ToastAnimator {
     super({ timing, delay, duration });
 
     this.messageDelay = this.duration * 0.4 + this.delay; // Delay message opacity change
-    this.ascension = undefined; // Calculated during the first animation
+    this.ascension = platform.isAndroid() ? 48 : 64; // Toasts are always 1 line
   }
 
   /**
@@ -38,14 +39,6 @@ export default class AscendToastAnimator extends ToastAnimator {
    */
   show(toast, callback) {
     toast = toast._toast;
-
-    const fabs = util.arrayFrom(document.querySelectorAll('ons-fab[position~=bottom]')).filter(fab => fab.visible);
-
-    if (!this.ascension) {
-      const cs = window.getComputedStyle(toast);
-      this.ascension = parseInt(cs.getPropertyValue('height'), 10) + parseInt(cs.getPropertyValue('margin-bottom'), 10);
-    }
-
     util.globals.fabOffset = this.ascension;
 
     animit.runAll(
@@ -67,7 +60,7 @@ export default class AscendToastAnimator extends ToastAnimator {
           done();
         }),
 
-      animit(fabs)
+      animit(this._getFabs())
         .wait(this.delay)
         .queue({
           transform: `translate3d(0, -${this.ascension}px, 0) scale(1)`
@@ -98,9 +91,6 @@ export default class AscendToastAnimator extends ToastAnimator {
    */
   hide(toast, callback) {
     toast = toast._toast;
-
-    const offset = this.ascension ? `${this.ascension}px` : '100%';
-    const fabs = util.arrayFrom(document.querySelectorAll('ons-fab')).filter(fab => fab.visible);
     util.globals.fabOffset = 0;
 
     animit.runAll(
@@ -111,7 +101,7 @@ export default class AscendToastAnimator extends ToastAnimator {
         })
         .wait(this.delay)
         .queue({
-          transform: `translate3d(0, ${offset}, 0)`
+          transform: `translate3d(0, ${this.ascension}px, 0)`
         }, {
           duration: this.duration,
           timing: this.timing
@@ -122,7 +112,7 @@ export default class AscendToastAnimator extends ToastAnimator {
           done();
         }),
 
-      animit(fabs)
+      animit(this._getFabs())
         .wait(this.delay)
         .queue({
           transform: 'translate3d(0, 0, 0) scale(1)'
@@ -145,5 +135,9 @@ export default class AscendToastAnimator extends ToastAnimator {
         })
         .restoreStyle()
     );
+  }
+
+  _getFabs() {
+    return util.arrayFrom(document.querySelectorAll('ons-fab[position~=bottom]')).filter(fab => fab.visible);
   }
 }

--- a/core/src/elements/ons-toast/ascend-animator.js
+++ b/core/src/elements/ons-toast/ascend-animator.js
@@ -37,13 +37,16 @@ export default class AscendToastAnimator extends ToastAnimator {
    * @param {Function} callback
    */
   show(toast, callback) {
-    const siblingPage = this._findSiblingControlComponent(toast);
     toast = toast._toast;
+
+    const fabs = util.arrayFrom(document.querySelectorAll('ons-fab[position~=bottom]')).filter(fab => fab.visible);
 
     if (!this.ascension) {
       const cs = window.getComputedStyle(toast);
       this.ascension = parseInt(cs.getPropertyValue('height'), 10) + parseInt(cs.getPropertyValue('margin-bottom'), 10);
     }
+
+    util.globals.fabOffset = this.ascension;
 
     animit.runAll(
       animit(toast)
@@ -64,13 +67,10 @@ export default class AscendToastAnimator extends ToastAnimator {
           done();
         }),
 
-      animit(siblingPage) // Cannot save/restore style
-        .queue({
-          bottom: '0'
-        })
+      animit(fabs)
         .wait(this.delay)
         .queue({
-          bottom: `${this.ascension}px`
+          transform: `translate3d(0, -${this.ascension}px, 0) scale(1)`
         }, {
           duration: this.duration,
           timing: this.timing
@@ -97,13 +97,11 @@ export default class AscendToastAnimator extends ToastAnimator {
    * @param {Function} callback
    */
   hide(toast, callback) {
-    const siblingPage = this._findSiblingControlComponent(toast);
     toast = toast._toast;
 
-    if (!this.ascension) {
-      const cs = window.getComputedStyle(toast);
-      this.ascension = parseInt(cs.getPropertyValue('height'), 10) + parseInt(cs.getPropertyValue('margin-bottom'), 10);
-    }
+    const offset = this.ascension ? `${this.ascension}px` : '100%';
+    const fabs = util.arrayFrom(document.querySelectorAll('ons-fab')).filter(fab => fab.visible);
+    util.globals.fabOffset = 0;
 
     animit.runAll(
       animit(toast)
@@ -113,7 +111,7 @@ export default class AscendToastAnimator extends ToastAnimator {
         })
         .wait(this.delay)
         .queue({
-          transform: `translate3d(0, ${this.ascension}px, 0)`
+          transform: `translate3d(0, ${offset}, 0)`
         }, {
           duration: this.duration,
           timing: this.timing
@@ -124,13 +122,10 @@ export default class AscendToastAnimator extends ToastAnimator {
           done();
         }),
 
-      animit(siblingPage) // Cannot save/restore style
-        .queue({
-          bottom: `${this.ascension}px`
-        })
+      animit(fabs)
         .wait(this.delay)
         .queue({
-          bottom: '0'
+          transform: 'translate3d(0, 0, 0) scale(1)'
         }, {
           duration: this.duration,
           timing: this.timing
@@ -150,10 +145,5 @@ export default class AscendToastAnimator extends ToastAnimator {
         })
         .restoreStyle()
     );
-  }
-
-  _findSiblingControlComponent(toast) {
-    const query = e => /(ons-page|ons-navigator|ons-tabbar|ons-splitter)/i.test(e.tagName);
-    return util.findChild(toast.parentNode, query) || util.findChild(document.body.children[0], query);
   }
 }

--- a/core/src/ons/util.js
+++ b/core/src/ons/util.js
@@ -21,6 +21,10 @@ import animationOptionsParse from './animation-options-parser';
 
 const util = {};
 
+util.globals = {
+  fabOffset: 0
+};
+
 /**
  * @param {String/Function} query dot class name or node name or matcher function.
  * @return {Function}

--- a/examples/toast/index.html
+++ b/examples/toast/index.html
@@ -36,6 +36,7 @@
     </p>
     <ons-fab position="bottom left">-</ons-fab>
     <ons-fab position="bottom right">+</ons-fab>
+    <ons-fab position="top right">+</ons-fab>
   </ons-page>
 
   <ons-toast>

--- a/examples/toast/index.html
+++ b/examples/toast/index.html
@@ -34,9 +34,18 @@
       <ons-button modifier="outline" onclick="setAnimation('fall')">Fall</ons-button>
       <ons-button modifier="outline" onclick="setAnimation('fade')">Fade</ons-button>
     </p>
-    <ons-fab position="bottom left">-</ons-fab>
-    <ons-fab position="bottom right">+</ons-fab>
+
     <ons-fab position="top right">+</ons-fab>
+    <ons-fab position="bottom left">+</ons-fab>
+
+    <ons-speed-dial position="right bottom" direction="up">
+      <ons-fab>
+        <ons-icon icon="md-car"></ons-icon>
+      </ons-fab>
+      <ons-speed-dial-item>C</ons-speed-dial-item>
+      <ons-speed-dial-item>B</ons-speed-dial-item>
+      <ons-speed-dial-item>A</ons-speed-dial-item>
+    </ons-speed-dial>
   </ons-page>
 
   <ons-toast>


### PR DESCRIPTION
This needs to be tested in different versions of Android.

@asial-matagawa There shouldn't be more reflows. I realized that the toast is always 1 line... so the heights are always 48 and 64 pixels, no need to compute the height during animation :sweat_smile:
Also, this now always uses `translate3d` for the animations.