### PR TITLE
Weak map polyfill

### DIFF
--- a/core/src/index.esm.js
+++ b/core/src/index.esm.js
@@ -1,5 +1,5 @@
 import ons from './ons'; // External dependency, always hoisted
-import setup from './setup';
+import setup from './setup'; // Add polyfills
 
 setup(ons); // Setup initial listeners
 

--- a/core/src/index.umd.js
+++ b/core/src/index.umd.js
@@ -1,5 +1,5 @@
 import ons from './ons'; // Add ons internals
-import setup from './setup'; // Add polyfil
+import setup from './setup'; // Add polyfills
 
 // Add and register Custom Elements
 import './elements/ons-template';

--- a/core/src/ons/content-ready.js
+++ b/core/src/ons/content-ready.js
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
-const readyMap = new WeakMap();
-const queueMap = new WeakMap();
+
+let readyMap, queueMap;
 
 function isContentReady(element) {
   if (element.childNodes.length > 0) {
@@ -42,6 +42,11 @@ function consumeQueue(element) {
 }
 
 export default function contentReady(element, fn = () => {}) {
+  if (readyMap === undefined) {
+    readyMap = new WeakMap();
+    queueMap = new WeakMap();
+  }
+
   addCallback(element, fn);
 
   if (isContentReady(element)) {

--- a/core/src/polyfills/MutationObserver@0.7.22/MutationObserver.js
+++ b/core/src/polyfills/MutationObserver@0.7.22/MutationObserver.js
@@ -8,41 +8,6 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 // @version 0.7.22
-if (typeof WeakMap === "undefined") {
-  (function() {
-    var defineProperty = Object.defineProperty;
-    var counter = Date.now() % 1e9;
-    var WeakMap = function() {
-      this.name = "__st" + (Math.random() * 1e9 >>> 0) + (counter++ + "__");
-    };
-    WeakMap.prototype = {
-      set: function(key, value) {
-        var entry = key[this.name];
-        if (entry && entry[0] === key) entry[1] = value; else defineProperty(key, this.name, {
-          value: [ key, value ],
-          writable: true
-        });
-        return this;
-      },
-      get: function(key) {
-        var entry;
-        return (entry = key[this.name]) && entry[0] === key ? entry[1] : undefined;
-      },
-      "delete": function(key) {
-        var entry = key[this.name];
-        if (!entry || entry[0] !== key) return false;
-        entry[0] = entry[1] = undefined;
-        return true;
-      },
-      has: function(key) {
-        var entry = key[this.name];
-        if (!entry) return false;
-        return entry[0] === key;
-      }
-    };
-    window.WeakMap = WeakMap;
-  })();
-}
 
 (function(global) {
   if (global.JsMutationObserver) {

--- a/core/src/polyfills/index.js
+++ b/core/src/polyfills/index.js
@@ -10,6 +10,7 @@ import './polyfill-switches';
 import 'core-js/fn/object/set-prototype-of';
 import 'core-js/fn/set';
 import 'core-js/fn/map';
+import 'core-js/fn/weak-map';
 
 // Polyfill Custom Elements v1 with global namespace pollution
 import '@onsenui/custom-elements/src/custom-elements';


### PR DESCRIPTION
@asial-matagawa @asialgearoid I think this should be enough :+1: 

Another possible solution would be importing `setup` before `ons` in `index.umd.js` in order to add all the polyfills. However, this is not possible for `index.esm.js` because `ons` is an external dependency and will be hoisted (`import` is always hoisted) when the user bundles his app. I think we should keep the same import order in both UMD and ESM to detect errors like this one.