### PR TITLE
Add defaultValue props to react inputs

### DIFF
--- a/bindings/react/src/components/BaseInput.jsx
+++ b/bindings/react/src/components/BaseInput.jsx
@@ -25,8 +25,6 @@ class BaseInput extends BasicComponent {
 
     if (this.props.value !== undefined) {
       node.value = this.props.value;
-    } else if (this.props.defaultValue !== undefined) {
-      node.value = this.props.defaultValue;
     }
 
     this.EVENT_TYPES.forEach(eventType => node.addEventListener(eventType, this.onChange));
@@ -59,10 +57,15 @@ BaseInput.propTypes = {
   modifier: PropTypes.string,
   disabled: PropTypes.bool,
   onChange: PropTypes.func,
+  defaultValue: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.instanceOf(Date)
+  ]),
   value: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.instanceOf(Date)
   ]),
+  defaultChecked: PropTypes.bool,
   checked: PropTypes.bool,
   placeholder: PropTypes.string,
   type: PropTypes.string,

--- a/bindings/react/src/components/BaseInput.jsx
+++ b/bindings/react/src/components/BaseInput.jsx
@@ -23,6 +23,12 @@ class BaseInput extends BasicComponent {
     super.componentDidMount();
     const node = ReactDOM.findDOMNode(this);
 
+    if (this.props.defaultValue !== undefined) {
+      node.value = this.props.defaultValue;
+    }
+    if (this.props.defaultChecked !== undefined) {
+      node.checked = this.props.defaultChecked;
+    }
     if (this.props.value !== undefined) {
       node.value = this.props.value;
     }
@@ -49,7 +55,8 @@ class BaseInput extends BasicComponent {
 
   render() {
     const { onChange, ...props } = this.props;
-    return React.createElement(this._getDomNodeName(), Util.getAttrs(this, props));
+    var p = Util.getAttrs(this, props);
+    return React.createElement(this._getDomNodeName(), p);
   }
 }
 
@@ -57,7 +64,7 @@ BaseInput.propTypes = {
   modifier: PropTypes.string,
   disabled: PropTypes.bool,
   onChange: PropTypes.func,
-  defaultValue: PropTypes.oneOfType([
+  defaultvalue: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.instanceOf(Date)
   ]),

--- a/bindings/react/src/components/BaseInput.jsx
+++ b/bindings/react/src/components/BaseInput.jsx
@@ -55,8 +55,7 @@ class BaseInput extends BasicComponent {
 
   render() {
     const { onChange, ...props } = this.props;
-    var p = Util.getAttrs(this, props);
-    return React.createElement(this._getDomNodeName(), p);
+    return React.createElement(this._getDomNodeName(), Util.getAttrs(this, props));
   }
 }
 
@@ -64,7 +63,7 @@ BaseInput.propTypes = {
   modifier: PropTypes.string,
   disabled: PropTypes.bool,
   onChange: PropTypes.func,
-  defaultvalue: PropTypes.oneOfType([
+  defaultValue: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.instanceOf(Date)
   ]),

--- a/bindings/react/src/components/BaseInput.jsx
+++ b/bindings/react/src/components/BaseInput.jsx
@@ -25,6 +25,8 @@ class BaseInput extends BasicComponent {
 
     if (this.props.value !== undefined) {
       node.value = this.props.value;
+    } else if (this.props.defaultValue !== undefined) {
+      node.value = this.props.defaultValue;
     }
 
     this.EVENT_TYPES.forEach(eventType => node.addEventListener(eventType, this.onChange));

--- a/bindings/react/src/components/Checkbox.jsx
+++ b/bindings/react/src/components/Checkbox.jsx
@@ -74,10 +74,19 @@ Checkbox.propTypes = {
    * @name checked
    * @type boolean
    * @description
-   *  [en]Controls the state of the checkbox.[/en]
+   *  [en]Controls the state of the checkbox (controlled).[/en]
    *  [ja][/ja]
    */
   checked: PropTypes.bool,
+
+  /**
+   * @name checked
+   * @type boolean
+   * @description
+   *  [en]Defined the state of the radio button at first render for uncontrolled inputs.[/en]
+   *  [ja][/ja]
+   */
+  defaultChecked: PropTypes.bool,
 
   /**
    * @name inputId

--- a/bindings/react/src/components/Input.jsx
+++ b/bindings/react/src/components/Input.jsx
@@ -53,6 +53,18 @@ Input.propTypes = {
   onChange: PropTypes.func,
 
   /**
+   * @name defaultValue
+   * @type string
+   * @description
+   *  [en]Content of the input.[/en]
+   *  [ja][/ja]
+   */
+  defaultValue: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.instanceOf(Date)
+  ]),
+
+  /**
    * @name value
    * @type string
    * @description

--- a/bindings/react/src/components/Input.jsx
+++ b/bindings/react/src/components/Input.jsx
@@ -53,25 +53,25 @@ Input.propTypes = {
   onChange: PropTypes.func,
 
   /**
-   * @name defaultValue
+   * @name value
    * @type string
    * @description
-   *  [en]Content of the input.[/en]
+   *  [en]Content of the input (controlled).[/en]
    *  [ja][/ja]
    */
-  defaultValue: PropTypes.oneOfType([
+  value: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.instanceOf(Date)
   ]),
 
   /**
-   * @name value
+   * @name defaultValue
    * @type string
    * @description
-   *  [en]Content of the input.[/en]
+   *  [en]Content of the input at first render (uncontrolled).[/en]
    *  [ja][/ja]
    */
-  value: PropTypes.oneOfType([
+  defaultValue: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.instanceOf(Date)
   ]),

--- a/bindings/react/src/components/Radio.jsx
+++ b/bindings/react/src/components/Radio.jsx
@@ -74,10 +74,19 @@ Radio.propTypes = {
    * @name checked
    * @type boolean
    * @description
-   *  [en]Controls the state of the radio button.[/en]
+   *  [en]Controls the state of the radio button (controlled).[/en]
    *  [ja][/ja]
    */
   checked: PropTypes.bool,
+
+  /**
+   * @name defaultChecked
+   * @type boolean
+   * @description
+   *  [en]Defined the state of the radio button at first render for uncontrolled inputs.[/en]
+   *  [ja][/ja]
+   */
+  defaultChecked: PropTypes.bool,
 
   /**
    * @name inputId

--- a/core/src/elements/base/base-input.js
+++ b/core/src/elements/base/base-input.js
@@ -73,6 +73,7 @@ export default class BaseInputElement extends BaseElement {
     this.appendChild(util.createFragment(this._template));
 
     this._setInputId();
+
     this._updateBoundAttributes();
 
     ModifierUtil.initModifier(this, this._scheme);


### PR DESCRIPTION
To be able to use seamlessly the onsen react inputs as [uncontrolled components](https://reactjs.org/docs/uncontrolled-components.html), we need them to support a [`defaultValue`](https://reactjs.org/docs/uncontrolled-components.html#default-values) property.