### PR TITLE
feat(platform): can ignore selected platform when checking the platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ CHANGELOG
 dev
 ---
 
+ ### New Features
+
+ * ons.platform: Can choose to ignore selected platform when checking what platform is e.g. `ons.platform.isAndroid`. ([#2475](https://github.com/OnsenUI/OnsenUI/issues/2475)).
+
  ### Bug Fixes
 
  * ons-toast: Fix app closing when toast is shown and back button is pressed ([#2388](https://github.com/OnsenUI/OnsenUI/issues/2388))

--- a/core/src/ons/platform.js
+++ b/core/src/ons/platform.js
@@ -138,17 +138,17 @@ class Platform {
   //----------------
   /**
    * @method isIOS
-   * @signature isIOS([ignoreSelectedPlatform])
-   * @param {Boolean} ignoreSelectedPlatform
+   * @signature isIOS([forceActualPlatform])
+   * @param {Boolean} forceActualPlatform
    *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
    *   [ja][/ja]
    * @description
-   *   [en]Returns whether the OS is iOS. By default does not ignore selected platform.[/en]
+   *   [en]Returns whether the OS is iOS. By default will return manually selected platform if it is set.[/en]
    *   [ja]iOS上で実行されているかどうかを返します。[/ja]
    * @return {Boolean}
    */
-  isIOS(ignoreSelectedPlatform = false) {
-    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
+  isIOS(forceActualPlatform) {
+    if (!forceActualPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'ios';
     }
 
@@ -252,17 +252,17 @@ class Platform {
   //----------------
   /**
    * @method isAndroid
-   * @signature isAndroid([ignoreSelectedPlatform])
-   * @param {Boolean} ignoreSelectedPlatform
+   * @signature isAndroid([forceActualPlatform])
+   * @param {Boolean} forceActualPlatform
    *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
    *   [ja][/ja]
    * @description
-   *   [en]Returns whether the OS is Android. By default does not ignore selected platform.[/en]
+   *   [en]Returns whether the OS is Android. By default will return manually selected platform if it is set.[/en]
    *   [ja]Android上で実行されているかどうかを返します。[/ja]
    * @return {Boolean}
    */
-  isAndroid(ignoreSelectedPlatform = false) {
-    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
+  isAndroid(forceActualPlatform) {
+    if (!forceActualPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'android';
     }
 
@@ -278,17 +278,17 @@ class Platform {
   //----------------
   /**
    * @method isWP
-   * @signature isWP([ignoreSelectedPlatform])
-   * @param {Boolean} ignoreSelectedPlatform
+   * @signature isWP([forceActualPlatform])
+   * @param {Boolean} forceActualPlatform
    *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
    *   [ja][/ja]
    * @description
-   *   [en]Returns whether the OS is Windows phone. By default does not ignore selected platform.[/en]
+   *   [en]Returns whether the OS is Windows phone. By default will return manually selected platform if it is set.[/en]
    *   [ja][/ja]
    * @return {Boolean}
    */
-  isWP(ignoreSelectedPlatform = false) {
-    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
+  isWP(forceActualPlatform) {
+    if (!forceActualPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'wp';
     }
 
@@ -301,17 +301,17 @@ class Platform {
 
   /**
    * @method isBlackBerry
-   * @signature isBlackBerry([ignoreSelectedPlatform])
-   * @param {Boolean} ignoreSelectedPlatform
+   * @signature isBlackBerry([forceActualPlatform])
+   * @param {Boolean} forceActualPlatform
    *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
    *   [ja][/ja]
    * @description
-   *   [en]Returns whether the device is BlackBerry. By default does not ignore selected platform.[/en]
+   *   [en]Returns whether the device is BlackBerry. By default will return manually selected platform if it is set.[/en]
    *   [ja]BlackBerry上で実行されているかどうかを返します。[/ja]
    * @return {Boolean}
    */
-  isBlackBerry(ignoreSelectedPlatform = false) {
-    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
+  isBlackBerry(forceActualPlatform) {
+    if (!forceActualPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'blackberry';
     }
 
@@ -327,17 +327,17 @@ class Platform {
   //----------------
   /**
    * @method isOpera
-   * @signature isOpera([ignoreSelectedPlatform])
-   * @param {Boolean} ignoreSelectedPlatform
+   * @signature isOpera([forceActualPlatform])
+   * @param {Boolean} forceActualPlatform
    *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
    *   [ja][/ja]
    * @description
-   *   [en]Returns whether the browser is Opera. By default does not ignore selected platform.[/en]
+   *   [en]Returns whether the browser is Opera. By default will return manually selected platform if it is set.[/en]
    *   [ja]Opera上で実行されているかどうかを返します。[/ja]
    * @return {Boolean}
    */
-  isOpera(ignoreSelectedPlatform = false) {
-    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
+  isOpera(forceActualPlatform) {
+    if (!forceActualPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'opera';
     }
 
@@ -346,17 +346,17 @@ class Platform {
 
   /**
    * @method isFirefox
-   * @signature isFirefox([ignoreSelectedPlatform])
-   * @param {Boolean} ignoreSelectedPlatform
+   * @signature isFirefox([forceActualPlatform])
+   * @param {Boolean} forceActualPlatform
    *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
    *   [ja][/ja]
    * @description
-   *   [en]Returns whether the browser is Firefox. By default does not ignore selected platform.[/en]
+   *   [en]Returns whether the browser is Firefox. By default will return manually selected platform if it is set.[/en]
    *   [ja]Firefox上で実行されているかどうかを返します。[/ja]
    * @return {Boolean}
    */
-  isFirefox(ignoreSelectedPlatform = false) {
-    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
+  isFirefox(forceActualPlatform) {
+    if (!forceActualPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'firefox';
     }
 
@@ -365,17 +365,17 @@ class Platform {
 
   /**
    * @method isSafari
-   * @signature isSafari([ignoreSelectedPlatform])
-   * @param {Boolean} ignoreSelectedPlatform
+   * @signature isSafari([forceActualPlatform])
+   * @param {Boolean} forceActualPlatform
    *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
    *   [ja][/ja]
    * @description
-   *   [en]Returns whether the browser is Safari. By default does not ignore selected platform.[/en]
+   *   [en]Returns whether the browser is Safari. By default will return manually selected platform if it is set.[/en]
    *   [ja]Safari上で実行されているかどうかを返します。[/ja]
    * @return {Boolean}
    */
-  isSafari(ignoreSelectedPlatform = false) {
-    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
+  isSafari(forceActualPlatform) {
+    if (!forceActualPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'safari';
     }
 
@@ -384,17 +384,17 @@ class Platform {
 
   /**
    * @method isChrome
-   * @signature isChrome([ignoreSelectedPlatform])
-   * @param {Boolean} ignoreSelectedPlatform
+   * @signature isChrome([forceActualPlatform])
+   * @param {Boolean} forceActualPlatform
    *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
    *   [ja][/ja]
    * @description
-   *   [en]Returns whether the browser is Chrome. By default does not ignore selected platform.[/en]
+   *   [en]Returns whether the browser is Chrome. By default will return manually selected platform if it is set.[/en]
    *   [ja]Chrome上で実行されているかどうかを返します。[/ja]
    * @return {Boolean}
    */
-  isChrome(ignoreSelectedPlatform = false) {
-    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
+  isChrome(forceActualPlatform) {
+    if (!forceActualPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'chrome';
     }
 
@@ -403,17 +403,17 @@ class Platform {
 
   /**
    * @method isIE
-   * @signature isIE([ignoreSelectedPlatform])
-   * @param {Boolean} ignoreSelectedPlatform
+   * @signature isIE([forceActualPlatform])
+   * @param {Boolean} forceActualPlatform
    *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
    *   [ja][/ja]
    * @description
-   *   [en]Returns whether the browser is Internet Explorer. By default does not ignore selected platform.[/en]
+   *   [en]Returns whether the browser is Internet Explorer. By default will return manually selected platform if it is set.[/en]
    *   [ja]Internet Explorer上で実行されているかどうかを返します。[/ja]
    * @return {Boolean}
    */
-  isIE(ignoreSelectedPlatform = false) {
-    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
+  isIE(forceActualPlatform) {
+    if (!forceActualPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'ie';
     }
 
@@ -422,17 +422,17 @@ class Platform {
 
   /**
    * @method isEdge
-   * @signature isEdge([ignoreSelectedPlatform])
-   * @param {Boolean} ignoreSelectedPlatform
+   * @signature isEdge([forceActualPlatform])
+   * @param {Boolean} forceActualPlatform
    *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
    *   [ja][/ja]
    * @description
-   *   [en]Returns whether the browser is Edge. By default does not ignore selected platform.[/en]
+   *   [en]Returns whether the browser is Edge. By default will return manually selected platform if it is set.[/en]
    *   [ja]Edge上で実行されているかどうかを返します。[/ja]
    * @return {Boolean}
    */
-  isEdge(ignoreSelectedPlatform = false) {
-    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
+  isEdge(forceActualPlatform) {
+    if (!forceActualPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'edge';
     }
 

--- a/core/src/ons/platform.js
+++ b/core/src/ons/platform.js
@@ -138,14 +138,17 @@ class Platform {
   //----------------
   /**
    * @method isIOS
-   * @signature isIOS()
+   * @signature isIOS([ignoreSelectedPlatform])
+   * @param {Boolean} ignoreSelectedPlatform
+   *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
+   *   [ja][/ja]
    * @description
-   *   [en]Returns whether the OS is iOS.[/en]
+   *   [en]Returns whether the OS is iOS. By default does not ignore selected platform.[/en]
    *   [ja]iOS上で実行されているかどうかを返します。[/ja]
    * @return {Boolean}
    */
-  isIOS() {
-    if (this._getSelectedPlatform()) {
+  isIOS(ignoreSelectedPlatform = false) {
+    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'ios';
     }
 
@@ -249,14 +252,17 @@ class Platform {
   //----------------
   /**
    * @method isAndroid
-   * @signature isAndroid()
+   * @signature isAndroid([ignoreSelectedPlatform])
+   * @param {Boolean} ignoreSelectedPlatform
+   *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
+   *   [ja][/ja]
    * @description
-   *   [en]Returns whether the OS is Android.[/en]
+   *   [en]Returns whether the OS is Android. By default does not ignore selected platform.[/en]
    *   [ja]Android上で実行されているかどうかを返します。[/ja]
    * @return {Boolean}
    */
-  isAndroid() {
-    if (this._getSelectedPlatform()) {
+  isAndroid(ignoreSelectedPlatform = false) {
+    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'android';
     }
 
@@ -271,10 +277,18 @@ class Platform {
   // Other devices
   //----------------
   /**
+   * @method isWP
+   * @signature isWP([ignoreSelectedPlatform])
+   * @param {Boolean} ignoreSelectedPlatform
+   *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
+   *   [ja][/ja]
+   * @description
+   *   [en]Returns whether the OS is Windows phone. By default does not ignore selected platform.[/en]
+   *   [ja][/ja]
    * @return {Boolean}
    */
-  isWP() {
-    if (this._getSelectedPlatform()) {
+  isWP(ignoreSelectedPlatform = false) {
+    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'wp';
     }
 
@@ -287,14 +301,17 @@ class Platform {
 
   /**
    * @method isBlackBerry
-   * @signature isBlackBerry()
+   * @signature isBlackBerry([ignoreSelectedPlatform])
+   * @param {Boolean} ignoreSelectedPlatform
+   *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
+   *   [ja][/ja]
    * @description
-   *   [en]Returns whether the device is BlackBerry.[/en]
+   *   [en]Returns whether the device is BlackBerry. By default does not ignore selected platform.[/en]
    *   [ja]BlackBerry上で実行されているかどうかを返します。[/ja]
    * @return {Boolean}
    */
-  isBlackBerry() {
-    if (this._getSelectedPlatform()) {
+  isBlackBerry(ignoreSelectedPlatform = false) {
+    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'blackberry';
     }
 
@@ -310,14 +327,17 @@ class Platform {
   //----------------
   /**
    * @method isOpera
-   * @signature isOpera()
+   * @signature isOpera([ignoreSelectedPlatform])
+   * @param {Boolean} ignoreSelectedPlatform
+   *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
+   *   [ja][/ja]
    * @description
-   *   [en]Returns whether the browser is Opera.[/en]
+   *   [en]Returns whether the browser is Opera. By default does not ignore selected platform.[/en]
    *   [ja]Opera上で実行されているかどうかを返します。[/ja]
    * @return {Boolean}
    */
-  isOpera() {
-    if (this._getSelectedPlatform()) {
+  isOpera(ignoreSelectedPlatform = false) {
+    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'opera';
     }
 
@@ -326,14 +346,17 @@ class Platform {
 
   /**
    * @method isFirefox
-   * @signature isFirefox()
+   * @signature isFirefox([ignoreSelectedPlatform])
+   * @param {Boolean} ignoreSelectedPlatform
+   *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
+   *   [ja][/ja]
    * @description
-   *   [en]Returns whether the browser is Firefox.[/en]
+   *   [en]Returns whether the browser is Firefox. By default does not ignore selected platform.[/en]
    *   [ja]Firefox上で実行されているかどうかを返します。[/ja]
    * @return {Boolean}
    */
-  isFirefox() {
-    if (this._getSelectedPlatform()) {
+  isFirefox(ignoreSelectedPlatform = false) {
+    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'firefox';
     }
 
@@ -342,14 +365,17 @@ class Platform {
 
   /**
    * @method isSafari
-   * @signature isSafari()
+   * @signature isSafari([ignoreSelectedPlatform])
+   * @param {Boolean} ignoreSelectedPlatform
+   *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
+   *   [ja][/ja]
    * @description
-   *   [en]Returns whether the browser is Safari.[/en]
+   *   [en]Returns whether the browser is Safari. By default does not ignore selected platform.[/en]
    *   [ja]Safari上で実行されているかどうかを返します。[/ja]
    * @return {Boolean}
    */
-  isSafari() {
-    if (this._getSelectedPlatform()) {
+  isSafari(ignoreSelectedPlatform = false) {
+    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'safari';
     }
 
@@ -358,14 +384,17 @@ class Platform {
 
   /**
    * @method isChrome
-   * @signature isChrome()
+   * @signature isChrome([ignoreSelectedPlatform])
+   * @param {Boolean} ignoreSelectedPlatform
+   *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
+   *   [ja][/ja]
    * @description
-   *   [en]Returns whether the browser is Chrome.[/en]
+   *   [en]Returns whether the browser is Chrome. By default does not ignore selected platform.[/en]
    *   [ja]Chrome上で実行されているかどうかを返します。[/ja]
    * @return {Boolean}
    */
-  isChrome() {
-    if (this._getSelectedPlatform()) {
+  isChrome(ignoreSelectedPlatform = false) {
+    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'chrome';
     }
 
@@ -374,14 +403,17 @@ class Platform {
 
   /**
    * @method isIE
-   * @signature isIE()
+   * @signature isIE([ignoreSelectedPlatform])
+   * @param {Boolean} ignoreSelectedPlatform
+   *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
+   *   [ja][/ja]
    * @description
-   *   [en]Returns whether the browser is Internet Explorer.[/en]
+   *   [en]Returns whether the browser is Internet Explorer. By default does not ignore selected platform.[/en]
    *   [ja]Internet Explorer上で実行されているかどうかを返します。[/ja]
    * @return {Boolean}
    */
-  isIE() {
-    if (this._getSelectedPlatform()) {
+  isIE(ignoreSelectedPlatform = false) {
+    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'ie';
     }
 
@@ -390,14 +422,17 @@ class Platform {
 
   /**
    * @method isEdge
-   * @signature isEdge()
+   * @signature isEdge([ignoreSelectedPlatform])
+   * @param {Boolean} ignoreSelectedPlatform
+   *   [en]If true, selected platform is ignored and the actual platform is returned.[/en]
+   *   [ja][/ja]
    * @description
-   *   [en]Returns whether the browser is Edge.[/en]
+   *   [en]Returns whether the browser is Edge. By default does not ignore selected platform.[/en]
    *   [ja]Edge上で実行されているかどうかを返します。[/ja]
    * @return {Boolean}
    */
-  isEdge() {
-    if (this._getSelectedPlatform()) {
+  isEdge(ignoreSelectedPlatform = false) {
+    if (!ignoreSelectedPlatform && this._getSelectedPlatform()) {
       return this._getSelectedPlatform() === 'edge';
     }
 

--- a/core/src/ons/platform.spec.js
+++ b/core/src/ons/platform.spec.js
@@ -49,6 +49,16 @@ describe('ons.platform', () => {
       ons.platform.select('ios');
       expect(ons.platform.isIOS()).to.be.true;
     });
+
+    it('ignores selected platform if ignoreSelectedPlatform is true', () => {
+      ons.platform.select('ios');
+      expect(ons.platform.isIOS(true)).to.be.false;
+    });
+
+    it('does not ignore selected platform if ignoreSelectedPlatform is false', () => {
+      ons.platform.select('ios');
+      expect(ons.platform.isIOS(false)).to.be.true;
+    });
   });
 
   describe('#isAndroid()', () => {
@@ -59,6 +69,16 @@ describe('ons.platform', () => {
     it('supports forcing the platform', () => {
       ons.platform.select('android');
       expect(ons.platform.isAndroid()).to.be.true;
+    });
+
+    it('ignores selected platform if ignoreSelectedPlatform is true', () => {
+      ons.platform.select('android');
+      expect(ons.platform.isAndroid(true)).to.be.false;
+    });
+
+    it('does not ignore selected platform if ignoreSelectedPlatform is false', () => {
+      ons.platform.select('android');
+      expect(ons.platform.isAndroid(false)).to.be.true;
     });
   });
 
@@ -82,6 +102,16 @@ describe('ons.platform', () => {
     it('supports forcing the platform', () => {
       ons.platform.select('wp');
       expect(ons.platform.isWP()).to.be.true;
+    });
+
+    it('ignores selected platform if ignoreSelectedPlatform is true', () => {
+      ons.platform.select('wp');
+      expect(ons.platform.isWP(true)).to.be.false;
+    });
+
+    it('does not ignore selected platform if ignoreSelectedPlatform is false', () => {
+      ons.platform.select('wp');
+      expect(ons.platform.isWP(false)).to.be.true;
     });
   });
 
@@ -112,6 +142,16 @@ describe('ons.platform', () => {
       ons.platform.select('blackberry');
       expect(ons.platform.isBlackBerry()).to.be.true;
     });
+
+    it('ignores selected platform if ignoreSelectedPlatform is true', () => {
+      ons.platform.select('blackberry');
+      expect(ons.platform.isBlackBerry(true)).to.be.false;
+    });
+
+    it('does not ignore selected platform if ignoreSelectedPlatform is false', () => {
+      ons.platform.select('blackberry');
+      expect(ons.platform.isBlackBerry(false)).to.be.true;
+    });
   });
 
   describe('#isOpera()', () => {
@@ -122,6 +162,16 @@ describe('ons.platform', () => {
     it('supports forcing the platform', () => {
       ons.platform.select('opera');
       expect(ons.platform.isOpera()).to.be.true;
+    });
+
+    it('ignores selected platform if ignoreSelectedPlatform is true', () => {
+      ons.platform.select('opera');
+      expect(ons.platform.isOpera(true)).to.be.false;
+    });
+
+    it('does not ignore selected platform if ignoreSelectedPlatform is false', () => {
+      ons.platform.select('opera');
+      expect(ons.platform.isOpera(false)).to.be.true;
     });
   });
 
@@ -134,6 +184,16 @@ describe('ons.platform', () => {
       ons.platform.select('firefox');
       expect(ons.platform.isFirefox()).to.be.true;
     });
+
+    it('ignores selected platform if ignoreSelectedPlatform is true', () => {
+      ons.platform.select('firefox');
+      expect(ons.platform.isFirefox(true)).to.be.false;
+    });
+
+    it('does not ignore selected platform if ignoreSelectedPlatform is false', () => {
+      ons.platform.select('firefox');
+      expect(ons.platform.isFirefox(false)).to.be.true;
+    });
   });
 
   describe('#isSafari()', () => {
@@ -144,6 +204,16 @@ describe('ons.platform', () => {
     it('supports forcing the platform', () => {
       ons.platform.select('safari');
       expect(ons.platform.isSafari()).to.be.true;
+    });
+
+    it('ignores selected platform if ignoreSelectedPlatform is true', () => {
+      ons.platform.select('safari');
+      expect(ons.platform.isSafari(true)).to.be.false;
+    });
+
+    it('does not ignore selected platform if ignoreSelectedPlatform is false', () => {
+      ons.platform.select('safari');
+      expect(ons.platform.isSafari(false)).to.be.true;
     });
   });
 
@@ -157,6 +227,16 @@ describe('ons.platform', () => {
       ons.platform.select('chrome');
       expect(ons.platform.isChrome()).to.be.true;
     });
+
+    it('ignores selected platform if ignoreSelectedPlatform is true', () => {
+      ons.platform.select('chrome');
+      expect(ons.platform.isChrome(true)).to.be.false;
+    });
+
+    it('does not ignore selected platform if ignoreSelectedPlatform is false', () => {
+      ons.platform.select('chrome');
+      expect(ons.platform.isChrome(false)).to.be.true;
+    });
   });
 
   describe('#isIE()', () => {
@@ -167,6 +247,37 @@ describe('ons.platform', () => {
     it('supports forcing the platform', () => {
       ons.platform.select('ie');
       expect(ons.platform.isIE()).to.be.true;
+    });
+
+    it('ignores selected platform if ignoreSelectedPlatform is true', () => {
+      ons.platform.select('ie');
+      expect(ons.platform.isIE(true)).to.be.false;
+    });
+
+    it('does not ignore selected platform if ignoreSelectedPlatform is false', () => {
+      ons.platform.select('ie');
+      expect(ons.platform.isIE(false)).to.be.true;
+    });
+  });
+
+  describe('#isEdge()', () => {
+    it('returns false if platform is not Edge', () => {
+      expect(ons.platform.isEdge()).to.be.false;
+    });
+
+    it('supports forcing the platform', () => {
+      ons.platform.select('edge');
+      expect(ons.platform.isEdge()).to.be.true;
+    });
+
+    it('ignores selected platform if ignoreSelectedPlatform is true', () => {
+      ons.platform.select('edge');
+      expect(ons.platform.isEdge(true)).to.be.false;
+    });
+
+    it('does not ignore selected platform if ignoreSelectedPlatform is false', () => {
+      ons.platform.select('edge');
+      expect(ons.platform.isEdge(false)).to.be.true;
     });
   });
 

--- a/core/src/onsenui.d.ts
+++ b/core/src/onsenui.d.ts
@@ -327,6 +327,12 @@ declare namespace ons {
      *
      */
     function isEdge(): boolean;
+
+    /**
+     * @description Returns whether device is Windows phone
+     * @return {Boolean}
+     */
+    function isWP(): boolean;
   }
   /**
    * @description Utility methods for modifier attributes


### PR DESCRIPTION
Enhancement based on #2475.

I've done this by adding `ignoreSelectedPlatform` argument to the relevant functions, with default of `false` so it doesn't change existing behaviour.

If there is a better way of doing this, let me know and I'll change it.