### PR TITLE
feat(angular): Add pull output for ons-pull-hook #2457

### DIFF
--- a/bindings/angular2/examples/pull-hook.spec.js
+++ b/bindings/angular2/examples/pull-hook.spec.js
@@ -9,6 +9,17 @@ describe('pull-hook.html', () => {
     expect($('ons-pull-hook').isPresent()).toBeTruthy();
   });
 
+  it('should handle pull event', () => {
+    expect($('#ratio').getText()).toBe('0.00');
+    browser.actions()
+      .mouseMove(element(by.css('.page__content')), {x: 10, y: 60})
+      .mouseDown()
+      .mouseMove({x: 10, y: 70})
+      .perform();
+
+    expect($('#ratio').getText()).not.toBe('0.00');
+  });
+
   it('should load stuff when pulled down', () => {
     expect($('#item-5').isPresent()).toBeFalsy();
     browser.actions()
@@ -21,4 +32,5 @@ describe('pull-hook.html', () => {
     browser.wait(EC.presenceOf($('#item-5')), 5000);
     expect($('#item-5').isPresent()).toBeTruthy();
   });
+
 });

--- a/bindings/angular2/examples/pull-hook.ts
+++ b/bindings/angular2/examples/pull-hook.ts
@@ -17,8 +17,11 @@ import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
     </ons-toolbar>
 
     <div class="content">
-      <ons-pull-hook #pullhook height="64px" threshold-height="128px" (changestate)="onChangeState($event)" (action)="onAction($event)">
-        {{message}}
+      <ons-pull-hook #pullhook height="64px" threshold-height="128px" (pull)="onPull($event)" (changestate)="onChangeState($event)" (action)="onAction($event)">
+        <div style="display: flex; justify-content: center; align-items: center;">
+          {{message}}
+          <span style="position: absolute; right: 8px;">Ratio: <span id="ratio">{{ratio | number: '.2'}}</span></span>
+        </div>
       </ons-pull-hook>
 
       <ons-list>
@@ -34,7 +37,10 @@ export class AppComponent implements AfterViewInit {
 
   items: number[] = [1, 2, 3, 4, 5];
 
-  @ViewChild('pullhook') pullhook:any;
+  ratio = 0;
+
+  @ViewChild('pullhook') pullhook: any;
+
   constructor() {
   }
 
@@ -62,6 +68,11 @@ export class AppComponent implements AfterViewInit {
         break;
     }
   }
+
+  onPull($event: any) {
+    this.ratio = $event.ratio;
+  }
+
 }
 
 @NgModule({

--- a/bindings/angular2/src/directives/ons-pull-hook.ts
+++ b/bindings/angular2/src/directives/ons-pull-hook.ts
@@ -24,7 +24,7 @@ import {
  *       </ons-toolbar>
  *       <div class="content">
  *         <ons-pull-hook height="64px" threshold-height="128px" 
- *           (changestate)="onChangeState($event)" (action)="onAction($event)">
+ *           (pull)="onPull($event)" (changestate)="onChangeState($event)" (action)="onAction($event)">
  *           {{message}}
  *         </ons-pull-hook>
  *       </div>
@@ -53,6 +53,11 @@ import {
  *           break;
  *       }
  *     }
+ * 
+ *     onPull($event) {
+ *       console.log($event.ratio);
+ *     }
+ * 
  *   }
  */
 @Directive({
@@ -66,22 +71,36 @@ export class OnsPullHook implements OnDestroy {
    * @param {Object} $event
    * @param {Function} $event.done
    * @desc
-   *   [en]Action to trigger.[/en]
+   *   [en]Triggers when the page is pulled down.[/en]
    *   [ja]`ons-pull-hook`要素のアクションが必要なときに呼び出されます。[/ja]
    */
-  @Output('action') action = new EventEmitter();
+  @Output() action = new EventEmitter();
 
   /**
    * @output changestate
    * @param {Object} $event
    * @param {String} $event.state
    * @desc
-   *   [en][/en]
+   *   [en]Triggers when the state is changed.[/en]
    *   [ja]`ons-pull-hook`要素の状態が変わった時に呼び出されます。[/ja]
    */
+
+
+  /**
+   * @output pull
+   * @param {Object} $event
+   * @param {Number} $event.ratio
+   * @param {Object} $event.options
+   * @desc
+   *   [en]Triggers whenever the element is pulled.[/en]
+   *   [ja]`ons-pull-hook`要素がプルされているときに呼び出されます。[/ja]
+   */
+  @Output() pull = new EventEmitter();
+
   constructor(private _elementRef: ElementRef) {
     this._element = _elementRef.nativeElement;
     this._element.onAction = (done: Function) => this.action.emit({done});
+    this._element.onPull = (ratio: number, options: any) => this.pull.emit({ratio, options});
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
#2457

This PR makes `ons-pull-hook` able to handle `onPull` callback more Angular-friendly.

```html
<ons-pull-hook (pull)="onPull($event)"></ons-tabbar>
```
```ts
onPull(event) {
  // Do something with event.ratio and event.options
}
```