### PR TITLE
fix(vue): make selected value update when options change in VOnsSelect

### DIFF
--- a/bindings/vue/CHANGELOG.md
+++ b/bindings/vue/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 ====
 
+dev
+----
+
+ ### Bug Fixes
+
+ * VOnsSelect: selected value is updated properly when options change. Fixes [#2486](https://github.com/OnsenUI/OnsenUI/issues/2486).
+
 2.6.1
 ----
 

--- a/bindings/vue/src/components/VOnsSelect.vue
+++ b/bindings/vue/src/components/VOnsSelect.vue
@@ -1,6 +1,6 @@
 <template>
   <ons-select v-on="$listeners" :modifier="normalizedModifier">
-    <select>
+    <select v-model="selectedValue">
       <slot></slot>
     </select>
   </ons-select>
@@ -8,10 +8,31 @@
 
 <script>
   import 'onsenui/esm/elements/ons-select';
-  import { modelInput, modifier } from '../mixins';
+  import { modifier } from '../mixins';
 
   export default {
     name: 'v-ons-select',
-    mixins: [modelInput, modifier]
+    mixins: [modifier],
+    model: {
+      prop: 'modelProp',
+      event: 'modelEvent'
+    },
+    props: {
+      modelProp: [Number, String],
+      modelEvent: {
+        type: String,
+        default: 'input'
+      }
+    },
+    computed: {
+      selectedValue: {
+        get() {
+          return this.modelProp;
+        },
+        set(val) {
+          this.$emit('modelEvent', val);
+        }
+      }
+    }
   };
 </script>


### PR DESCRIPTION
Fixes #2486.

This fix might cause problems because `v-model` is put directly on the
inner `select`, _not_ the `ons-select`. The proper solution is to make
`value` an attribute on `ons-select` (at the moment it is a JS
property).