### PR TITLE
Remove redundant `-` from all modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ v2.4.2
 
  * ons-fab: Added new appearances for iOS.
 
+### BREAKING CHANGES
+
+ * ons-button: Renamed some modifiers on ons-button component. From `large--cta` to `large-cta`, from `large--quiet` to `large-quite`, from `material--flat` to `material-flat`.
+
 v2.4.1
 ----
 

--- a/bindings/angular1/examples/button/index.html
+++ b/bindings/angular1/examples/button/index.html
@@ -31,11 +31,11 @@
       </ons-button>
       <ons-button modifier="material">button</ons-button>
       <ons-button modifier="material" disabled>disabled</ons-button>
-      <ons-button ripple modifier="material--flat">
+      <ons-button ripple modifier="material-flat">
         flat with ripple
       </ons-button>
-      <ons-button modifier="material--flat">flat</ons-button>
-      <ons-button modifier="material--flat" disabled>flat disabled</ons-button>
+      <ons-button modifier="material-flat">flat</ons-button>
+      <ons-button modifier="material-flat" disabled>flat disabled</ons-button>
     </section>
     <section style="padding: 8px">
       <h3>iOS buttons</h3>
@@ -46,11 +46,11 @@
       <ons-button>Default</ons-button>
       <ons-button modifier="cta">cta</ons-button>
       <p></p>
-      <ons-button modifier="large--quiet">large--quiet</ons-button>
+      <ons-button modifier="large-quiet">large-quiet</ons-button>
       <p></p>
       <ons-button modifier="large">large</ons-button>
       <p></p>
-      <ons-button modifier="large--cta">large--cta</ons-button>
+      <ons-button modifier="large-cta">large-cta</ons-button>
     </section>
 
     <section style="padding: 8px">
@@ -61,11 +61,11 @@
       <ons-button disabled="true">Default</ons-button>
       <ons-button modifier="cta" disabled="true">cta</ons-button>
       <p></p>
-      <ons-button modifier="large--quiet" disabled="true">large--quiet</ons-button>
+      <ons-button modifier="large-quiet" disabled="true">large-quiet</ons-button>
       <p></p>
       <ons-button modifier="large" disabled="true">large</ons-button>
       <p></p>
-      <ons-button modifier="large--cta" disabled="true">large--cta</ons-button>
+      <ons-button modifier="large-cta" disabled="true">large-cta</ons-button>
     </section>
   </ons-page>
 </body>

--- a/bindings/angular1/examples/ripple/index.html
+++ b/bindings/angular1/examples/ripple/index.html
@@ -57,7 +57,7 @@
       Material button
     </ons-button>
 
-    <ons-button modifier="material--flat" ripple>
+    <ons-button modifier="material-flat" ripple>
       Flat button
     </ons-button>
 

--- a/bindings/angular1/examples/styles/app.css
+++ b/bindings/angular1/examples/styles/app.css
@@ -317,7 +317,7 @@ a {
     padding: 10px;
 }
 
-.button--large--cta:active {
+.button--large-cta:active {
     background-color:#000000; 
     color:#FFFFFF; 
 }

--- a/bindings/angular1/examples/text_input/index.html
+++ b/bindings/angular1/examples/text_input/index.html
@@ -36,7 +36,7 @@
 
       <br>
       <br>
-      <ons-button modifier="large--cta" style="display: block; width: 100%; margin-top: 8px;">Submit</ons-button>
+      <ons-button modifier="large-cta" style="display: block; width: 100%; margin-top: 8px;">Submit</ons-button>
     </section>
   </ons-page>
 </body>

--- a/bindings/react/src/components/Button.jsx
+++ b/bindings/react/src/components/Button.jsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
  [/en]
  * [ja][/ja]
  * @example
- * <Button modifier="large--cta">
+ * <Button modifier="large-cta">
  *   Tap Me
  * </Button>
  */

--- a/core/src/elements/ons-button.js
+++ b/core/src/elements/ons-button.js
@@ -42,16 +42,16 @@ const defaultClassName = 'button';
  * @modifier large
  *   [en]Large button that covers the width of the screen.[/en]
  *   [ja]横いっぱいに広がる大きなボタンを表示します。[/ja]
- * @modifier large--quiet
+ * @modifier large-quiet
  *   [en]Large quiet button.[/en]
  *   [ja]横いっぱいに広がるquietボタンを表示します。[/ja]
- * @modifier large--cta
+ * @modifier large-cta
  *   [en]Large call to action button.[/en]
  *   [ja]横いっぱいに広がるctaボタンを表示します。[/ja]
  * @modifier material
  *   [en]Material Design button[/en]
  *   [ja]マテリアルデザインのボタン[/ja]
- * @modifier material--flat
+ * @modifier material-flat
  *   [en]Material Design flat button[/en]
  *   [ja]マテリアルデザインのフラットボタン[/ja]
  * @description
@@ -66,7 +66,7 @@ const defaultClassName = 'button';
  * @guide using-modifier [en]More details about the `modifier` attribute[/en][ja]modifier属性の使い方[/ja]
  * @guide cross-platform-styling [en]Information about cross platform styling[/en][ja]Information about cross platform styling[/ja]
  * @example
- * <ons-button modifier="large--cta">
+ * <ons-button modifier="large-cta">
  *   Tap Me
  * </ons-button>
  */

--- a/core/src/elements/ons-button.spec.js
+++ b/core/src/elements/ons-button.spec.js
@@ -48,9 +48,9 @@ describe('ons-button', () => {
       expect(e.hasAttribute('ripple')).to.be.true;
       expect(e.firstChild.tagName.toLowerCase()).to.equal('ons-ripple');
       e = ons._util.createElement('<ons-button modifier="quiet"></ons-button>');
-      expect(e.getAttribute('modifier')).to.contain('material--flat');
-      e = ons._util.createElement('<ons-button modifier="large--quiet"></ons-button>');
-      expect(e.getAttribute('modifier')).to.contain('large').and.to.contain('material--flat');
+      expect(e.getAttribute('modifier')).to.contain('material-flat');
+      e = ons._util.createElement('<ons-button modifier="large-quiet"></ons-button>');
+      expect(e.getAttribute('modifier')).to.contain('large').and.to.contain('material-flat');
       ons.platform.select('');
     });
   });

--- a/core/src/elements/ons-toolbar-button.spec.js
+++ b/core/src/elements/ons-toolbar-button.spec.js
@@ -59,7 +59,7 @@ describe('ons-toolbar-button', () => {
       let e = document.createElement('ons-toolbar-button');
       expect(e.getAttribute('modifier')).to.equal('material');
       e = ons._util.createElement('<ons-toolbar-button modifier="outline"></ons-toolbar-button>');
-      expect(e.getAttribute('modifier')).to.contain('material--flat');
+      expect(e.getAttribute('modifier')).to.contain('material-flat');
       ons.platform.select('');
     });
   });

--- a/core/src/ons/autostyle.js
+++ b/core/src/ons/autostyle.js
@@ -22,12 +22,12 @@ let autoStyleEnabled = true;
 
 // Modifiers
 const modifiersMap = {
-  'quiet': 'material--flat',
-  'light': 'material--flat',
-  'outline': 'material--flat',
+  'quiet': 'material-flat',
+  'light': 'material-flat',
+  'outline': 'material-flat',
   'cta': '',
-  'large--quiet': 'material--flat large',
-  'large--cta': 'large',
+  'large-quiet': 'material-flat large',
+  'large-cta': 'large',
   'noborder': '',
   'tappable': ''
 };
@@ -69,8 +69,8 @@ platforms.ios = element => {
  if (/material/.test(element.getAttribute('modifier'))) {
    util.removeModifier(element, 'material');
 
-   if (util.removeModifier(element, 'material--flat')) {
-     util.addModifier(element, (util.removeModifier(element, 'large')) ? 'large--quiet' : 'quiet');
+   if (util.removeModifier(element, 'material-flat')) {
+     util.addModifier(element, (util.removeModifier(element, 'large')) ? 'large-quiet' : 'quiet');
    }
 
    if (!element.getAttribute('modifier')) {

--- a/core/src/ons/autostyle.spec.js
+++ b/core/src/ons/autostyle.spec.js
@@ -12,9 +12,9 @@ describe('ons._autoStyle', () => {
     expect(e.hasAttribute('ripple')).to.be.true;
     expect(e.firstChild.tagName.toLowerCase()).to.equal('ons-ripple');
     e = ons._util.createElement('<ons-button modifier="quiet"></ons-button>');
-    expect(e.getAttribute('modifier')).to.contain('material--flat');
-    e = ons._util.createElement('<ons-button modifier="large--quiet"></ons-button>');
-    expect(e.getAttribute('modifier')).to.contain('large').and.to.contain('material--flat');
+    expect(e.getAttribute('modifier')).to.contain('material-flat');
+    e = ons._util.createElement('<ons-button modifier="large-quiet"></ons-button>');
+    expect(e.getAttribute('modifier')).to.contain('large').and.to.contain('material-flat');
     ons.platform.select('');
   });
 
@@ -23,7 +23,7 @@ describe('ons._autoStyle', () => {
       const e = document.createElement('ons-button');
       expect(ons._autoStyle.mapModifier('quiet', e)).to.equal('quiet');
       ons.platform.select('android');
-      expect(ons._autoStyle.mapModifier('quiet', e)).to.equal('material--flat');
+      expect(ons._autoStyle.mapModifier('quiet', e)).to.equal('material-flat');
       e.setAttribute('disable-auto-styling', '');
       expect(ons._autoStyle.mapModifier('quiet', e)).to.equal('quiet');
       ons.platform.select('');

--- a/css-components/src/components/button.css
+++ b/css-components/src/components/button.css
@@ -277,7 +277,7 @@
     <button class="button--large--quiet" style="width: 95%; margin: 0 auto;">Button</button>
 */
 
-.button--large--quiet { /* stylelint-disable-line */
+.button--large-quiet {
   @apply(--button);
   font-size: var(--font-size--large);
   font-weight: var(--font-weight--large);
@@ -290,22 +290,23 @@
   text-align: center;
 }
 
-.button--large--quiet:active { /* stylelint-disable-line */
+.button--large-quiet:active {
   transition: none;
   opacity: var(--button-active-opacity);
   color: var(--button-quiet-color);
   @apply(--button--quiet);
 }
 
-.button--large--quiet:disabled, .button--large--quiet[disabled] { /* stylelint-disable-line */
+.button--large-quiet:disabled,
+.button--large-quiet[disabled] {
   @apply(--button--disabled);
 }
 
-.button--large--quiet:hover { /* stylelint-disable-line */
+.button--large-quiet:hover {
   @apply(--button--hover);
 }
 
-.button--large--quiet:focus { /* stylelint-disable-line */
+.button--large-quiet:focus {
   outline: 0;
 }
 
@@ -317,7 +318,7 @@
     <button class="button--large--cta" style="width: 95%; margin: 0 auto;">Button</button>
 */
 
-.button--large--cta { /* stylelint-disable-line */
+.button--large-cta {
   @apply(--button);
   border: none;
   background-color: var(--button-cta-background-color);
@@ -331,22 +332,23 @@
   display: block;
 }
 
-.button--large--cta:hover { /* stylelint-disable-line */
+.button--large-cta:hover {
   @apply(--button--hover);
 }
 
-.button--large--cta:focus { /* stylelint-disable-line */
+.button--large-cta:focus {
   @apply(--button--focus);
 }
 
-.button--large--cta:active { /* stylelint-disable-line */
+.button--large-cta:active {
   color: var(--button-cta-color);
   background-color: var(--button-cta-background-color);
   transition: none;
   opacity: var(--button-active-opacity);
 }
 
-.button--large--cta:disabled, .button--large--cta[disabled] { /* stylelint-disable-line */
+.button--large-cta:disabled,
+.button--large-cta[disabled] {
   @apply(--button--disabled);
 }
 
@@ -398,7 +400,7 @@
     <button class="button button--material--flat" disabled>DISABLED</button>
 */
 
-.button--material--flat { /* stylelint-disable-line */
+.button--material-flat {
   @apply(--button--material);
   @apply(--material-shadow-0);
   background-color: transparent;
@@ -406,11 +408,11 @@
   transition: all 0.25s linear;
 }
 
-.button--material--flat:hover { /* stylelint-disable-line */
+.button--material-flat:hover {
   transition: all 0.25s linear;
 }
 
-.button--material--flat:focus { /* stylelint-disable-line */
+.button--material-flat:focus {
   @apply(--material-shadow-0);
   background-color: transparent;
   color: var(--material-button-background-color);
@@ -419,7 +421,7 @@
   border: none;
 }
 
-.button--material--flat:active { /* stylelint-disable-line */
+.button--material-flat:active {
   @apply(--material-shadow-0);
   outline: 0;
   opacity: 1;
@@ -429,7 +431,8 @@
   transition: all 0.25s linear;
 }
 
-.button--material--flat:disabled, .button--material--flat[disabled] {/* stylelint-disable-line */
+.button--material-flat:disabled,
+.button--material-flat[disabled] {
   transition: none;
   opacity: 1;
   @apply(--material-shadow-0);

--- a/examples/button/index.html
+++ b/examples/button/index.html
@@ -23,11 +23,11 @@
     <ons-button>Default</ons-button>
     <ons-button modifier="cta">cta</ons-button>
     <p></p>
-    <ons-button modifier="large--quiet">large--quiet</ons-button>
+    <ons-button modifier="large-quiet">large-quiet</ons-button>
     <p></p>
     <ons-button modifier="large">large</ons-button>
     <p></p>
-    <ons-button modifier="large--cta">large--cta</ons-button>
+    <ons-button modifier="large-cta">large-cta</ons-button>
 
     <!-- Disabled -->
     <p></p><br><br>
@@ -37,11 +37,11 @@
     <ons-button disabled="true">Default</ons-button>
     <ons-button modifier="cta" disabled="true">cta</ons-button>
     <p></p>
-    <ons-button modifier="large--quiet" disabled="true">large--quiet</ons-button>
+    <ons-button modifier="large-quiet" disabled="true">large-quiet</ons-button>
     <p></p>
     <ons-button modifier="large" disabled="true">large</ons-button>
     <p></p>
-    <ons-button modifier="large--cta" disabled="true">large--cta</ons-button>
+    <ons-button modifier="large-cta" disabled="true">large-cta</ons-button>
   </ons-page>
 </body>
 </html>


### PR DESCRIPTION
@asial-matagawa @frandiox @misterjunio I renamed some modifiers have redundant `-` on `ons-button`. I think all modifiers should not have `--` anymore. Should we merge this changes? Let me know what do you think.

Changes: 

  * `large--cta` => `large-cta`
  * `large--quiet` => `large-quiet`
  * `material--flat` => `material-flat`
