### PR TITLE
Add ControlValueAccessor to ons-input

### DIFF
--- a/bindings/angular2/src/directives/ons-input.ts
+++ b/bindings/angular2/src/directives/ons-input.ts
@@ -11,11 +11,7 @@ import {
   SimpleChange,
   forwardRef
 } from '@angular/core';
-import { 
-  ControlValueAccessor,
-  FormControl,
-  NG_VALUE_ACCESSOR
-} from '@angular/forms';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 /**
  * @element ons-input
@@ -40,6 +36,7 @@ import {
 export class OnsInput implements OnChanges, OnDestroy, ControlValueAccessor {
   private _element: any;
   private _boundOnChange: Function;
+  private _propagateChange = (_: any) => { };
 
   /**
    * @input value
@@ -66,25 +63,9 @@ export class OnsInput implements OnChanges, OnDestroy, ControlValueAccessor {
     this._element.addEventListener('input', this._boundOnChange);
   }
 
-
-  private propagateChange = (_: any) => { };
-
-  public writeValue(obj: any) {
-   if (obj) {
-     this._element.value = obj;
-   }
-  }
-
-  public registerOnChange(fn: any) {
-    this.propagateChange = fn;
-  }
-
-  public registerOnTouched() { }
-
-
   _onChange(event: any) {
     this._valueChange.emit(this._element.value);
-    this.propagateChange(this._element.value);
+    this._propagateChange(this._element.value);
   }
 
   ngOnChanges(changeRecord: {[key: string]: SimpleChange;}) {
@@ -107,4 +88,16 @@ export class OnsInput implements OnChanges, OnDestroy, ControlValueAccessor {
 
     this._element = null;
   }
+
+  writeValue(obj: any) {
+    if (obj) {
+      this._element.value = obj;
+    }
+  }
+ 
+  registerOnChange(fn: any) {
+     this._propagateChange = fn;
+  }
+ 
+  registerOnTouched() { }
 }

--- a/bindings/angular2/src/directives/ons-input.ts
+++ b/bindings/angular2/src/directives/ons-input.ts
@@ -5,6 +5,7 @@ import {
   ElementRef,
   Input,
   Output,
+  HostListener,
   EventEmitter,
   OnChanges,
   OnDestroy,
@@ -37,6 +38,7 @@ export class OnsInput implements OnChanges, OnDestroy, ControlValueAccessor {
   private _element: any;
   private _boundOnChange: Function;
   private _propagateChange = (_: any) => { };
+  private _propagateTouched = () => {};
 
   /**
    * @input value
@@ -68,6 +70,11 @@ export class OnsInput implements OnChanges, OnDestroy, ControlValueAccessor {
     this._propagateChange(this._element.value);
   }
 
+  @HostListener('blur')
+  _onBlur() {
+    this._propagateTouched();
+  }
+
   ngOnChanges(changeRecord: {[key: string]: SimpleChange;}) {
     const value = changeRecord['_value'].currentValue;
     if (this._element.value !== value) {
@@ -97,5 +104,7 @@ export class OnsInput implements OnChanges, OnDestroy, ControlValueAccessor {
      this._propagateChange = fn;
   }
  
-  registerOnTouched() { }
+  registerOnTouched(fn: any) {
+    this. _propagateTouched = fn;
+  }
 }

--- a/bindings/angular2/src/directives/ons-input.ts
+++ b/bindings/angular2/src/directives/ons-input.ts
@@ -90,9 +90,7 @@ export class OnsInput implements OnChanges, OnDestroy, ControlValueAccessor {
   }
 
   writeValue(obj: any) {
-    if (obj) {
-      this._element.value = obj;
-    }
+    this._element.value = obj;
   }
  
   registerOnChange(fn: any) {

--- a/bindings/angular2/src/directives/ons-input.ts
+++ b/bindings/angular2/src/directives/ons-input.ts
@@ -8,8 +8,14 @@ import {
   EventEmitter,
   OnChanges,
   OnDestroy,
-  SimpleChange
+  SimpleChange,
+  forwardRef
 } from '@angular/core';
+import { 
+  ControlValueAccessor,
+  FormControl,
+  NG_VALUE_ACCESSOR
+} from '@angular/forms';
 
 /**
  * @element ons-input
@@ -22,9 +28,16 @@ import {
  *   <ons-input [(value)]="value"></ons-input>
  */
 @Directive({
-  selector: 'ons-input'
+  selector: 'ons-input',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => OnsInput),
+      multi: true,
+    }
+  ]
 })
-export class OnsInput implements OnChanges, OnDestroy {
+export class OnsInput implements OnChanges, OnDestroy, ControlValueAccessor {
   private _element: any;
   private _boundOnChange: Function;
 
@@ -53,8 +66,25 @@ export class OnsInput implements OnChanges, OnDestroy {
     this._element.addEventListener('input', this._boundOnChange);
   }
 
+
+  private propagateChange = (_: any) => { };
+
+  public writeValue(obj: any) {
+   if (obj) {
+     this._element.value = obj;
+   }
+  }
+
+  public registerOnChange(fn: any) {
+    this.propagateChange = fn;
+  }
+
+  public registerOnTouched() { }
+
+
   _onChange(event: any) {
     this._valueChange.emit(this._element.value);
+    this.propagateChange(this._element.value);
   }
 
   ngOnChanges(changeRecord: {[key: string]: SimpleChange;}) {

--- a/bindings/angular2/src/directives/ons-range.ts
+++ b/bindings/angular2/src/directives/ons-range.ts
@@ -8,8 +8,10 @@ import {
   EventEmitter,
   OnChanges,
   OnDestroy,
-  SimpleChange
+  SimpleChange,
+  forwardRef
 } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 /**
  * @element ons-range
@@ -22,11 +24,19 @@ import {
  *   <ons-range [(value)]="foo"></ons-range>
  */
 @Directive({
-  selector: 'ons-range'
+  selector: 'ons-range',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => OnsRange),
+      multi: true,
+    }
+  ]
 })
-export class OnsRange implements OnChanges, OnDestroy {
+export class OnsRange implements OnChanges, OnDestroy, ControlValueAccessor {
   private _element: any;
   private _boundOnChange: Function;
+  private _propagateChange = (_: any) => { };
 
   /**
    * @input value
@@ -55,6 +65,7 @@ export class OnsRange implements OnChanges, OnDestroy {
 
   _onChange(event: any) {
     this._valueChange.emit(this._element.value);
+    this._propagateChange(this._element.value);
   }
 
   ngOnChanges(changeRecord: {[key: string]: SimpleChange;}) {
@@ -75,4 +86,14 @@ export class OnsRange implements OnChanges, OnDestroy {
 
     this._element = null;
   }
+
+  writeValue(obj: any) {
+    this._element.value = obj;
+  }
+ 
+  registerOnChange(fn: any) {
+     this._propagateChange = fn;
+  }
+ 
+  registerOnTouched() { }
 }

--- a/bindings/angular2/src/directives/ons-range.ts
+++ b/bindings/angular2/src/directives/ons-range.ts
@@ -5,6 +5,7 @@ import {
   ElementRef,
   Input,
   Output,
+  HostListener,
   EventEmitter,
   OnChanges,
   OnDestroy,
@@ -37,6 +38,7 @@ export class OnsRange implements OnChanges, OnDestroy, ControlValueAccessor {
   private _element: any;
   private _boundOnChange: Function;
   private _propagateChange = (_: any) => { };
+  private _propagateTouched = () => {};
 
   /**
    * @input value
@@ -68,6 +70,11 @@ export class OnsRange implements OnChanges, OnDestroy, ControlValueAccessor {
     this._propagateChange(this._element.value);
   }
 
+  @HostListener('blur')
+  _onBlur() {
+    this._propagateTouched();
+  }
+
   ngOnChanges(changeRecord: {[key: string]: SimpleChange;}) {
     const value = changeRecord['_value'].currentValue;
     this._element.value = value;
@@ -95,5 +102,7 @@ export class OnsRange implements OnChanges, OnDestroy, ControlValueAccessor {
      this._propagateChange = fn;
   }
  
-  registerOnTouched() { }
+  registerOnTouched(fn: any) {
+    this. _propagateTouched = fn;
+  }
 }

--- a/bindings/angular2/src/directives/ons-search-input.ts
+++ b/bindings/angular2/src/directives/ons-search-input.ts
@@ -8,8 +8,10 @@ import {
   EventEmitter,
   OnChanges,
   OnDestroy,
-  SimpleChange
+  SimpleChange,
+  forwardRef
 } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 /**
  * @element ons-search-input
@@ -22,11 +24,19 @@ import {
  *   <ons-search-input [(value)]="value"></ons-search-input>
  */
 @Directive({
-  selector: 'ons-search-input'
+  selector: 'ons-search-input',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => OnsSearchInput),
+      multi: true,
+    }
+  ]
 })
-export class OnsSearchInput implements OnChanges, OnDestroy {
+export class OnsSearchInput implements OnChanges, OnDestroy, ControlValueAccessor {
   private _element: any;
   private _boundOnChange: Function;
+  private _propagateChange = (_: any) => { };
 
   /**
    * @input value
@@ -55,6 +65,7 @@ export class OnsSearchInput implements OnChanges, OnDestroy {
 
   _onChange(event: any) {
     this._valueChange.emit(this._element.value);
+    this._propagateChange(this._element.value);
   }
 
   ngOnChanges(changeRecord: {[key: string]: SimpleChange;}) {
@@ -77,4 +88,14 @@ export class OnsSearchInput implements OnChanges, OnDestroy {
 
     this._element = null;
   }
+
+  writeValue(obj: any) {
+    this._element.value = obj;
+  }
+ 
+  registerOnChange(fn: any) {
+     this._propagateChange = fn;
+  }
+ 
+  registerOnTouched() { }
 }

--- a/bindings/angular2/src/directives/ons-search-input.ts
+++ b/bindings/angular2/src/directives/ons-search-input.ts
@@ -5,6 +5,7 @@ import {
   ElementRef,
   Input,
   Output,
+  HostListener,
   EventEmitter,
   OnChanges,
   OnDestroy,
@@ -37,6 +38,7 @@ export class OnsSearchInput implements OnChanges, OnDestroy, ControlValueAccesso
   private _element: any;
   private _boundOnChange: Function;
   private _propagateChange = (_: any) => { };
+  private _propagateTouched = () => {};
 
   /**
    * @input value
@@ -61,6 +63,11 @@ export class OnsSearchInput implements OnChanges, OnDestroy, ControlValueAccesso
     this._element = _elementRef.nativeElement;
 
     this._element.addEventListener('input', this._boundOnChange);
+  }
+
+  @HostListener('blur')
+  _onBlur() {
+    this._propagateTouched();
   }
 
   _onChange(event: any) {
@@ -97,5 +104,7 @@ export class OnsSearchInput implements OnChanges, OnDestroy, ControlValueAccesso
      this._propagateChange = fn;
   }
  
-  registerOnTouched() { }
+  registerOnTouched(fn: any) {
+    this. _propagateTouched = fn;
+  }
 }

--- a/bindings/angular2/src/directives/ons-switch.ts
+++ b/bindings/angular2/src/directives/ons-switch.ts
@@ -5,6 +5,7 @@ import {
   ElementRef,
   Input,
   Output,
+  HostListener,
   EventEmitter,
   OnChanges,
   OnDestroy,
@@ -37,6 +38,7 @@ export class OnsSwitch implements OnChanges, OnDestroy, ControlValueAccessor {
   private _element: any;
   private _boundOnChange: Function;
   private _propagateChange = (_: any) => { };
+  private _propagateTouched = () => {};
 
   /**
    * @input value
@@ -70,6 +72,11 @@ export class OnsSwitch implements OnChanges, OnDestroy, ControlValueAccessor {
     this._propagateChange(this._element.checked);
   }
 
+  @HostListener('blur')
+  _onBlur() {
+    this._propagateTouched();
+  }
+
   ngOnChanges(changeRecord: SimpleChanges) {
     const value = !!(<any>changeRecord).value.currentValue;
     this._element.checked = value;
@@ -96,5 +103,7 @@ export class OnsSwitch implements OnChanges, OnDestroy, ControlValueAccessor {
     this._propagateChange = fn;
   }
 
-  registerOnTouched() { }
+  registerOnTouched(fn: any) {
+    this. _propagateTouched = fn;
+  }
 }

--- a/bindings/angular2/src/directives/ons-switch.ts
+++ b/bindings/angular2/src/directives/ons-switch.ts
@@ -8,8 +8,10 @@ import {
   EventEmitter,
   OnChanges,
   OnDestroy,
-  SimpleChanges
+  SimpleChanges,
+  forwardRef
 } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 /**
  * @element ons-switch
@@ -22,11 +24,19 @@ import {
  *   <ons-switch [(value)]="target"></ons-switch>
  */
 @Directive({
-  selector: 'ons-switch'
+  selector: 'ons-switch',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => OnsSwitch),
+      multi: true,
+    }
+  ]
 })
-export class OnsSwitch implements OnChanges, OnDestroy {
+export class OnsSwitch implements OnChanges, OnDestroy, ControlValueAccessor {
   private _element: any;
   private _boundOnChange: Function;
+  private _propagateChange = (_: any) => { };
 
   /**
    * @input value
@@ -57,6 +67,7 @@ export class OnsSwitch implements OnChanges, OnDestroy {
 
   _onChange(event: any) {
     this._valueChange.emit(this._element.checked);
+    this._propagateChange(this._element.checked);
   }
 
   ngOnChanges(changeRecord: SimpleChanges) {
@@ -76,4 +87,14 @@ export class OnsSwitch implements OnChanges, OnDestroy {
     this._element.removeEventListener('change', this._boundOnChange);
     this._element = null;
   }
+
+  writeValue(obj: any) {
+    this._element.checked = obj;
+  }
+
+  registerOnChange(fn: any) {
+    this._propagateChange = fn;
+  }
+
+  registerOnTouched() { }
 }


### PR DESCRIPTION
As mentioned in #2261, the current `ons-input` does not support Reactive Form.
This PR proposes how to implement it.

We can use `ons-input` directive as following with help of `ControlValueAccessor `.
```html
<form [formGroup]="form">
  <ons-input formControlName="value"></ons-input>
</form>
```
We can use `ngModel` too.
```html
<ons-input [(ngModel)]="value"></ons-input>
```

How do you like it ?