### PR TITLE
fix(ons-page): Page now sets its own class if it has a bottom toolbar

### DIFF
--- a/core/src/elements/ons-bottom-toolbar.js
+++ b/core/src/elements/ons-bottom-toolbar.js
@@ -58,12 +58,6 @@ export default class BottomToolbarElement extends BaseElement {
     ModifierUtil.initModifier(this, scheme);
   }
 
-  connectedCallback() {
-    if (util.match(this.parentNode, 'ons-page')) {
-      this.parentNode.classList.add('page-with-bottom-toolbar');
-    }
-  }
-
   static get observedAttributes() {
     return ['modifier', 'class'];
   }

--- a/core/src/elements/ons-bottom-toolbar.spec.js
+++ b/core/src/elements/ons-bottom-toolbar.spec.js
@@ -29,18 +29,6 @@ describe('ons-bottom-toolbar', () => {
     expect(element.classList.contains('bottom-bar--fuga')).to.be.true;
   });
 
-  it('ensures its page\'s class', () => {
-    var element = new ons.elements.BottomToolbar(),
-      page = new ons.elements.Page();
-
-    document.body.appendChild(page);
-    page.appendChild(element);
-
-    expect(page.classList.contains('page-with-bottom-toolbar')).to.be.true;
-
-    document.body.removeChild(page);
-  });
-
   describe('#_compile()', () => {
     it('does not compile twice', () => {
       const div1 = document.createElement('div');

--- a/core/src/elements/ons-page.js
+++ b/core/src/elements/ons-page.js
@@ -193,6 +193,12 @@ export default class PageElement extends BaseElement {
       this.attributeChangedCallback('class');
     }
 
+    const bottomToolbar = util.findChild(this, 'ons-bottom-toolbar');
+    if (bottomToolbar) {
+      this._defaultClassName += ' page-with-bottom-toolbar';
+      this.attributeChangedCallback('class');
+    }
+
     ModifierUtil.initModifier(this, scheme);
   }
 

--- a/core/src/elements/ons-page.spec.js
+++ b/core/src/elements/ons-page.spec.js
@@ -56,6 +56,15 @@ describe('OnsPageElement', () => {
     expect(page.querySelector('#inner').className).not.to.contain('page--wrapper');
   });
 
+  it('should add an extra class if there is a bottom toolbar', () => {
+    const page = ons._util.createElement(`<ons-page>
+      <div class="page__content">...</div>
+      <ons-bottom-toolbar></ons-bottom-toolbar>
+    </ons-page>`);
+
+    expect(page.className).to.contain('page-with-bottom-toolbar');
+  });
+
   describe('#attachedCallback()', () => {
     it('calls \'onInit\' hook', () => {
       const p = new Promise((resolve) => element.onInit = resolve);


### PR DESCRIPTION
Fixes #2459. In this issue, the Vue bindings were causing "page-with-bottom-toolbar" to
be removed. This was because this class was being set on ons-page by ons-bottom-toolbar,
and not being restored when Vue overwrote the classes. If possible, the page should be
responsible for its own classes, so I have moved this class handling from ons-bottom-toolbar
into ons-page.