### PR TITLE
Add gulp tasks for building `vue-onsenui-helper-json` package.

### DIFF
--- a/bindings/vue/.gitignore
+++ b/bindings/vue/.gitignore
@@ -1,3 +1,2 @@
 node_modules
-build
 npm-debug.log

--- a/bindings/vue/.gitignore
+++ b/bindings/vue/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+build
 npm-debug.log

--- a/bindings/vue/gulpfile.babel.js
+++ b/bindings/vue/gulpfile.babel.js
@@ -93,7 +93,7 @@ gulp.task('build:helper-json', ['build:core-docs'], (done) => {
     }
   };
 
-  const destinationPath = path.join(__dirname, 'build', 'vue-onsenui-helper-json');
+  const destinationPath = path.join(__dirname, 'packages', 'vue-onsenui-helper-json');
   const tags = {};
   const attributes = {};
 

--- a/bindings/vue/gulpfile.babel.js
+++ b/bindings/vue/gulpfile.babel.js
@@ -1,6 +1,7 @@
 import 'babel-polyfill';
 
 import gulp from 'gulp';
+import * as glob from 'glob';
 import path from'path';
 import {merge} from 'event-stream';
 import runSequence from 'run-sequence';
@@ -9,6 +10,7 @@ import WebpackDevServer from 'webpack-dev-server';
 import open from 'open';
 import os from 'os';
 import fs from 'fs';
+import fse from 'fs-extra';
 import yargs, {argv} from 'yargs';
 import {spawn} from 'child_process';
 import WebdriverIOLauncher from 'webdriverio/build/lib/launcher';
@@ -41,6 +43,150 @@ gulp.task('build:core-docs', (done) => {
       done();
     }
   });
+});
+
+// Build tags and attribute data files required for `vue-onsenui-helper-json`.
+//
+// `vue-onsenui-tags.json`
+//    tells
+//    (1) what tags exist in `vue-onsenui`
+//    (2) the allowed attributes and the description of each tag.
+// `vue-onsenui-attributes.json` 
+//    tells the type, the description and the allowed values of each attribute.
+//
+// Their schemas are defined in the corresponding tag provider in vuejs/vetur.
+gulp.task('build:helper-json', ['build:core-docs'], (done) => {
+  const extractEnglishDescription = (description) => {
+    // Extract inner characters of [en][/en]
+    let match;
+    if (match = /\[en]((.|\r|\n)*)\[\/en]/m.exec(description)) {
+      const extractedCharacters = match[1];
+
+      // Remove leading whitespaces
+      return extractedCharacters.replace(/^[\n ]*(.*)/, '$1');
+    }
+
+    return '';
+  };
+  const convertType = (type) => {
+    switch (true) { // regex switch
+      case /^Boolean$/.test(type):
+        return 'any'; // Vetur (0.8.6) recognizes only `v` and `event` as a valid type
+      case /^Number$/.test(type):
+        return 'any'; // same as above
+      case /^String$/.test(type):
+        return 'any'; // same as above
+      case /^Color$/.test(type):
+        return 'any'; // same as above
+      case /^Function$/.test(type):
+        return 'any'; // same as above
+      case /^Array$/.test(type):
+        return 'any'; // same as above
+      case /^Expression$/.test(type):
+        return 'any'; // same as above
+      case /^Object$/.test(type):
+        return 'any'; // same as above
+      case /|/.test(type):
+        return 'any'; // same as above
+      default:
+        throw new Error(`Unknown type: ${JSON.stringify(type)}`);
+    }
+  };
+
+  const destinationPath = path.join(__dirname, 'build', 'vue-onsenui-helper-json');
+  const tags = {};
+  const attributes = {};
+
+  glob.sync('../../build/docs/element/*.json').forEach((path) => {
+    const doc = JSON.parse(fs.readFileSync(path));
+
+    // Add prefix `v-`
+    doc.name = doc.name.replace(/^ons-/, 'v-ons-').replace(/^(ons)(\.|$)/gm, '$$$&');
+
+    // Only core tags and vue-onsenui tags should be shown in autocompletion
+    if (!(doc.extensionOf == null || doc.extensionOf === 'vue')) {
+      return;
+    }
+
+    // Some tags don't exist in vue-onsenui
+    if (['v-ons-if', 'v-ons-template', 'v-ons-gesture-detector'].indexOf(doc.name) !== -1) {
+      return;
+    }
+
+    // Filter attributes
+    // (Partially copied from OnsenUI/onsen.io/modules/v2-wc-api-docs.js)
+    for (let i = doc.attributes.length - 1 ; i >= 0 ; i--) {
+      const attr = doc.attributes[i];
+
+      const isAllowedAttr =
+        // Only core attributes and vue-onsenui attributes should be shown in autocompletion
+        (attr.extensionOf == null || attr.extensionOf === 'vue')
+        &&
+        // Some attributes don't exist in vue-onsenui
+        !/(^on-|initial-index|page$|delegate)/.test(attr.name);
+
+      if (isAllowedAttr) {
+        if (/^animation/.test(attr.name)) {
+          attr.name = 'options.' + attr.name;
+        }
+        attr.type = attr.type || 'Boolean';
+      } else {
+        // console.log(`Excluded attribute: ${doc.name}/${attr.name}`);
+        doc.attributes.splice(i, 1);
+      }
+    }
+
+    // If the tag has `options.*` attribute, remove them all and add `option` attribute.
+    if (doc.attributes.find(attr => attr.name.match(/^options/))) {
+      doc.attributes = doc.attributes.filter(attr => !attr.name.match(/^options/));
+      doc.attributes.push(
+        {
+          name: 'options',
+          type: 'Expression',
+          description: '\n[en]Additional options for this element. Must be specified with an object.[/en]\n[ja][/ja]',
+          deprecated: false,
+          required: false,
+          default: null,
+          initonly: false
+        }
+      );
+    }
+
+    // Add the tag to `vue-onsenui-tags.json`
+    tags[doc.name] = {
+      attributes: doc.attributes.map(attr => attr.name),
+      description: extractEnglishDescription(doc.description),
+    };
+
+    // Add the attributes of the tag to `vue-onsenui-attributes.json`
+    for (const attr of doc.attributes) {
+      try {
+        attributes[`${doc.name}/${attr.name}`] = {
+          type: convertType(attr.type),
+          description: extractEnglishDescription(attr.description),
+        };
+      } catch (e) {
+        console.error(e.stack);
+        throw new Error(`Failed to convert type of the following attribute:\n${JSON.stringify(attr, null, 2)}`);
+      }
+    }
+  });
+
+  // Generate `vue-onsenui-tags.json`
+  fse.outputFileSync(
+    path.join(destinationPath, 'vue-onsenui-tags.json'),
+    JSON.stringify(tags, null, 2),
+    {encoding: 'utf8'}
+  );
+
+  // Generate `vue-onsenui-attributes.json`
+  fse.outputFileSync(
+    path.join(destinationPath, 'vue-onsenui-attributes.json'),
+    JSON.stringify(attributes, null, 2),
+    {encoding: 'utf8'}
+  );
+
+  done();
 });
 
 gulp.task('serve', done => {

--- a/bindings/vue/gulpfile.babel.js
+++ b/bindings/vue/gulpfile.babel.js
@@ -18,6 +18,31 @@ const $ = require('gulp-load-plugins')();
 
 const FLAGS = `--inline --colors --progress --display-error-details --display-cached`;
 
+// Build docs by running the parent gulpfile.
+//
+// We need the files in `build/docs/` in the project root
+// to generate tags data and attributes data of `vue-onsenui` components.
+gulp.task('build:core-docs', (done) => {
+  console.log('Running parent gulpfile...');
+  spawn('node_modules/.bin/gulp', ['build-docs'],
+    {
+      cwd: path.join(__dirname, '..', '..'), // exec in the project root
+      stdio: 'inherit', // redirect stdio/stdout/stderr to this process
+    }
+  )
+  .on('error', function (error) {
+      done(new Error(error.message));
+  })
+  .on('exit', function(code) {
+    if (code !== 0) {
+      done(new Error('gulp exited with code ' + code));
+    } else {
+      console.log('Done.');
+      done();
+    }
+  });
+});
+
 gulp.task('serve', done => {
   createDevServer('./webpack.config.js').listen('3030', '0.0.0.0', () => {
     open('http://0.0.0.0:3030/index.html');

--- a/bindings/vue/package.json
+++ b/bindings/vue/package.json
@@ -5,7 +5,8 @@
   "author": "Onsen UI Team <team@monaca.io>",
   "scripts": {
     "dev": "webpack-dev-server --inline --hot --host 0.0.0.0",
-    "build": "cross-env NODE_ENV=production webpack --progress --hide-modules --config webpack.config.prod.js",
+    "build": "cross-env NODE_ENV=production webpack --progress --hide-modules --config webpack.config.prod.js && npm run build:helper-json",
+    "build:helper-json": "gulp build:helper-json",
     "prepublish": "npm run build",
     "test": "gulp test"
   },

--- a/bindings/vue/package.json
+++ b/bindings/vue/package.json
@@ -53,6 +53,8 @@
     "cross-env": "^1.0.8",
     "css-loader": "^0.23.1",
     "file-loader": "^0.8.5",
+    "fs-extra": "^3.0.1",
+    "glob": "^7.1.2",
     "gulp-chmod": "^2.0.0",
     "gulp-download": "^0.0.1",
     "gulp-unzip": "^0.2.0",

--- a/bindings/vue/packages/vue-onsenui-helper-json/.gitignore
+++ b/bindings/vue/packages/vue-onsenui-helper-json/.gitignore
@@ -1,0 +1,2 @@
+vue-onsenui-tags.json
+vue-onsenui-attributes.json

--- a/bindings/vue/packages/vue-onsenui-helper-json/CHANGELOG.md
+++ b/bindings/vue/packages/vue-onsenui-helper-json/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 ====
 
-dev
+v1.0.0
 ----
 
  * Initial version of this package.

--- a/bindings/vue/packages/vue-onsenui-helper-json/CHANGELOG.md
+++ b/bindings/vue/packages/vue-onsenui-helper-json/CHANGELOG.md
@@ -1,0 +1,8 @@
+CHANGELOG
+====
+
+dev
+----
+
+ * Initial version of this package.
+ * Supported `onsenui@2.4.2` and `vue-onsenui@2.0.0`.

--- a/bindings/vue/packages/vue-onsenui-helper-json/LICENSE
+++ b/bindings/vue/packages/vue-onsenui-helper-json/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2013-2017 ASIAL CORPORATION
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/bindings/vue/packages/vue-onsenui-helper-json/README.md
+++ b/bindings/vue/packages/vue-onsenui-helper-json/README.md
@@ -1,0 +1,10 @@
+# vue-onsenui-helper-json
+
+Tags and attributes information of vue-onsenui, which makes IDE / test editor plugin development easier.
+
+This NPM package is maintained in the following directory in [OnsenUI/OnsenUI](https://github.com/OnsenUI/OnsenUI):  
+https://github.com/OnsenUI/OnsenUI/tree/master/bindings/vue/packages/vue-onsenui-helper-json
+
+## Supported Environments
+
+- [Vetur](https://github.com/vuejs/vetur)

--- a/bindings/vue/packages/vue-onsenui-helper-json/package.json
+++ b/bindings/vue/packages/vue-onsenui-helper-json/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "vue-onsenui-helper-json",
+  "version": "0.0.0",
+  "author": "Onsen UI Team <team@monaca.io>",
+  "description": "Tags and attributes information of vue-onsenui, which makes IDE / test editor plugin development easier.",
+  "private": false,
+  "files": [
+    "vue-onsenui-tags.json",
+    "vue-onsenui-attributes.json"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OnsenUI/vue-onsenui-helper-json.git"
+  },
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/OnsenUI/vue-onsenui-helper-json/issues"
+  },
+  "homepage": "https://github.com/OnsenUI/vue-onsenui-helper-json#readme"
+}

--- a/bindings/vue/packages/vue-onsenui-helper-json/package.json
+++ b/bindings/vue/packages/vue-onsenui-helper-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-onsenui-helper-json",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "author": "Onsen UI Team <team@monaca.io>",
   "description": "Tags and attributes information of vue-onsenui, which makes IDE / test editor plugin development easier.",
   "private": false,

--- a/bindings/vue/yarn.lock
+++ b/bindings/vue/yarn.lock
@@ -296,17 +296,7 @@ babel-helper-explode-assignable-expression@^6.22.0:
     babel-traverse "^6.22.0"
     babel-types "^6.22.0"
 
-babel-helper-function-name@^6.22.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.23.0.tgz#25742d67175c8903dbe4b6cb9d9e1fcb8dcf23a6"
-  dependencies:
-    babel-helper-get-function-arity "^6.22.0"
-    babel-runtime "^6.22.0"
-    babel-template "^6.23.0"
-    babel-traverse "^6.23.0"
-    babel-types "^6.23.0"
-
-babel-helper-function-name@^6.24.1:
+babel-helper-function-name@^6.22.0, babel-helper-function-name@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz#d3475b8c03ed98242a25b48351ab18399d3580a9"
   dependencies:
@@ -315,13 +305,6 @@ babel-helper-function-name@^6.24.1:
     babel-template "^6.24.1"
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
-
-babel-helper-get-function-arity@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz#0beb464ad69dc7347410ac6ade9f03a50634f5ce"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-types "^6.22.0"
 
 babel-helper-get-function-arity@^6.24.1:
   version "6.24.1"
@@ -731,17 +714,7 @@ babel-template@^6.16.0:
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-template@^6.22.0, babel-template@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.23.0.tgz#04d4f270adbb3aa704a8143ae26faa529238e638"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-traverse "^6.23.0"
-    babel-types "^6.23.0"
-    babylon "^6.11.0"
-    lodash "^4.2.0"
-
-babel-template@^6.24.1:
+babel-template@^6.22.0, babel-template@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
   dependencies:
@@ -765,21 +738,7 @@ babel-traverse@^6.16.0, babel-traverse@^6.18.0:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.22.0, babel-traverse@^6.23.0:
-  version "6.23.1"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.23.1.tgz#d3cb59010ecd06a97d81310065f966b699e14f48"
-  dependencies:
-    babel-code-frame "^6.22.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.23.0"
-    babylon "^6.15.0"
-    debug "^2.2.0"
-    globals "^9.0.0"
-    invariant "^2.2.0"
-    lodash "^4.2.0"
-
-babel-traverse@^6.24.1:
+babel-traverse@^6.22.0, babel-traverse@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
   dependencies:
@@ -802,18 +761,9 @@ babel-types@^6.16.0, babel-types@^6.18.0:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babel-types@^6.19.0, babel-types@^6.24.1:
+babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
-  dependencies:
-    babel-runtime "^6.22.0"
-    esutils "^2.0.2"
-    lodash "^4.2.0"
-    to-fast-properties "^1.0.1"
-
-babel-types@^6.22.0, babel-types@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.23.0.tgz#bb17179d7538bad38cd0c9e115d340f77e7e9acf"
   dependencies:
     babel-runtime "^6.22.0"
     esutils "^2.0.2"
@@ -831,6 +781,10 @@ babylon@^6.15.0:
 balanced-match@^0.4.1, balanced-match@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
+
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
 balanced-match@~0.1.0:
   version "0.1.0"
@@ -896,6 +850,13 @@ brace-expansion@^1.0.0:
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.6.tgz#7197d7eaa9b87e648390ea61fc66c84427420df9"
   dependencies:
     balanced-match "^0.4.1"
+    concat-map "0.0.1"
+
+brace-expansion@^1.1.7:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
+  dependencies:
+    balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 braces@^1.8.2:
@@ -1830,6 +1791,14 @@ fresh@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.3.0.tgz#651f838e22424e7566de161d8358caa199f83d4f"
 
+fs-extra@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1920,6 +1889,17 @@ glob@^7.0.0, glob@^7.0.5, glob@^7.0.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 globals@^9.0.0:
   version "9.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.12.0.tgz#992ce90828c3a55fa8f16fada177adb64664cf9d"
@@ -1930,7 +1910,7 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-graceful-fs@^4.1.0, graceful-fs@^4.1.2:
+graceful-fs@^4.1.0, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.9"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.9.tgz#baacba37d19d11f9d146d3578bc99958c3787e29"
 
@@ -2217,13 +2197,7 @@ interpret@^0.6.4:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-0.6.6.tgz#fecd7a18e7ce5ca6abfb953e1f86213a49f1625b"
 
-invariant@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.1.tgz#b097010547668c7e337028ebe816ebe36c8a8d54"
-  dependencies:
-    loose-envify "^1.0.0"
-
-invariant@^2.2.2:
+invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -2467,6 +2441,12 @@ json3@^3.3.2:
 json5@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.0.tgz#9b20715b026cbe3778fd769edccd822d8332a5b2"
+
+jsonfile@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.0.tgz#92e7c7444e5ffd5fa32e6a9ae8b85034df8347d0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonpointer@^4.0.0:
   version "4.0.0"
@@ -2904,6 +2884,12 @@ minimatch@^3.0.0, minimatch@^3.0.2:
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
     brace-expansion "^1.0.0"
+
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
 
 minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
@@ -4374,6 +4360,10 @@ uniqid@^4.0.0:
 uniqs@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/uniqs/-/uniqs-2.0.0.tgz#ffede4b36b25290696e6e165d4a59edb998e6b02"
+
+universalify@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.0.tgz#9eb1c4651debcc670cc94f1a75762332bb967778"
 
 unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
@masahirotanaka @frandiox @misterjunio @takuyaW 
This PR adds new gulp tasks for building a metadata package of `vue-onsenui` which is required for IDE plugins such as [Vetur](https://github.com/vuejs/Vetur).
I already created [`OnsenUI/vue-onsenui-helper-json`](https://github.com/OnsenUI/vue-onsenui-helper-json) and published a npm package [`vue-onsenui-helper`](https://www.npmjs.com/package/vue-onsenui-helper-json) by using the gulp tasks.

After this PR, whenever building the production package of `vue-onsenui`, the following two files will be created (and ignored by `.gitignore`):
- `bindings/vue/packages/vue-onsenui-helper-json/vue-onsenui-tags.json`
  - information about what tags are provided by `vue-onsenui` and what attributes each tag has.
- `bindings/vue/packages/vue-onsenui-helper-json/vue-onsenui-attributes.json`
  - information about how each attribute is.

The schema of these files are just same as files in [`ElementUI/element-helper-json`](https://github.com/ElementUI/element-helper-json).

Also, the following files are statically located and not ignored by `.gitignore`:
- `bindings/vue/packages/vue-onsenui-helper-json/package.json`
- `bindings/vue/packages/vue-onsenui-helper-json/LICENSE`
- `bindings/vue/packages/vue-onsenui-helper-json/README.md`
- `bindings/vue/packages/vue-onsenui-helper-json/CHANGELOG.md`

## TODO

I have not yet created a script for automatically updating `OnsenUI/vue-onsenui-helper-json`.
I am planning to create it with the same way as `OnsenUI/OnsenUI-dist`.