### PR TITLE
Completed build instructions when using some bindings

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -48,6 +48,13 @@ $ yarn build
 
 The files will be built and copied into **OnsenUI/build** folder.
 
+If you want to work with some bindings, like `vue`, you need to run the following commands:
+
+```
+$ cd bindings/vue
+$ yarn install
+```
+
 It is also possible to serve the files for development and running examples:
 
 ```bash


### PR DESCRIPTION
Otherwise the `gulp serve` command will fail if use some bindings on them