### PR TITLE
Fixes "Cannot read property 'classList' of null

### DIFF
--- a/core/src/ons/internal/swiper.js
+++ b/core/src/ons/internal/swiper.js
@@ -143,7 +143,10 @@ export default class Swiper {
   }
 
   _setSwiping(toggle) {
-    this.target.classList.toggle('swiping', toggle); // Hides everything except shown pages
+    if (this.target && this.target.classList) {
+      this.target.classList.toggle('swiping', toggle); // Hides everything except shown pages
+    }
+
   }
 
   setActiveIndex(index, options = {}) {


### PR DESCRIPTION
I'm facing a problem that when I have a carousel on navigationStack and I need to remove this page, the app fires this error on Console and the navigation. As far as I understood, Onsenui tries to toggle the active carousel item through css, but the component has been already unmounted.