### PR TITLE
fix(core, issue #2237): limited modifier scope

### DIFF
--- a/core/src/ons/internal/modifier-util.js
+++ b/core/src/ons/internal/modifier-util.js
@@ -76,7 +76,7 @@ export default class ModifierUtil {
    */
   static applyDiffToElement(diff, element, scheme) {
     Object.keys(scheme).forEach(selector => {
-      const targetElements = !selector || util.match(element, selector) ? [element] : element.querySelectorAll(selector);
+      const targetElements = !selector || util.match(element, selector) ? [element] : [].filter.call(element.querySelectorAll(selector), targetElement => !util.findParent(targetElement, element.tagName, parent => parent === element));
       for (let i = 0; i < targetElements.length; i++) {
         ModifierUtil.applyDiffToClassList(diff, targetElements[i].classList, scheme[selector]);
       }


### PR DESCRIPTION
This fixes the issue reported here - https://github.com/OnsenUI/OnsenUI/issues/2237 - where the modifier classes leak into child components of the same type.