### PR TITLE
fix(react/navigator): remove unnecessary renderPage

### DIFF
--- a/bindings/react/src/components/Navigator.jsx
+++ b/bindings/react/src/components/Navigator.jsx
@@ -307,11 +307,10 @@ class Navigator extends BasicComponent {
   render() {
     const {...others} = this.props;
     Util.convert(others, 'animationOptions', {fun: Util.animationOptionsConverter, newName: 'animation-options'});
-    const pages = this.routes ? this.routes.map((route) => this.props.renderPage(route, this)) : null;
 
     return (
       <ons-navigator {...others} ref={(navi) => { this._navi = navi; }}>
-        {pages}
+        {this.pages}
       </ons-navigator>
     );
   }


### PR DESCRIPTION
remove the renderPage executing in navigator which would render page component twice