### PR TITLE
fix(react): support <Input readonly=false />

### DIFF
--- a/bindings/react/examples/components/Input.js
+++ b/bindings/react/examples/components/Input.js
@@ -55,7 +55,9 @@ export default class extends React.Component {
         <p>
         Please enter a text
         </p>
-          <Input disabled={false} value={this.state.text} float onChange={event => this.setState({text: event.target.value}) } modifier='material' placeholder='Username'></Input>
+          <Input disabled={false} value={this.state.text} float onChange={event => this.setState({text: event.target.value}) } modifier='material' placeholder='Username' />
+
+          <Input readonly={true} disabled={false} value={this.state.text} float onChange={event => this.setState({text: event.target.value}) } modifier='material' placeholder='Username (read-only)' />
 
           <input value={this.state.text} onChange={event => this.setState({text: event.target.value})} />
 

--- a/bindings/react/src/components/Input.jsx
+++ b/bindings/react/src/components/Input.jsx
@@ -44,6 +44,15 @@ Input.propTypes = {
   disabled: PropTypes.bool,
 
   /**
+   * @name readonly
+   * @type bool
+   * @description
+   *  [en]Specifies whether the input is read-only.[/en]
+   *  [ja][/ja]
+   */
+  readonly: PropTypes.bool,
+
+  /**
    * @name onChange
    * @type function
    * @description


### PR DESCRIPTION
* add proptype to <Input /> for readonly prop to support `... readonly={false}`, which closes #2323
* add example for readonly=true

(a commit contained in this PR wrongly states "... readonly=true", this should be "false")


