### PR TITLE
Cross swipe

### DIFF
--- a/bindings/angular2/examples/pull-hook.ts
+++ b/bindings/angular2/examples/pull-hook.ts
@@ -2,6 +2,8 @@ import {
   Component,
   OnsenModule,
   NgModule,
+  ViewChild,
+  AfterViewInit,
   CUSTOM_ELEMENTS_SCHEMA
 } from '../src/ngx-onsenui';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
@@ -15,7 +17,7 @@ import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
     </ons-toolbar>
 
     <div class="content">
-      <ons-pull-hook height="64px" threshold-height="128px" (changestate)="onChangeState($event)" (action)="onAction($event)">
+      <ons-pull-hook #pullhook height="64px" threshold-height="128px" (changestate)="onChangeState($event)" (action)="onAction($event)">
         {{message}}
       </ons-pull-hook>
 
@@ -26,13 +28,18 @@ import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
   </ons-page>
   `
 })
-export class AppComponent {
+export class AppComponent implements AfterViewInit {
 
   message: string = 'Pull down to refresh';
 
   items: number[] = [1, 2, 3, 4, 5];
 
+  @ViewChild('pullhook') pullhook:any;
   constructor() {
+  }
+
+  ngAfterViewInit() {
+    this.pullhook.nativeElement._disableDragLock();
   }
 
   onAction($event: any) {

--- a/core/src/elements/ons-carousel.spec.js
+++ b/core/src/elements/ons-carousel.spec.js
@@ -264,8 +264,9 @@ describe('OnsCarouselElement', () => {
       expect(carousel._lastDragEvent).not.to.be.ok;
     });
 
-    it('should work if carousel is swipeable and direction is horizontal', () => {
+    it('should work if carousel is swipeable, direction is horizontal and is started', () => {
       carousel.setAttribute('swipeable', '');
+      carousel._onDragStart(ev);
       carousel._onDrag(ev);
       expect(carousel._lastDragEvent).to.be.ok;
     });

--- a/core/src/elements/ons-pull-hook.spec.js
+++ b/core/src/elements/ons-pull-hook.spec.js
@@ -90,7 +90,7 @@ describe('OnsPullHookElement', () => {
       const spy = chai.spy.on(pullHook, '_translateTo');
 
       // Need to initiate the dragging.
-      pullHook._onDragStart();
+      pullHook._onDragStart(event);
       pullHook._onDrag(event);
 
       expect(spy).to.have.been.called.with(10);
@@ -101,7 +101,7 @@ describe('OnsPullHookElement', () => {
 
       event.gesture.interimDirection = 'up';
       // Need to initiate the dragging.
-      pullHook._onDragStart();
+      pullHook._onDragStart(event);
       pullHook._onDrag(event);
 
       expect(spy).to.have.been.called.with(10);
@@ -111,7 +111,7 @@ describe('OnsPullHookElement', () => {
       pullHook.setAttribute('height', 10);
       event.gesture.deltaY = 20;
 
-      pullHook._onDragStart();
+      pullHook._onDragStart(event);
       pullHook._onDrag(event);
 
       expect(pullHook.getAttribute('state')).to.equal('preaction');
@@ -120,7 +120,7 @@ describe('OnsPullHookElement', () => {
     it('bounces back if pull distance is higher than threshold', () => {
       const spy = chai.spy.on(event.gesture, 'stopDetect');
 
-      pullHook._onDragStart();
+      pullHook._onDragStart(event);
       event.gesture.deltaY = 200;
       pullHook._onDrag(event);
 
@@ -131,12 +131,12 @@ describe('OnsPullHookElement', () => {
   describe('#_onDragStart()', () => {
     it('does nothing if the pull hook is disabled', () => {
       pullHook.setAttribute('disabled', '');
-      pullHook._onDragStart();
+      pullHook._onDragStart(event);
       expect(pullHook._startScroll).to.be.an('undefined');
     });
 
     it('saves the current scroll', () => {
-      pullHook._onDragStart();
+      pullHook._onDragStart(event);
       expect(pullHook._startScroll).to.equal(0);
     });
   });
@@ -144,7 +144,7 @@ describe('OnsPullHookElement', () => {
   describe('#_onDragEnd()', () => {
     it('does nothing if the pull hook is disabled', () => {
       pullHook.setAttribute('disabled', '');
-      expect(pullHook._onDragEnd()).to.be.an('undefined');
+      expect(pullHook._onDragEnd(event)).to.be.an('undefined');
     });
 
     it('changes the state', () => {
@@ -153,9 +153,9 @@ describe('OnsPullHookElement', () => {
       pullHook.setAttribute('height', 10);
       event.gesture.deltaY = 20;
 
-      pullHook._onDragStart();
+      pullHook._onDragStart(event);
       pullHook._onDrag(event);
-      pullHook._onDragEnd();
+      pullHook._onDragEnd(event);
 
       expect(spy).to.have.been.called.with('action');
     });
@@ -163,9 +163,9 @@ describe('OnsPullHookElement', () => {
     it('translates back', () => {
       const spy = chai.spy.on(pullHook, '_translateTo');
 
-      pullHook._onDragStart();
+      pullHook._onDragStart(event);
       pullHook._onDrag(event);
-      pullHook._onDragEnd();
+      pullHook._onDragEnd(event);
 
       expect(spy).to.have.been.called.with(0, {animate: true});
     });

--- a/core/src/elements/ons-range.js
+++ b/core/src/elements/ons-range.js
@@ -86,13 +86,19 @@ export default class RangeElement extends BaseInputElement {
   /* Own props */
 
   _onDragstart(e) {
-    e.stopPropagation();
+    e.consumed = true;
     e.gesture.stopPropagation();
     this._input.classList.add(activeClassToken);
+    this.addEventListener('drag', this._onDrag);
+  }
+
+  _onDrag(e) {
+    e.stopPropagation();
   }
 
   _onDragend(e) {
     this._input.classList.remove(activeClassToken);
+    this.removeEventListener('drag', this._onDrag);
   }
 
   get _ratio() {

--- a/core/src/elements/ons-splitter-side.js
+++ b/core/src/elements/ons-splitter-side.js
@@ -565,7 +565,7 @@ export default class SplitterSideElement extends BaseElement {
     const action = swipeable === null ? 'off' : 'on';
 
     if (this._gestureDetector) {
-      this._gestureDetector[action]('dragstart dragleft dragright dragend', this._boundHandleGesture);
+      this._gestureDetector[action]('drag dragstart dragend', this._boundHandleGesture);
     }
   }
 

--- a/core/src/elements/ons-splitter-side.js
+++ b/core/src/elements/ons-splitter-side.js
@@ -132,14 +132,21 @@ class CollapseMode {
     const distance = this._element._side === 'left' ? event.gesture.center.clientX : window.innerWidth - event.gesture.center.clientX;
     const area = this._element._swipeTargetWidth;
     const isOpen = this.isOpen();
-    this._ignoreDrag = scrolling || (area && distance > area && !isOpen);
+    this._ignoreDrag = scrolling || event.consumed || (area && distance > area && !isOpen);
 
-    this._width = widthToPx(this._element._width, this._element.parentNode);
-    this._startDistance = this._distance = isOpen ? this._width : 0;
+    if (!this._ignoreDrag) {
+      event.consume && event.consume();
+      event.consumed = true;
+
+      this._width = widthToPx(this._element._width, this._element.parentNode);
+      this._startDistance = this._distance = isOpen ? this._width : 0;
+    }
   }
 
   _onDrag(event) {
+    event.stopPropagation();
     event.gesture.preventDefault();
+
     const delta = this._element._side === 'left' ? event.gesture.deltaX : -event.gesture.deltaX;
     const distance = Math.max(0, Math.min(this._width, this._startDistance + delta));
     if (distance !== this._distance) {
@@ -150,6 +157,8 @@ class CollapseMode {
   }
 
   _onDragEnd(event) {
+    event.stopPropagation();
+
     const {_distance: distance, _width: width, _element: el} = this;
     const direction = event.gesture.interimDirection;
     const shouldOpen = el._side !== direction && distance > width * el._threshold;

--- a/core/src/elements/ons-switch.js
+++ b/core/src/elements/ons-switch.js
@@ -113,6 +113,7 @@ export default class SwitchElement extends BaseCheckboxElement {
   _onChange(event) {
     if (event && event.stopPropagation) {
       event.stopPropagation();
+      event.gesture.stopPropagation();
     }
 
     this._emitChangeEvent();
@@ -137,7 +138,7 @@ export default class SwitchElement extends BaseCheckboxElement {
       return;
     }
 
-    e.stopPropagation();
+    e.consumed = true;
 
     ModifierUtil.addModifier(this, 'active');
     this._startX = this._locations[this.checked ? 1 : 0];// - e.gesture.deltaX;
@@ -147,7 +148,9 @@ export default class SwitchElement extends BaseCheckboxElement {
   }
 
   _onDrag(e) {
-    e.gesture.srcEvent.preventDefault();
+    e.stopPropagation();
+    e.gesture.preventDefault();
+    event.gesture.stopPropagation();
     this._handle.style.left = this._getPosition(e) + 'px';
   }
 

--- a/core/src/elements/ons-switch.js
+++ b/core/src/elements/ons-switch.js
@@ -113,7 +113,6 @@ export default class SwitchElement extends BaseCheckboxElement {
   _onChange(event) {
     if (event && event.stopPropagation) {
       event.stopPropagation();
-      event.gesture.stopPropagation();
     }
 
     this._emitChangeEvent();
@@ -150,7 +149,6 @@ export default class SwitchElement extends BaseCheckboxElement {
   _onDrag(e) {
     e.stopPropagation();
     e.gesture.preventDefault();
-    event.gesture.stopPropagation();
     this._handle.style.left = this._getPosition(e) + 'px';
   }
 

--- a/core/src/ons/internal/swipe-reveal.js
+++ b/core/src/ons/internal/swipe-reveal.js
@@ -47,7 +47,7 @@ export default class SwipeReveal {
       this.gestureDetector = new GestureDetector(this.elementHandler, {dragMinDistance: 1});
     }
 
-    this.gestureDetector[action]('dragstart dragleft dragright dragend', this.boundHandleGesture);
+    this.gestureDetector[action]('drag dragstart dragend', this.boundHandleGesture);
   }
 
   handleGesture(e) {

--- a/core/src/ons/internal/swipe-reveal.js
+++ b/core/src/ons/internal/swipe-reveal.js
@@ -61,13 +61,20 @@ export default class SwipeReveal {
   onDragStart(event) {
     const scrolling = !/left|right/.test(event.gesture.direction);
     const distance = this.side === 'left' ? event.gesture.center.clientX : window.innerWidth - event.gesture.center.clientX;
-    this._ignoreDrag = scrolling || this.ignoreSwipe(event, distance);
+    this._ignoreDrag = scrolling || event.consumed || this.ignoreSwipe(event, distance);
 
-    this._width = widthToPx(this.element._width || '100%', this.element.parentNode);
-    this._startDistance = this._distance = 0;
+    if (!this._ignoreDrag) {
+      event.consume && event.consume();
+      event.consumed = true;
+
+      this._width = widthToPx(this.element._width || '100%', this.element.parentNode);
+      this._startDistance = this._distance = 0;
+    }
   }
 
   onDrag(event) {
+    event.stopPropagation();
+
     event.gesture.preventDefault();
     const delta = this.side === 'left' ? event.gesture.deltaX : -event.gesture.deltaX;
     const distance = Math.max(0, Math.min(this._width, this._startDistance + delta));
@@ -79,10 +86,11 @@ export default class SwipeReveal {
   }
 
   onDragEnd(event) {
+    event.stopPropagation();
+
     const direction = event.gesture.interimDirection;
     const isSwipeMax = this.side !== direction && this._distance > this._width * this.getThreshold();
     isSwipeMax ? this.swipeMax(this.animator) : this.swipeMin(this.animator);
-    this._ignoreDrag = true;
   }
 
   dispose() {

--- a/examples/swipe/index.html
+++ b/examples/swipe/index.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Swipe Party</title>
+  <link rel="stylesheet" href="../../build/css/onsenui.css">
+  <link rel="stylesheet" href="../../build/css/onsen-css-components.css">
+
+  <script src="../../build/js/onsenui.js"></script>
+
+  <script>
+
+  </script>
+
+  <style>
+    ons-carousel-item {
+      display: table;
+      text-align: center;
+      padding-top: 40px;
+    }
+  </style>
+
+</head>
+
+<body>
+
+  <ons-splitter>
+    <ons-splitter-side swipeable collapse="" width="200px">
+      <ons-page>Splitter side</ons-page>
+    </ons-splitter-side>
+    <ons-splitter-content>
+
+      <ons-navigator swipeable>
+        <ons-page>
+          Previous navigator page
+        </ons-page>
+
+        <ons-page>
+          <ons-toolbar>
+            <div class="center">Swipe Party</div>
+          </ons-toolbar>
+
+          <ons-pull-hook id="pull-hook">
+            <span>Hi!</span>
+          </ons-pull-hook>
+
+
+          <ons-carousel style="width: 100%; height: 300px" swipeable overscrollable auto-scroll auto-scroll-ratio="0.2">
+            <ons-carousel-item style="background-color: gray;">
+              <br><ons-switch></ons-switch>
+              <br><ons-range></ons-range>
+            </ons-carousel-item>
+            <ons-carousel-item style="background-color: #373B44;">
+            </ons-carousel-item>
+          </ons-carousel>
+
+          <br><ons-switch></ons-switch>
+          <br><ons-range></ons-range>
+        </ons-page>
+      </ons-navigator>
+
+
+    </ons-splitter-content>
+  </ons-splitter>
+
+
+</body>
+</html>


### PR DESCRIPTION
@anatoo @asial-matagawa @misterjunio This should fix most of the issues for swipeable components. Please have a look and play with it a little bit (mostly on Safari/devices). There is an example in `examples/swipe/index.html` that combines all of them.

Basically, the first element takes the event if it can consume it. Otherwise, it bubbles. There is, however, the HammerJS' `dragLockToAxis` with an error margin of 25px and this should also work when there are no parent components that can consume the event.

Apart from that, I removed events like `dragright dragleft dragup dragdown` and `swipe swiperight swipeleft swipeup swipedown` in favor of `drag dragstart dragend`. The carousel was using all of them and, as a result, it was calling the handlers more times than needed. @anatoo Do you think this can be an issue? I think `drag` should be enough, right?