### PR TITLE
React: Navigator resetPageStack pop option

### DIFF
--- a/bindings/react/src/components/Navigator.jsx
+++ b/bindings/react/src/components/Navigator.jsx
@@ -203,6 +203,7 @@ class Navigator extends BasicComponent {
     }
 
     this.routesBeforePop = this.routes.slice();
+    this.routesAfterPop = this.routesBeforePop.slice(0, this.routesBeforePop.length - 1);
 
     const update = () => {
       return new Promise((resolve) => {
@@ -244,7 +245,7 @@ class Navigator extends BasicComponent {
 
     event.routes = {
       poppedRoute: this.routesBeforePop[this.routesBeforePop.length - 1],
-      routes: this.routesBeforePop.slice(0, this.routesBeforePop.length - 1)
+      routes: this.routesAfterPop
     };
 
     this.props.onPostPop(event);

--- a/bindings/react/src/components/Navigator.jsx
+++ b/bindings/react/src/components/Navigator.jsx
@@ -76,7 +76,26 @@ class Navigator extends BasicComponent {
     if (this.isRunning()) {
       return Promise.reject('Navigator is already running animation.');
     }
+    const renderPage = (route) => {
+      return this.props.renderPage(route, this);
+    };
+    if (options.pop) {
+      return new Promise((resolve) => {
+        this.routesBeforePop = this.routes.slice();
+        this.routesAfterPop = routes;
+        this.routes = routes.concat([this.routes[this.routes.length - 1]]);
 
+        const update = () => {
+          this.pages.pop();
+          this.routes = routes;
+          return new Promise((resolve) => this.forceUpdate(resolve));
+        };
+
+        this.update(this.pages).then(() => {
+          this._navi._popPage(options, update);
+        });
+      });
+    }
     return new Promise((resolve) => {
       var lastRoute = routes[routes.length - 1];
       var newPage = this.props.renderPage(lastRoute, this);
@@ -89,10 +108,6 @@ class Navigator extends BasicComponent {
 
       this._navi._pushPage(options, update).then(() => {
         this.routes = routes;
-
-        var renderPage = (route) => {
-          return this.props.renderPage(route, this);
-        };
 
         this.pages = routes.map(renderPage);
         this.update(this.pages).then(resolve);


### PR DESCRIPTION
Following discussions on #2277 with @frandiox, this PR adds a `pop` option to `Navigator.resetPageStack()`.