### PR TITLE
Revert changes to fix OnsenUI/OnsenUI#1860

### DIFF
--- a/core/src/elements/ons-progress-circular.js
+++ b/core/src/elements/ons-progress-circular.js
@@ -32,8 +32,8 @@ const scheme = {
 const template = util.createElement(`
   <svg class="progress-circular">
     <circle class="progress-circular__background" />
-    <circle class="progress-circular__secondary" />
-    <circle class="progress-circular__primary" />
+    <circle class="progress-circular__secondary" cx="50%" cy="50%" r="40%" />
+    <circle class="progress-circular__primary" cx="50%" cy="50%" r="40%" />
   </svg>
 `);
 

--- a/css-components/src/components/progress-circular.css
+++ b/css-components/src/components/progress-circular.css
@@ -33,9 +33,6 @@
 .progress-circular__background,
 .progress-circular__primary,
 .progress-circular__secondary {
-  cx: 50%;
-  cy: 50%;
-  r: 40%;
   animation: none;
   fill: none;
   stroke-width: 5%;


### PR DESCRIPTION
There were changes in https://github.com/OnsenUI/OnsenUI/issues/1860 that moved SVG attributes from the template to the stylesheet. This feature (from SVG 2) isn't supported in Firefox and iOS 8 (https://github.com/OnsenUI/OnsenUI/issues/1860). This PR reverts those changes.

Tested with FF 57.0 and iPhone 6 Plus iOS 8.4 sim