### PR TITLE
Fix position of notification badge in text-only tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ dev
  ### Bug Fixes
 
  * ons-tab: Fixed [#2307](https://github.com/OnsenUI/OnsenUI/issues/2307).
+ * css-components: Fixed [#2045](https://github.com/OnsenUI/OnsenUI/issues/2045).
 
  ### Misc
 

--- a/css-components/src/components/tabbar.css
+++ b/css-components/src/components/tabbar.css
@@ -160,19 +160,29 @@
 
 .tabbar__label {
   @apply(--reset-font);
+  display: inline-block;
 }
 
-.tabbar__badge.notification { /* FIXME */
-  position: absolute;
-  top: 5px;
+.tabbar__badge.notification {
+  vertical-align: text-bottom;
+  top: -1px;
+  margin-left: 5px;
   z-index: 10;
   font-size: 12px;
   height: 16px;
+  min-width: 16px;
   line-height: 16px;
   border-radius: 8px;
 }
 
+.tabbar__icon ~ .tabbar__badge.notification {
+  position: absolute;
+  top: 5px;
+  margin-left: 0;
+}
+
 .tabbar__icon + .tabbar__label {
+  display: block;
   font-size: 10px;
   line-height: 1;
   margin: 0;


### PR DESCRIPTION
This fixes #2045. The existing CSS is fine for tabs with icons, but there is an issue with text-only tabs. These are more common on Android than on iOS. I could not find anything in the Material documentation about how tabs with badges should be displayed. So, I have put the badge inline, which is common in apps such as Whatsapp.

I have a slight concern that `tabbar__label` is no longer block for text-only tabs, so if users are styling based on that, they will notice a change. However, I think the correct way they should be styling anyway is on `tabbar_button`, so this probably should not be an issue.