### PR TITLE
feat(ons-toolbar): Add methods to show and hide toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ dev
  ### New Features
 
  * ons.platform: Can choose to ignore selected platform when checking what platform is e.g. `ons.platform.isAndroid`. ([#2475](https://github.com/OnsenUI/OnsenUI/issues/2475)).
+ * ons-toolbar: Add methods to show and hide the toolbar ([#2478](https://github.com/OnsenUI/OnsenUI/issues/2478))
 
  ### Bug Fixes
 

--- a/bindings/react/src/components/Toolbar.jsx
+++ b/bindings/react/src/components/Toolbar.jsx
@@ -1,4 +1,5 @@
 import SimpleWrapper from './SimpleWrapper.jsx';
+import ReactDOM from 'react-dom';
 
 import PropTypes from 'prop-types';
 
@@ -33,6 +34,20 @@ class Toolbar extends SimpleWrapper {
   _getDomNodeName() {
     return 'ons-toolbar';
   }
+
+  componentDidMount() {
+    super.componentDidMount();
+
+    if (this.props.visible !== undefined) {
+      ReactDOM.findDOMNode(this).setVisibility(this.props.visible);
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.visible !== nextProps.visible) {
+      ReactDOM.findDOMNode(this).setVisibility(nextProps.visible);
+    }
+  }
 }
 
 Toolbar.propTypes = {
@@ -45,7 +60,16 @@ Toolbar.propTypes = {
    *  [/en]
    *  [ja][/ja]
    */
-  modifier: PropTypes.string
+  modifier: PropTypes.string,
+
+  /**
+   * @name visible
+   * @type bool
+   * @description
+   *  [en]If true, the toolbar is shown on the screen. Otherwise, the toolbar is not shown.[/en]
+   *  [ja][/ja]
+   */
+  visible: PropTypes.bool
 };
 
 export default Toolbar;

--- a/bindings/vue/gulpfile.babel.js
+++ b/bindings/vue/gulpfile.babel.js
@@ -94,7 +94,7 @@ gulp.task('generate-components', () => {
   };
 
   const components = {
-    'toolbar': 'modifier',
+    'toolbar': 'hidable modifier',
     'bottom-toolbar': 'modifier',
     'toolbar-button': 'modifier',
     'alert-dialog-button': 'modifier',

--- a/bindings/vue/src/components/VOnsToolbar.vue
+++ b/bindings/vue/src/components/VOnsToolbar.vue
@@ -7,10 +7,10 @@
 <script>
   /* This file was generated automatically by 'generate-components' task in bindings/vue/gulpfile.babel.js */
   import 'onsenui/esm/elements/ons-toolbar';
-  import { deriveEvents, modifier } from '../mixins';
+  import { deriveEvents, hidable, modifier } from '../mixins';
 
   export default {
     name: 'v-ons-toolbar',
-    mixins: [deriveEvents, modifier]
+    mixins: [deriveEvents, hidable, modifier]
   };
 </script>

--- a/core/src/elements/ons-toolbar.js
+++ b/core/src/elements/ons-toolbar.js
@@ -51,9 +51,9 @@ const scheme = {
  *   [en]
  *     Toolbar component that can be used with navigation.
  *
- *     Left, center and right container can be specified by class names.
+ *     Left, center and right containers can be specified by class names.
  *
- *     This component will automatically displays as a Material Design toolbar when running on Android devices.
+ *     This component will automatically display as a Material Design toolbar when running on Android devices.
  *   [/en]
  *   [ja]ナビゲーションで使用するツールバー用コンポーネントです。クラス名により、左、中央、右のコンテナを指定できます。[/ja]
  * @codepen aHmGL
@@ -133,6 +133,56 @@ export default class ToolbarElement extends BaseElement {
         ModifierUtil.onModifierChanged(last, current, this, scheme);
         break;
     }
+  }
+
+  /**
+   * @method setVisibility
+   * @signature setVisibility(visible)
+   * @param {Boolean} visible
+   *   [en]Set to true to show the toolbar, false to hide it[/en]
+   *   [ja][/ja]
+   * @description
+   *   [en]Shows the toolbar if visible is true, otherwise hides it.[/en]
+   *   [ja][/ja]
+   */
+  setVisibility(visible) {
+    contentReady(this, () => {
+      this.style.display = visible ? '' : 'none';
+
+      if (this.parentNode) {
+        const siblingBackground = util.findChild(this.parentNode, '.page__background');
+        if (siblingBackground) {
+          siblingBackground.style.top = visible ? null : 0;
+        }
+
+        const siblingContent = util.findChild(this.parentNode, '.page__content');
+        if (siblingContent) {
+          siblingContent.style.top = visible ? null : 0;
+        }
+      }
+    });
+  }
+
+  /**
+   * @method show
+   * @signature show()
+   * @description
+   *   [en]Show the toolbar.[/en]
+   *   [ja][/ja]
+   */
+  show() {
+    this.setVisibility(true);
+  }
+
+  /**
+   * @method hide
+   * @signature hide()
+   * @description
+   *   [en]Hide the toolbar.[/en]
+   *   [ja][/ja]
+   */
+  hide() {
+    this.setVisibility(false);
   }
 
   /**

--- a/core/src/elements/ons-toolbar.spec.js
+++ b/core/src/elements/ons-toolbar.spec.js
@@ -119,4 +119,16 @@ describe('OnsToolbarElement', () => {
       ons.platform.select('');
     });
   });
+
+  describe('setVisibility', () => {
+    it('should hide the toolbar', () => {
+      element.setVisibility(false);
+      expect(element.style.display).to.equal('none');
+    });
+
+    it('should show the toolbar', () => {
+      element.setVisibility(true);
+      expect(element.style.display).not.to.equal('none');
+    });
+  });
 });

--- a/core/src/onsenui.d.ts
+++ b/core/src/onsenui.d.ts
@@ -429,6 +429,23 @@ declare namespace ons {
     visible: any;
   }
 
+  interface OnsToolbarElement extends HTMLElement {
+    /**
+     * @description Show or hide the toolbar element
+     */
+    setVisibility(visible: boolean): void;
+
+    /**
+     * @description Show the toolbar element
+     */
+    show(): void;
+
+    /**
+     * @description Hide the toolbar element
+     */
+    hide(): void;
+  }
+
   interface OnsToolbarButtonElement extends HTMLElement {
     disabled: any;
   }

--- a/examples/toolbar/index.html
+++ b/examples/toolbar/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Tabbar | Onsen UI</title>
+    <link rel="stylesheet" href="../../build/css/onsenui.css">
+    <link rel="stylesheet" href="../../build/css/onsen-css-components.css">
+
+    <script src="../../build/js/onsenui.js"></script>
+
+  </head>
+
+  <body>
+    <ons-page>
+        <ons-toolbar id="myToolbar">
+          <div class="left">L</div>
+          <div class="center">Toolbar Demo</div>
+          <div class="right">R</div>
+        </ons-toolbar>
+        <ons-button onclick="myToolbar.show()">Show toolbar</ons-button>
+        <ons-button onclick="myToolbar.hide()">Hide toolbar</ons-button>
+    </ons-page>
+  </body>
+</html>


### PR DESCRIPTION
This adds similar methods as already exist on `ons-tabbar`. This also works on all the bindings.

While trying to update the docs for Vue, I realised we don't have a way of adding Vue-specific items to the docs. I have created an issue at https://github.com/OnsenUI/OnsenUI/issues/2479.