### PR TITLE
fix(ons-toast): Fixed layout of material design toast

### DIFF
--- a/css-components/src/components/toast.css
+++ b/css-components/src/components/toast.css
@@ -74,7 +74,7 @@
   margin: 0;
   background-color: var(--material-toast-background-color);
   border-radius: 0;
-  padding: 24px;
+  padding: 16px 24px;
 }
 
 .toast--material__message {

--- a/css-components/src/components/toast.css
+++ b/css-components/src/components/toast.css
@@ -74,7 +74,7 @@
   margin: 0;
   background-color: var(--material-toast-background-color);
   border-radius: 0;
-  padding: 0 24px;
+  padding: 24px;
 }
 
 .toast--material__message {


### PR DESCRIPTION
Fixed layout of ons-toast on Android.
Before fixing:
<img width="461" alt="2018-05-28 20 08 30" src="https://user-images.githubusercontent.com/32335696/40611866-10dc9bc2-62b3-11e8-91f4-511dfa08870a.png">