### PR TITLE
Add `onsenui-helper-json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "chalk": "^1.1.3",
     "eslint": "^2.12.0",
     "event-stream": "^3.3.2",
+    "fs-extra": "^4.0.0",
     "gulp": "^3.9.0",
     "gulp-add-src": "^0.2.0",
     "gulp-autoprefixer": "^3.1.0",

--- a/packages/onsenui-helper-json/.gitignore
+++ b/packages/onsenui-helper-json/.gitignore
@@ -1,0 +1,2 @@
+onsenui-tags.json
+onsenui-attributes.json

--- a/packages/onsenui-helper-json/CHANGELOG.md
+++ b/packages/onsenui-helper-json/CHANGELOG.md
@@ -1,0 +1,8 @@
+CHANGELOG
+====
+
+dev
+----
+
+ * Initial version.
+ * Supported `onsenui@2.5.0`.

--- a/packages/onsenui-helper-json/LICENSE
+++ b/packages/onsenui-helper-json/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2013-2017 ASIAL CORPORATION
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/onsenui-helper-json/README.md
+++ b/packages/onsenui-helper-json/README.md
@@ -1,0 +1,3 @@
+# onsenui-helper-json
+
+Tags and attributes information of `onsenui`, which makes IDE / test editor plugin development easier.

--- a/packages/onsenui-helper-json/package.json
+++ b/packages/onsenui-helper-json/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "onsenui-helper-json",
+  "version": "0.0.0",
+  "author": "Onsen UI Team <team@monaca.io>",
+  "description": "Tags and attributes information of `onsenui`, which makes IDE / test editor plugin development easier.",
+  "private": false,
+  "files": [
+    "onsenui-tags.json",
+    "onsenui-attributes.json"
+  ],
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/OnsenUI/OnsenUI/issues"
+  },
+  "homepage": "https://github.com/OnsenUI/OnsenUI#readme"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,13 +1758,13 @@ commander@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.3.0.tgz#fd430e889832ec353b9acd1de217c11cb3eef873"
 
-commander@2.8.x:
+commander@2.8.x, commander@^2.2.0, commander@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@^2.2.0, commander@^2.8.1, commander@^2.9.0:
+commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -2919,6 +2919,14 @@ fs-extra@0.30.0:
     klaw "^1.0.0"
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
+
+fs-extra@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.0.tgz#414fb4ca2d2170ba0014159d3a8aec3303418d9e"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
 
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
@@ -4091,6 +4099,12 @@ json5@^0.5.1:
 jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -6719,6 +6733,10 @@ underscore@1.7.x:
 unique-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unique-stream/-/unique-stream-1.0.0.tgz#d59a4a75427447d9aa6c91e70263f8d26a4b104b"
+
+universalify@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
@adamkozuch @masahirotanaka @frandiox @misterjunio
This PR adds a core version of `vue-onsenui-helper-json`.
I have not yet released `onsenui-helper-json` on NPM.

The code in this PR is very redundant, so I feel like I need to refactor things related to `wcdoc` later.