### PR TITLE
fix(css): Fix CSS import paths

### DIFF
--- a/core/css/fonts.css
+++ b/core/css/fonts.css
@@ -1,4 +1,4 @@
-@import url("ionicons/css/ionicons.min.css");
-@import url("material-design-iconic-font/css/material-design-iconic-font.min.css");
-@import url("font_awesome/css/font-awesome.min.css");
+@import url("./ionicons/css/ionicons.min.css");
+@import url("./material-design-iconic-font/css/material-design-iconic-font.min.css");
+@import url("./font_awesome/css/font-awesome.min.css");
 


### PR DESCRIPTION
The CSS import paths for font icons should be changed from

```css
@import url('ionicons/css/ionicons.min.css');
@import url('material-design-iconic-font/css/material-design-iconic-font.min.css');
@import url('font_awesome/css/font-awesome.min.css');
```

to

```css
@import url('./ionicons/css/ionicons.min.css');
@import url('./material-design-iconic-font/css/material-design-iconic-font.min.css');
@import url('./font_awesome/css/font-awesome.min.css');
```

This will solve #2336 and #2453 .