### PR TITLE
Increase font size of text-input in order to avoid iOS zoom issues

### DIFF
--- a/css-components/src/components/text-input.css
+++ b/css-components/src/components/text-input.css
@@ -1,6 +1,6 @@
 
 :root {
-  --text-input-font-size: 15px;
+  --text-input-font-size: 16px;
   --text-input-height: 31px;
   --text-input-border-color: var(--input-border-color);
   --material-text-input-font-size: 16px;
@@ -187,4 +187,3 @@
     background-size: 100% 2px, 100% 2px;
   }
 }
-


### PR DESCRIPTION
Hi, just thought I could contribute with fixing a little annoying issue. 

When building Onsen apps, inputs has by default got a 15 pixel font size, which makes iOS/iPhone zoom unintended when interacting with the element. Increasing font-size to 16px seem to be the only good fix for this. So thought it could be nice to suggest this beeing the new default. 

Thanks for building an amazing framework, by the way. I´m really enjoying it. 