### PR TITLE
feat(ons): Add ons.getScriptPage method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ dev
 
  * ons-navigator: Ignore swipes on back buttons.
 
+### Misc
+
+ * ons.getScriptPage: Added new method as a shortcut to get the current page and attach lifecycle hooks.
+
 v2.5.1
 ----
 

--- a/core/src/ons/ons.js
+++ b/core/src/ons/ons.js
@@ -229,7 +229,7 @@ ons.enableAutoStyling = ons._autoStyle.enable;
  * @method forcePlatformStyling
  * @signature forcePlatformStyling(platform)
  * @description
- *   [en]Refresh styling for the given platform.[/en]
+ *   [en]Refresh styling for the given platform. Only useful for demos. Use `ons.platform.select(...)` for development and production.[/en]
  *   [ja][/ja]
  * @param {string} platform New platform to style the elements.
  */
@@ -480,8 +480,8 @@ function waitDeviceReady() {
 }
 
 /**
- * @method lastCreatedPage
- * @signature lastCreatedPage()
+ * @method getScriptPage
+ * @signature getScriptPage()
  * @description
  *   [en]Access the last created page from the current `script` scope. Only works inside `<script></script>` tags that are direct children of `ons-page` element. Use this to add lifecycle hooks to a page.[/en]
  *   [ja][/ja]
@@ -490,7 +490,7 @@ function waitDeviceReady() {
  *   [ja][/ja]
  */
 const getCS = 'currentScript' in document ? () => document.currentScript : () => document.scripts[document.scripts.length - 1];
-ons.lastCreatedPage = () => getCS() && /ons-page/i.test(getCS().parentElement.tagName) && getCS().parentElement || null;
+ons.getScriptPage = () => getCS() && /ons-page/i.test(getCS().parentElement.tagName) && getCS().parentElement || null;
 
 window._superSecretOns = ons;
 export default ons;

--- a/core/src/ons/ons.js
+++ b/core/src/ons/ons.js
@@ -479,5 +479,18 @@ function waitDeviceReady() {
   }, false);
 }
 
+/**
+ * @method lastCreatedPage
+ * @signature lastCreatedPage()
+ * @description
+ *   [en]Access the last created page from the current `script` scope. Only works inside `<script></script>` tags that are direct children of `ons-page` element. Use this to add lifecycle hooks to a page.[/en]
+ *   [ja][/ja]
+ * @return {HTMLElement}
+ *   [en]Returns the corresponding page element.[/en]
+ *   [ja][/ja]
+ */
+const getCS = 'currentScript' in document ? () => document.currentScript : () => document.scripts[document.scripts.length - 1];
+ons.lastCreatedPage = () => getCS() && /ons-page/i.test(getCS().parentElement.tagName) && getCS().parentElement || null;
+
 window._superSecretOns = ons;
 export default ons;

--- a/core/src/onsenui.d.ts
+++ b/core/src/onsenui.d.ts
@@ -66,11 +66,24 @@ declare namespace ons {
   function disableAutoStyling(): void;
   function enableAutoStyling(): void;
   /**
-   * @description Refresh styling for the given platform.
+   * @description Refresh styling for the given platform. Only useful for demos. Use `ons.platform.select(...)` for development and production.
    */
   function forcePlatformStyling(platform: string): void;
-  function preload(...args: any[]): any;
-  function createElement(...args: any[]): any;
+  /**
+   * @description Access the last created page from the current `script` scope. Only works inside `<script></script>` tags that are direct children of `ons-page` element. Use this to add lifecycle hooks to a page.
+   * @return Returns the corresponding page element.
+   */
+  function getScriptPage(): HTMLElement | null;
+  /**
+   * @description Separated files need to be requested on demand and this can slightly delay pushing new pages. This method requests and caches templates for later use.
+   * @return Promise that resolves when all the templates are cached.
+   */
+  function preload(...args: any[]): Promise<DocumentFragment[]>;
+  /**
+   * @description Create a new element from a template. Both inline HTML and external files are supported although the return value differs.
+   * @return If the provided template was an inline HTML string, it returns the new element. Otherwise, it returns a promise that resolves to the new element.
+   */
+  function createElement(...args: any[]): HTMLElement | Promise<HTMLElement>;
   /**
    * @description Create a popover instance from a template.
    * @return Promise object that resolves to the popover component object.
@@ -86,7 +99,11 @@ declare namespace ons {
    * @return Promise object that resolves to the alert dialog component object.
    */
   function createAlertDialog(page: string, options?: OnsOptions): Promise<HTMLElement>;
-  function openActionSheet(...args: any[]): any;
+  /**
+   * @description Shows an instant Action Sheet and lets the user choose an action.
+   * @return Will resolve when the action sheet is closed. The resolve value is either the index of the tapped button or -1 when canceled.
+   */
+  function openActionSheet(...args: any[]): Promise<number>;
   /**
    * @description If no page is defined for the `ons-loading-placeholder` attribute it will wait for this method being called before loading the page.
    */

--- a/examples/navigator/index.html
+++ b/examples/navigator/index.html
@@ -77,20 +77,20 @@
       </div>
 
       <script>
-        myNavigator.topPage.onInit = function() {
+        ons.getScriptPage().onInit = function() {
           console.log(this.id, 'init hook');
-        };
 
-        myNavigator.topPage.onShow = function() {
-          console.log(this.id, 'show hook');
-        };
+          this.onShow = function() {
+            console.log(this.id, 'show hook');
+          };
 
-        myNavigator.topPage.onHide = function() {
-          console.log(this.id, 'hide hook');
-        };
+          this.onHide = function() {
+            console.log(this.id, 'hide hook');
+          };
 
-        myNavigator.topPage.onDestroy = function() {
-          console.log(this.id, 'destroy hook');
+          this.onDestroy = function() {
+            console.log(this.id, 'destroy hook');
+          };
         };
       </script>
     </ons-page>


### PR DESCRIPTION
@misterjunio @asial-matagawa It should be a function because we don't document properties in `ons` object. Perhaps `ons.getScriptPage()` would be a better name, what do you think?