### PR TITLE
Reveal, PullHook and Swipe to pop fixes for 2.5.0

### DIFF
--- a/core/css/common.css
+++ b/core/css/common.css
@@ -105,6 +105,12 @@ ons-bottom-toolbar {
   overflow: visible;
 }
 
+.page.overflow-visible .page__content.content-swiping,
+.page.overflow-visible .page__content.content-swiping .page,
+.page.overflow-visible .page__content.content-swiping .page__content {
+  overflow: auto;
+}
+
 .toolbar:not(.toolbar--transparent) + .page__background,
 .toolbar:not(.toolbar--cover-content) + .page__background + .page__content {
   top: 44px;

--- a/core/src/elements/ons-navigator/ios-swipe-animator.js
+++ b/core/src/elements/ons-navigator/ios-swipe-animator.js
@@ -59,14 +59,18 @@ export default class IOSSwipeNavigatorTransitionAnimator extends IOSSlideNavigat
 
       // Shadow && styles
       if (this.shouldAnimateToolbar) {
-        this.decomp.leave.content.appendChild(this.swipeShadow);
+        this.swipeShadow.style.top = this.decomp.leave.toolbar.offsetHeight + 'px';
+        this.target.leave.appendChild(this.swipeShadow);
         this._saveStyle(this.target.enter, this.target.leave);
+        this.swipingContent = this.decomp.leave.content;
       } else {
-        leavePage._contentElement.appendChild(this.swipeShadow);
+        leavePage.appendChild(this.swipeShadow);
         this._saveStyle(enterPage, leavePage);
+        this.swipingContent = this.decomp.leave.content;
       }
       leavePage.classList.add('overflow-visible');
       this.overflowElement = leavePage;
+      this.swipingContent.classList.add('content-swiping');
     }
 
     const swipeRatio = (distance - maxWidth) / maxWidth;
@@ -102,7 +106,7 @@ export default class IOSSwipeNavigatorTransitionAnimator extends IOSSlideNavigat
 
         /* Leave page */
 
-        animit([this.decomp.leave.content, this.decomp.leave.bottomToolbar, this.decomp.leave.background])
+        animit([this.decomp.leave.content, this.decomp.leave.bottomToolbar, this.decomp.leave.background, this.swipeShadow])
           .queue({
             transform: `translate3d(${distance}px, 0px, 0px)`
           }),
@@ -196,7 +200,7 @@ export default class IOSSwipeNavigatorTransitionAnimator extends IOSSlideNavigat
 
         /* Leave page */
 
-        animit([this.decomp.leave.content, this.decomp.leave.bottomToolbar, this.decomp.leave.background])
+        animit([this.decomp.leave.content, this.decomp.leave.bottomToolbar, this.decomp.leave.background, this.swipeShadow])
           .queue({
             transform: `translate3d(0, 0px, 0px)`
           }, {
@@ -317,7 +321,7 @@ export default class IOSSwipeNavigatorTransitionAnimator extends IOSSlideNavigat
 
         /* Leave page */
 
-        animit([this.decomp.leave.content, this.decomp.leave.bottomToolbar, this.decomp.leave.background])
+        animit([this.decomp.leave.content, this.decomp.leave.bottomToolbar, this.decomp.leave.background, this.swipeShadow])
           .queue({
             transform: `translate3d(100%, 0px, 0px)`
           }, {
@@ -426,7 +430,8 @@ export default class IOSSwipeNavigatorTransitionAnimator extends IOSSlideNavigat
     this.swipeShadow.remove();
     this.backgroundMask.remove();
     this.overflowElement.classList.remove('overflow-visible');
-    this.decomp = this.target = this.overflowElement = this._savedStyle = null;
+    this.swipingContent.classList.remove('content-swiping');
+    this.decomp = this.target = this.overflowElement = this.swipingContent = this._savedStyle = null;
     this.isDragStart = true;
   }
 }

--- a/core/src/elements/ons-navigator/ios-swipe-animator.js
+++ b/core/src/elements/ons-navigator/ios-swipe-animator.js
@@ -62,15 +62,13 @@ export default class IOSSwipeNavigatorTransitionAnimator extends IOSSlideNavigat
         this.swipeShadow.style.top = this.decomp.leave.toolbar.offsetHeight + 'px';
         this.target.leave.appendChild(this.swipeShadow);
         this._saveStyle(this.target.enter, this.target.leave);
-        this.swipingContent = this.decomp.leave.content;
       } else {
         leavePage.appendChild(this.swipeShadow);
         this._saveStyle(enterPage, leavePage);
-        this.swipingContent = this.decomp.leave.content;
       }
       leavePage.classList.add('overflow-visible');
       this.overflowElement = leavePage;
-      this.swipingContent.classList.add('content-swiping');
+      this.decomp.leave.content.classList.add('content-swiping');
     }
 
     const swipeRatio = (distance - maxWidth) / maxWidth;
@@ -430,8 +428,8 @@ export default class IOSSwipeNavigatorTransitionAnimator extends IOSSlideNavigat
     this.swipeShadow.remove();
     this.backgroundMask.remove();
     this.overflowElement.classList.remove('overflow-visible');
-    this.swipingContent.classList.remove('content-swiping');
-    this.decomp = this.target = this.overflowElement = this.swipingContent = this._savedStyle = null;
+    this.decomp.leave.content.classList.remove('content-swiping');
+    this.decomp = this.target = this.overflowElement = this._savedStyle = null;
     this.isDragStart = true;
   }
 }

--- a/core/src/elements/ons-pull-hook.js
+++ b/core/src/elements/ons-pull-hook.js
@@ -149,14 +149,18 @@ export default class PullHookElement extends BaseElement {
 
     if (!this._ignoreDrag) {
       const consume = event.consume;
-      event.consume = () => { consume && consume(); this._ignoreDrag = true; };
-      if (this._canConsumeGesture(event.gesture)) {
+      event.consume = () => {
         consume && consume();
-        event.consumed = true;
-      } else {
+        this._ignoreDrag = true;
         // This elements resizes .page__content so it is safer
         // to hide it when other components are dragged.
         this._hide();
+      };
+
+      if (this._canConsumeGesture(event.gesture)) {
+        consume && consume();
+        event.consumed = true;
+        this._show(); // Not enough due to 'dragLockAxis'
       }
     }
 

--- a/core/src/elements/ons-pull-hook.js
+++ b/core/src/elements/ons-pull-hook.js
@@ -122,7 +122,6 @@ export default class PullHookElement extends BaseElement {
 
     this.style.height = `${height}px`;
     this.style.lineHeight = `${height}px`;
-    this._pageElement.style.marginTop = `-${height}px`;
   }
 
   _onScroll(event) {
@@ -154,6 +153,10 @@ export default class PullHookElement extends BaseElement {
       if (this._canConsumeGesture(event.gesture)) {
         consume && consume();
         event.consumed = true;
+      } else {
+        // This elements resizes .page__content so it is safer
+        // to hide it when other components are dragged.
+        this._hide();
       }
     }
 
@@ -163,6 +166,11 @@ export default class PullHookElement extends BaseElement {
   _onDrag(event) {
     if (this.disabled || this._ignoreDrag || !this._canConsumeGesture(event.gesture)) {
       return;
+    }
+
+    // Necessary due to 'dragLockAxis' (25px)
+    if (this.style.display === 'none') {
+      this._show();
     }
 
     event.stopPropagation();
@@ -367,11 +375,17 @@ export default class PullHookElement extends BaseElement {
   }
 
   _show() {
-    this.style.visibility = '';
+    this.style.display = '';
+    if (this._pageElement) {
+      this._pageElement.style.marginTop = `-${this.height}px`;
+    }
   }
 
   _hide() {
-    this.style.visibility = 'hidden';
+    this.style.display = 'none';
+    if (this._pageElement) {
+      this._pageElement.style.marginTop = '';
+    }
   }
 
   /**
@@ -463,7 +477,7 @@ export default class PullHookElement extends BaseElement {
   }
 
   disconnectedCallback() {
-    this._pageElement.style.marginTop = '';
+    this._hide();
 
     this._destroyEventListeners();
   }

--- a/core/src/elements/ons-splitter-side.js
+++ b/core/src/elements/ons-splitter-side.js
@@ -148,6 +148,8 @@ class CollapseMode {
 
       this._width = widthToPx(this._element._width, this._element.parentNode);
       this._startDistance = this._distance = this.isOpen() ? this._width : 0;
+
+      util.skipContentScroll(event.gesture);
     }
   }
 

--- a/core/src/elements/ons-splitter-side.js
+++ b/core/src/elements/ons-splitter-side.js
@@ -128,16 +128,15 @@ class CollapseMode {
   }
 
   _canConsumeGesture(gesture) {
-    const d = gesture.direction;
     const isOpen = this.isOpen();
-    const validDrag = this._element._side === 'left'
+    const validDrag = d => this._element._side === 'left'
       ? ((d === 'left' && isOpen) || (d === 'right' && !isOpen))
       : ((d === 'left' && !isOpen) || (d === 'right' && isOpen));
 
     const distance = this._element._side === 'left' ? gesture.center.clientX : window.innerWidth - gesture.center.clientX;
     const area = this._element._swipeTargetWidth;
 
-    return validDrag && !(area && distance > area && !isOpen);
+    return (validDrag(gesture.direction) || validDrag(gesture.interimDirection)) && !(area && distance > area && !isOpen);
   }
 
   _onDragStart(event) {

--- a/core/src/elements/ons-splitter/overlay-animator.js
+++ b/core/src/elements/ons-splitter/overlay-animator.js
@@ -21,6 +21,8 @@ import SplitterAnimator from './animator.js';
 export default class OverlaySplitterAnimator extends SplitterAnimator {
 
   translate(distance) {
+    this._mask.style.display = 'block'; // Avoid content clicks
+
     animit(this._side)
       .queue({
         transform: `translate3d(${this.minus + distance}px, 0px, 0px)`

--- a/core/src/elements/ons-splitter/push-animator.js
+++ b/core/src/elements/ons-splitter/push-animator.js
@@ -34,6 +34,8 @@ export default class PushSplitterAnimator extends SplitterAnimator {
       this._slidingElements = this._getSlidingElements();
     }
 
+    this._mask.style.display = 'block'; // Avoid content clicks
+
     animit(this._slidingElements)
       .queue({
         transform: `translate3d(${this.minus + distance}px, 0px, 0px)`

--- a/core/src/elements/ons-splitter/reveal-animator.js
+++ b/core/src/elements/ons-splitter/reveal-animator.js
@@ -49,6 +49,7 @@ export default class RevealSplitterAnimator extends SplitterAnimator {
     sideElement.style.zIndex = 0;
     sideElement.style.backgroundColor = 'black';
     sideElement.style.transform = this._generateBehindPageStyle(0).container.transform;
+    sideElement.style.display = 'none';
 
     const splitter = sideElement.parentElement;
     contentReady(splitter, () => {
@@ -59,7 +60,7 @@ export default class RevealSplitterAnimator extends SplitterAnimator {
   }
 
   _unsetStyles(sideElement) {
-    sideElement.style.left = sideElement.style.right = sideElement.style.zIndex = sideElement.style.backgroundColor = '';
+    sideElement.style.left = sideElement.style.right = sideElement.style.zIndex = sideElement.style.backgroundColor = sideElement.style.display = '';
     if (sideElement._content) {
       sideElement._content.style.opacity = '';
     }
@@ -92,9 +93,10 @@ export default class RevealSplitterAnimator extends SplitterAnimator {
   }
 
   translate(distance) {
+    this._side.style.display = '';
+    this._side.style.zIndex = 1;
     this.maxWidth = this.maxWidth || this._getMaxWidth();
     const menuStyle = this._generateBehindPageStyle(Math.min(distance, this.maxWidth));
-    this._side.style.zIndex = 1;
 
     if (!this._slidingElements) {
       this._slidingElements = this._getSlidingElements();
@@ -116,10 +118,11 @@ export default class RevealSplitterAnimator extends SplitterAnimator {
    * @param {Function} done
    */
   open(done) {
+    this._side.style.display = '';
+    this._side.style.zIndex = 1;
     this.maxWidth = this.maxWidth || this._getMaxWidth();
     const menuStyle = this._generateBehindPageStyle(this.maxWidth);
     this._slidingElements = this._getSlidingElements();
-    this._side.style.zIndex = 1;
 
     animit.runAll(
       animit(this._slidingElements)
@@ -197,6 +200,7 @@ export default class RevealSplitterAnimator extends SplitterAnimator {
         .queue(callback => {
           this._slidingElements = null;
           this._side.style.zIndex = 0;
+          this._side.style.display = 'none';
           this._side._content.style.opacity = '';
           done && done();
           callback();

--- a/core/src/elements/ons-splitter/reveal-animator.js
+++ b/core/src/elements/ons-splitter/reveal-animator.js
@@ -102,6 +102,8 @@ export default class RevealSplitterAnimator extends SplitterAnimator {
       this._slidingElements = this._getSlidingElements();
     }
 
+    this._mask.style.display = 'block'; // Avoid content clicks
+
     animit.runAll(
       animit(this._slidingElements)
         .queue({

--- a/core/src/ons/internal/swipe-reveal.js
+++ b/core/src/ons/internal/swipe-reveal.js
@@ -15,6 +15,7 @@ limitations under the License.
 
 */
 
+import util from '../../ons/util';
 import GestureDetector from '../../ons/gesture-detector';
 
 const widthToPx = (width) => {
@@ -68,6 +69,8 @@ export default class SwipeReveal {
 
       this._width = widthToPx(this.element._width || '100%');
       this._startDistance = this._distance = 0;
+
+      util.skipContentScroll(event.gesture);
     }
   }
 

--- a/core/src/ons/util.js
+++ b/core/src/ons/util.js
@@ -463,4 +463,18 @@ util.warn = (...args) => {
   }
 };
 
+util.skipContentScroll = gesture => {
+  const clickedElement = document.elementFromPoint(gesture.center.clientX, gesture.center.clientY);
+  const content = util.findParent(clickedElement, '.page__content', e => util.match(e, '.page'));
+  if (content) {
+    const preventScroll = e => e.preventDefault();
+    content.addEventListener('touchmove', preventScroll, true);
+    const clean = e => {
+      content.removeEventListener('touchmove', preventScroll, true);
+      content.removeEventListener('touchend', clean, true);
+    };
+    content.addEventListener('touchend', clean, true);
+  }
+};
+
 export default util;

--- a/examples/navigator/index.html
+++ b/examples/navigator/index.html
@@ -35,12 +35,10 @@
 </head>
 
 <body>
-  <ons-navigator id="myNavigator">
+  <ons-navigator id="myNavigator" swipeable>
     <ons-page id="page0">
       <ons-toolbar>
-      <div class="left"><ons-toolbar-button modifier="border">Test</ons-toolbar-button></div>
         <div class="center">Navigator</div>
-        <div class="right"><ons-toolbar-button modifier="border"><ons-icon icon="ion-navicon"></ons-icon></ons-toolbar-button></div>
       </ons-toolbar>
 
       <div style="text-align: center">


### PR DESCRIPTION
@asial-matagawa Due to some changes in animations, the side menus must be hidden for reveal animator, otherwise, they will be partially visible when pushing pages in the navigator. I remember there was a white glitch when using `visibility: hidden` but I couldn't find it on Chrome or Firefox with this `display: none`. Do you think it is fine?