### PR TITLE
feat(ngx-onsenui): Add ons-tabbar directive

### DIFF
--- a/bindings/angular2/examples/tabbar.spec.js
+++ b/bindings/angular2/examples/tabbar.spec.js
@@ -23,4 +23,15 @@ describe('tabbar.html', () => {
     browser.wait(EC.visibilityOf(element.all(by.css('.normal-page')).get(0)), 5000);
     expect(element.all(by.css('.normal-page')).get(0).isDisplayed()).toBeTruthy();
   });
+
+  it ('should handle swipe event', () => {
+    expect($('#index').getText()).toBe('0.00');
+    browser.actions()
+      .mouseMove(element(by.css('.page__content')), {x: 16, y: 16})
+      .mouseDown()
+      .mouseMove({x: -50, y: 16})
+      .mouseMove({x: -100, y: 16})
+      .perform();
+    expect($('#index').getText()).not.toBe('0.00');
+  })
 });

--- a/bindings/angular2/examples/tabbar.ts
+++ b/bindings/angular2/examples/tabbar.ts
@@ -8,12 +8,8 @@ import {
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 
 @Component({
-  selector: 'ons-page',
+  selector: 'ons-page[home]',
   template: `
-    <ons-toolbar>
-      <div class="center">Page</div>
-    </ons-toolbar>
-    <div class="background"></div>
     <div class="content" id="initial-page">
       <div style="text-align: center; margin: 10px">
         <p>Home</p>
@@ -35,13 +31,9 @@ export class HomeComponent {
 }
 
 @Component({
-  selector: 'ons-page',
+  selector: 'ons-page[page]',
   template: `
-    <ons-toolbar>
-      <div class="center">Page</div>
-    </ons-toolbar>
-    <div class="background"></div>
-    <div class="content" class="normal-page">
+    <div class="content normal-page">
       <div style="text-align: center; margin: 10px">
         <p>Page</p>
       </div>
@@ -54,21 +46,34 @@ export class PageComponent {
 @Component({
   selector: 'app',
   template: `
-  <ons-tabbar swipeable animation="none">
-    <div class="tabbar__content"></div>
-    <div class="tabbar">
-      <ons-tab label="Page1" icon="ion-home" [page]="home" active></ons-tab>
-      <ons-tab label="Page2" icon="ion-help" [page]="page"></ons-tab>
-      <ons-tab label="Page3" icon="ion-stop" [page]="page"></ons-tab>
-    </div>
-  </ons-tabbar>
+    <ons-page>
+      <ons-toolbar>
+        <div class="center">Tabbar</div>
+        <div class="right">
+          Index: <span id="index">{{index}}</span>
+        </div>
+      </ons-toolbar>
+      <ons-tabbar swipeable animation="none" position="auto" (swipe)="onSwipe($event)">
+        <div class="tabbar__content"></div>
+        <div class="tabbar">
+          <ons-tab label="Page1" icon="ion-home" [page]="home" active></ons-tab>
+          <ons-tab label="Page2" icon="ion-help" [page]="page"></ons-tab>
+          <ons-tab label="Page3" icon="ion-stop" [page]="page"></ons-tab>
+        </div>
+      </ons-tabbar>
+    </ons-page>
   `
 })
 export class AppComponent {
-  home = HomeComponent
-  page = PageComponent
+  home = HomeComponent;
+  page = PageComponent;
+  index = 0.0;
 
   constructor() { }
+
+  onSwipe(event: any) {
+    this.index = event.index;
+  }
 }
 
 @NgModule({

--- a/bindings/angular2/src/directives/ons-tabbar.ts
+++ b/bindings/angular2/src/directives/ons-tabbar.ts
@@ -71,11 +71,11 @@ export class OnsTabbar {
    *   [en]Triggers when the tabbar is swiped.[/en]
    *   [ja]`<ons-tabbar>`がスワイプされた時に発火します。[/ja]
    */
-  @Output('swipe') swipe = new EventEmitter();
+  @Output('swipe') _swipe = new EventEmitter();
 
   constructor(private _elementRef: ElementRef) {
     this._element = _elementRef.nativeElement;
-    this._element.onSwipe = (index: number, options: any) => this.swipe.emit({index, options});
+    this._element.onSwipe = (index: number, options: any) => this._swipe.emit({index, options});
   }
 }
 

--- a/bindings/angular2/src/directives/ons-tabbar.ts
+++ b/bindings/angular2/src/directives/ons-tabbar.ts
@@ -8,10 +8,76 @@ import {
   ElementRef,
   Type,
   Input,
+  Output,
+  EventEmitter,
   OnDestroy,
   NgZone
 } from '@angular/core';
 import * as ons from 'onsenui';
+
+/**
+ * @element ons-tabbar
+ * @directive OnsTabbar
+ * @selector ons-tabbar
+ * @description
+ *   [en]Angular directive for `<ons-tabbar>` component.[/en]
+ *   [ja]`<ons-tabbar>`要素のためのディレクティブです。[/ja]
+ * @example
+ *   @Component({
+ *     selector: 'ons-page',
+ *     template: `
+ *       <ons-toolbar>
+ *         <div class="center">Page</div>
+ *       </ons-toolbar>
+ *       <div class="content">...</div>
+ *     `
+ *   })
+ *   class PageComponent {
+ *   }
+ *
+ *   @Component({
+ *     selector: 'app',
+ *     template: `
+ *     <ons-tabbar swipeable (swipe)="onSwipe($event)">
+ *       <div class="tabbar__content"></div>
+ *       <div class="tabbar">
+ *         <ons-tab label="Page1" icon="ion-home" [page]="page" active></ons-tab>
+ *         <ons-tab label="Page2" icon="ion-help" [page]="page"></ons-tab>
+ *         <ons-tab label="Page3" icon="ion-stop" [page]="page"></ons-tab>
+ *       </div>
+ *     </ons-tabbar>
+ *     `
+ *   })
+ *   export class AppComponent {
+ *     page = PageComponent
+ * 
+ *     onSwipe(event) {
+ *       console.log(event);
+ *     }
+ *   }
+ */
+@Directive({
+  selector: 'ons-tabbar'
+})
+export class OnsTabbar {
+  private _element: any;
+
+  /**
+   * @output swipe
+   * @param {Object} $event
+   * @param {number} $event.index
+   * @param {Object} $event.options
+   * @desc
+   *   [en]Triggers when the tabbar is swiped.[/en]
+   *   [ja]`<ons-tabbar>`がスワイプされた時に発火します。[/ja]
+   */
+  @Output('swipe') swipe = new EventEmitter();
+
+  constructor(private _elementRef: ElementRef) {
+    this._element = _elementRef.nativeElement;
+    this._element.onSwipe = (index: number, options: any) => this.swipe.emit({index, options});
+  }
+}
 
 /**
  * @element ons-tab

--- a/bindings/angular2/src/ngx-onsenui.ts
+++ b/bindings/angular2/src/ngx-onsenui.ts
@@ -22,7 +22,7 @@ import {CommonModule} from '@angular/common';
 import {BrowserModule} from '@angular/platform-browser';
 
 import {OnsNavigator} from './directives/ons-navigator';
-import {OnsTab} from './directives/ons-tabbar';
+import {OnsTabbar, OnsTab} from './directives/ons-tabbar';
 import {OnsSwitch} from './directives/ons-switch';
 import {OnsRange} from './directives/ons-range';
 import {OnsSelect} from './directives/ons-select';
@@ -42,6 +42,7 @@ import {ComponentLoader} from './ons/component-loader';
 
 const directives = [
   OnsNavigator,
+  OnsTabbar,
   OnsTab,
   OnsSwitch,
   OnsRange,


### PR DESCRIPTION
Related to #2451, this PR proposes `ons-tabbar` directive.

With `swipe` event binding, we can write the callback method as following.

```html
<ons-tabbar swipeable (swipe)="onSwipe($event)">
  <ons-tab></ons-tab>
  <ons-tab></ons-tab>
</ons-tabbar>
```

```ts
onSwipe(event) {
  // Do something with event.index and event.options
}
```
