### PR TITLE
fix(platform): Add landscape check for iPhone X. Closes #2279.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ dev
  * ons-navigator: Fixed[#2286](https://github.com/OnsenUI/OnsenUI/issues/2286).
  * ons-navigator: Fixed[#1992](https://github.com/OnsenUI/OnsenUI/issues/1992).
  * css-components: Fixed [#2045](https://github.com/OnsenUI/OnsenUI/issues/2045).
+ * ons.platform: Fixed [#2279](https://github.com/OnsenUI/OnsenUI/issues/2279).
 
  ### Misc
 

--- a/core/src/ons/platform.js
+++ b/core/src/ons/platform.js
@@ -109,7 +109,9 @@ class Platform {
   isIPhoneX() {
     // iPhone 8 and iPhone X have a same user agent. We cannot avoid using window.screen.
     // This works well both in iOS Safari and (UI|WK)WebView of iPhone X.
-    return this.isIPhone() && window.screen.width === 375 && window.screen.height === 812;
+    return this.isIPhone() &&
+      (window.screen.width === 375 && window.screen.height === 812
+    || window.screen.width === 812 && window.screen.height === 375);
   }
 
   /**


### PR DESCRIPTION
Though this check isn't strictly necessary for on-device use, it is helpful for in-browser development. See #2279 for discussion.