### PR TITLE
fix(vue): make options.animation work for v-ons-splitter-side

### DIFF
--- a/bindings/vue/CHANGELOG.md
+++ b/bindings/vue/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG
 2.6.1
 ----
 
+ ### Bug Fixes
+
+ * VOnsSplitterSide: `options.animation` can now be used to set the animation. Fixes [#2394](https://github.com/OnsenUI/OnsenUI/issues/2394).
+
  ### Misc
 
  * Depend on OnsenUI ~v2.10.0

--- a/bindings/vue/examples/components/Splitter.vue
+++ b/bindings/vue/examples/components/Splitter.vue
@@ -7,6 +7,7 @@
         :side="state.side"
         :collapse="state.collapse"
         :width="state.width"
+        :options="{ animation: 'reveal' }"
         @preopen="log('preopen')"
         @postopen="log('postopen')"
         @preclose="log('preclose')"

--- a/core/src/elements/ons-splitter-side.js
+++ b/core/src/elements/ons-splitter-side.js
@@ -607,8 +607,8 @@ export default class SplitterSideElement extends BaseElement {
    */
   toggle(options = {}, force) {
     const shouldOpen = typeof force === 'boolean' ? force : !this.isOpen;
-    const action = shouldOpen ? 'open' : 'close',
-      FINAL_STATE = shouldOpen ? OPEN_STATE : CLOSED_STATE;
+    const action = shouldOpen ? 'open' : 'close';
+    const FINAL_STATE = shouldOpen ? OPEN_STATE : CLOSED_STATE;
 
     if (this._mode === SPLIT_MODE) {
       return Promise.resolve(false);
@@ -628,6 +628,10 @@ export default class SplitterSideElement extends BaseElement {
 
     const unlock = this._lock.lock();
     this._state = CHANGING_STATE;
+
+    if (options.animation) {
+      this._updateAnimation(options.animation);
+    }
 
     return new Promise(resolve => {
       this._animator[action](() => {


### PR DESCRIPTION
Fixes #2394.