### PR TITLE
chore(tests): Allow unit tests to pass even if Sauce credentials do not exist

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -299,7 +299,24 @@ gulp.task('unit-test', argv['skip-build'] ? [] : (argv.watch ? ['watch-core'] : 
 
     (async () => {
       const specs = argv.specs || 'core/src/**/*.spec.js'; // you cannot use commas for --specs
-      const browsers = argv.browsers ? argv.browsers.split(',').map(s => s.trim()) : ['local_chrome_headless', 'remote_macos_elcapitan_safari_10'];
+      let browsers = argv.browsers ? argv.browsers.split(',').map(s => s.trim()) : ['local_chrome_headless', 'remote_macos_elcapitan_safari_10'];
+
+      // If the Sauce credentials are not set, remove the remote builds from the queue.
+      // This way, we can run the unit test more easily locally, as well as safely for
+      // pull requests. These values are not passed to PR builds because in theory the
+      // PR could log out these values and expose them.
+      if (!process.env.SAUCE_USERNAME || !process.env.SAUCE_ACCESS_KEY) {
+        browsers = browsers.filter(browser => {
+          const isRemote = browser.indexOf('remote') === 0;
+
+          if (isRemote) {
+            console.warn(`Not testing on ${browser} due to missing credentials`);
+            return false;
+          } else {
+            return true;
+          }
+        });
+      }
 
       let listOfSpecFiles;
       if (argv.separately) { // resolve glob pattern


### PR DESCRIPTION
As part of improving our contribution process to make it easier for everyone, I am adding automated testing of pull requests on CircleCI. PRs from branches inside the Onsen UI project have always run on Circle CI, but not if they come from a forked repository. This was disabled because tests on Sauce Labs would fail to run without the credentials, which are not included in these kinds of PRs. Now, we simply skip these tests if the credentials don't exist. This will also make testing locally a bit more painless.

Once this is merged, I will configure the project to require passing tests before a PR is merged. 