### PR TITLE
feat(ngx): Add OnsSegment directive

### DIFF
--- a/bindings/angular2/examples/segment.ts
+++ b/bindings/angular2/examples/segment.ts
@@ -23,7 +23,7 @@ export class Page3Component {
 
   logIndexes() {
     console.log('active button index', this.inj.get(AppComponent)._segment.nativeElement.getActiveButtonIndex());
-    console.log('active button index', this.inj.get(AppComponent)._tabbar.nativeElement.getActiveTabIndex());
+    console.log('active tab index', this.inj.get(AppComponent)._tabbar.nativeElement.getActiveTabIndex());
   }
 }
 
@@ -42,7 +42,7 @@ export class Page2Component {
 
   logIndexes() {
     console.log('active button index', this.inj.get(AppComponent)._segment.nativeElement.getActiveButtonIndex());
-    console.log('active button index', this.inj.get(AppComponent)._tabbar.nativeElement.getActiveTabIndex());
+    console.log('active tab index', this.inj.get(AppComponent)._tabbar.nativeElement.getActiveTabIndex());
   }
 }
 
@@ -71,7 +71,7 @@ export class Page1Component {
 
   logIndexes() {
     console.log('active button index', this.inj.get(AppComponent)._segment.nativeElement.getActiveButtonIndex());
-    console.log('active button index', this.inj.get(AppComponent)._tabbar.nativeElement.getActiveTabIndex());
+    console.log('active tab index', this.inj.get(AppComponent)._tabbar.nativeElement.getActiveTabIndex());
   }
 }
 
@@ -81,7 +81,7 @@ export class Page1Component {
     <ons-page>
       <ons-toolbar>
         <div class="center">
-          <ons-segment #segment id="segment" tabbar-id="tabbar" style="width: 280px; margin-top: 8px;">
+          <ons-segment #segment style="width: 280px; margin-top: 8px;" [tabbar]="tabbar" (postchange)="onPostChange($event)">
             <button>Page 1</button>
             <button>Page 2</button>
             <button>Page 3</button>
@@ -89,14 +89,7 @@ export class Page1Component {
         </div>
       </ons-toolbar>
 
-      <!-- Comment <ons-tabbar> out to test this one -->
-      <ons-segment active-index="1" style="width: 280px; margin: 10px 20px;">
-        <button>Label 1</button>
-        <button>Label 2</button>
-        <button>Label 3</button>
-      </ons-segment>
-
-      <ons-tabbar #tabbar id="tabbar">
+      <ons-tabbar #tabbar>
         <ons-tab [page]="page1" active></ons-tab>
         <ons-tab [page]="page2"></ons-tab>
         <ons-tab [page]="page3"></ons-tab>
@@ -111,10 +104,10 @@ export class AppComponent {
   page2 = Page2Component;
   page3 = Page3Component;
 
-  constructor() {
-    document.addEventListener('postchange', function (event) {
-      console.log('postchange event', event);
-    });
+  constructor() {}
+
+  onPostChange(event: any) {
+    console.log('postchange event', event);
   }
 }
 

--- a/bindings/angular2/src/directives/ons-segment.ts
+++ b/bindings/angular2/src/directives/ons-segment.ts
@@ -1,0 +1,120 @@
+import {
+  Component,
+  Directive,
+  Input,
+  Output,
+  EventEmitter,
+  ElementRef,
+  OnChanges
+} from '@angular/core';
+
+/**
+ * @element ons-segment
+ * @directive OnsSegment
+ * @selector ons-segment
+ * @description
+ *   [en]Angular directive for `<ons-segment>` component.[/en]
+ *   [ja]`<ons-segment>`要素のAngularディレクティブです。[/ja]
+ * @example
+ *   @Component({
+ *     selector: 'app',
+ *     template: `
+ *       <ons-page>
+ *         <ons-toolbar>
+ *           <div class="center">
+ *             <ons-segment style="width: 280px; margin-top: 8px;" [tabbar]="tabbar" (postchange)="onPostChange($event)">
+ *               <button>Page 1</button>
+ *               <button>Page 2</button>
+ *               <button>Page 3</button>
+ *             </ons-segment>
+ *           </div>
+ *         </ons-toolbar>
+ *         <ons-tabbar #tabbar>
+ *           <ons-tab [page]="page1" active></ons-tab>
+ *           <ons-tab [page]="page2"></ons-tab>
+ *           <ons-tab [page]="page3"></ons-tab>
+ *         </ons-tabbar>
+ *       </ons-page>
+ *     `
+ *   })
+ *   export class AppComponent {
+ *     page1 = PageComponent;
+ *     page2 = PageComponent;
+ *     page3 = PageComponent;
+ *
+ *     constructor() {}
+ *
+ *     onPostChange(event: any) {
+ *      console.log('postchange event', event);
+ *     }
+ *   }
+ *
+ *   @Component({
+ *     selector: 'ons-page[tab]',
+ *     template: `<h2>Page</h2>`
+ *   })
+ *   export class PageComponent {
+ *     constructor() { }
+ *   }
+ */
+@Directive({
+  selector: 'ons-segment'
+})
+export class OnsSegment implements OnChanges {
+  private _element: any;
+
+  /**
+   * @output postchange
+   * @param {Object} $event
+   * @param {number} $event.index
+   * @desc
+   *   [en]Triggers when the index of the active button is changed.[/en]
+   *   [ja]`ons-segment`要素のアクティブなボタンのインデックスが変わった時に呼び出されます。[/ja]
+   */
+
+  /**
+   * @input activeIndex
+   * @type {number}
+   * @desc
+   *   [en]Input index of the active button.[/en]
+   *   [ja]アクティブなボタンのインデックスを設定します。[/ja]
+   */
+  @Input() activeIndex: number;
+
+  /**
+   * @output activeIndexChange
+   * @type {number}
+   * @desc
+   *   [en]Triggers when the index of the active button is changed.[/en]
+   *   [ja]アクティブなボタンのインデックスが変化した時に発火します。[/ja]
+   */
+  @Output() activeIndexChange = new EventEmitter<number>();
+
+  /**
+   * @input tabbar
+   * @type {Type<any>}
+   * @desc
+   *   [en]The tabbar component to "connect" to the segment. Must be inside the same page. Works only during initialization.[/en]
+   *   [ja]このセグメントに紐づけるタブバーを指定します。タブバーはセグメントと同一ページ内に存在する必要があります。初期化時にのみ動作します。[/ja]
+   */
+  @Input() set tabbar(_tabbar: any) {
+    this._element._tabbar = _tabbar;
+    this._element._tabbar.setAttribute('hide-tabs', '');
+    setImmediate(() => this._element._setChecked(this._element._tabbar.getActiveTabIndex()));
+    this._element._tabbar.addEventListener('prechange', this._element._onTabbarPreChange);
+  }
+
+  constructor(private _elementRef: ElementRef) {
+    this._element = _elementRef.nativeElement;
+    this._element.addEventListener('postchange', (event: any) => {
+      this.activeIndexChange.emit(event.index);
+    });
+  }
+
+  ngOnChanges() {
+    if (this.activeIndex) {
+      this._element.setActiveButton(this.activeIndex);
+    }
+  }
+
+}

--- a/bindings/angular2/src/ngx-onsenui.ts
+++ b/bindings/angular2/src/ngx-onsenui.ts
@@ -23,6 +23,7 @@ import {BrowserModule} from '@angular/platform-browser';
 
 import {OnsNavigator} from './directives/ons-navigator';
 import {OnsTabbar, OnsTab} from './directives/ons-tabbar';
+import {OnsSegment} from './directives/ons-segment';
 import {OnsSwitch} from './directives/ons-switch';
 import {OnsRange} from './directives/ons-range';
 import {OnsSelect} from './directives/ons-select';
@@ -44,6 +45,7 @@ const directives = [
   OnsNavigator,
   OnsTabbar,
   OnsTab,
+  OnsSegment,
   OnsSwitch,
   OnsRange,
   OnsSelect,

--- a/core/src/elements/ons-segment.js
+++ b/core/src/elements/ons-segment.js
@@ -156,8 +156,8 @@ export default class SegmentElement extends BaseElement {
   }
 
   connectedCallback() {
-    if (this.hasAttribute('tabbar-id')) {
-      contentReady(this, () => {
+    contentReady(this, () => {
+      if (this.hasAttribute('tabbar-id')) {
         const page = util.findParent(this, 'ons-page');
         this._tabbar = page && page.querySelector('#' + this.getAttribute('tabbar-id'));
         if (!this._tabbar || this._tabbar.tagName !== 'ONS-TABBAR') {
@@ -168,8 +168,8 @@ export default class SegmentElement extends BaseElement {
         setImmediate(() => this._setChecked(this._tabbar.getActiveTabIndex()));
 
         this._tabbar.addEventListener('prechange', this._onTabbarPreChange);
-      });
-    }
+      }
+    });
 
     this.addEventListener('change', this._onChange);
   }


### PR DESCRIPTION
This PR introduces `OnsSegment` directive according to #2390 .

You can use `tabbar` input instead of passing `tabbar-id`.
(If you like to use `tabbar-id`, please set `id` to `ons-tabbar` 😉)

```html
<ons-segment [tabbar]="tabbar" (postchange)="onPostChange($event)">
  <button>Page 1</button>
  <button>Page 2</button>
  <button>Page 3</button>
</ons-segment>
<ons-tabbar #tabbar>
  <ons-tab></ons-tab>
  <ons-tab></ons-tab>
  <ons-tab></ons-tab>
</ons-tabbar>
```

You can change the index of the active button by using `activeIndex` input.

```html
<ons-segment [(activeIndex)]="index" (postchange)="onPostChange($event)">
  <button>Page 1</button>
  <button>Page 2</button>
  <button>Page 3</button>
</ons-segment>
```

`activeIndex` also outputs the current index of active button when it is changed.