### PR TITLE
fix (BasicComponent): null check result of findDOMNode

### DIFF
--- a/bindings/react/src/components/BasicComponent.jsx
+++ b/bindings/react/src/components/BasicComponent.jsx
@@ -11,7 +11,9 @@ class BasicComponent extends React.Component {
 
   updateClasses() {
     var node = ReactDOM.findDOMNode(this);
-
+    
+    if (!node) return;
+        
     if (typeof this.props.className !== 'undefined') {
       if (this.lastClass) {
         node.className = node.className.replace(this.lastClass, ' ');


### PR DESCRIPTION
Apologies for the commit message not following proper formatting. 

If updateClasses somehow gets called after a component has unmounted and findDOMNode returns null or undefined, an error invariably gets thrown on the first property lookup of node. This pull request simply adds a small check to return early from the updateClasses function in such a case.