### PR TITLE
Remove dotted border on buttons in Firefox

### DIFF
--- a/css-components/src/components/button.css
+++ b/css-components/src/components/button.css
@@ -50,6 +50,10 @@
     outline: 0;
   }
 
+  --button::-moz-focus-inner {
+    border: 0;
+  }
+
   --button--active: {
     background-color: var(--button-background-color);
     transition: none;


### PR DESCRIPTION
This PR will remove the border which Firefox inserts on all focused buttons. The normal :focus { outline: 0; } does actually not do anything here.