### PR TITLE
React Tabbar, update page when not passing explicit prop in.

### DIFF
--- a/bindings/react/src/components/Tabbar.jsx
+++ b/bindings/react/src/components/Tabbar.jsx
@@ -43,15 +43,19 @@ class Tabbar extends BasicComponent {
       }
     };
     this.onPreChange = callback.bind(this, 'onPreChange');
-    this.onPostChange = callback.bind(this, 'onPostChange');
-    this.onReactive = callback.bind(this, 'onReactive');
+    this.onReactive  = callback.bind(this, 'onReactive');
+    this.updateIndex = this.updateIndex.bind(this);
+    this.state = {
+        index:this.props.index ? this.props.index : 0
+    }
+
   }
 
   componentDidMount() {
     super.componentDidMount();
     const node = this._tabbar;
     node.addEventListener('prechange', this.onPreChange);
-    node.addEventListener('postchange', this.onPostChange);
+    node.addEventListener('postchange', this.updateIndex);
     node.addEventListener('reactive', this.onReactive);
     node.onSwipe = this.props.onSwipe || null;
     if (this.props.visible !== undefined) {
@@ -62,31 +66,42 @@ class Tabbar extends BasicComponent {
   componentWillUnmount() {
     const node = this._tabbar;
     node.removeEventListener('prechange', this.onPreChange);
-    node.removeEventListener('postchange', this.onPostChange);
+    node.removeEventListener('postchange', this.updateIndex);
     node.removeEventListener('reactive', this.onReactive);
   }
 
   componentWillReceiveProps(nextProps) {
     const node = this._tabbar;
+
     if (nextProps.index !== this.props.index && nextProps.index !== node.getActiveTabIndex()) {
       node.setActiveTab(nextProps.index, { reject: false });
     }
+
     if (this.props.onSwipe !== nextProps.onSwipe) {
       node.onSwipe = nextProps.onSwipe;
     }
     if (this.props.visible !== nextProps.visible) {
       node.setTabbarVisibility(nextProps.visible);
     }
+    if(nextProps.index !== this.props.index && nextProps.index !== this.state.index) {
+      this.setState({
+        index: nextProps.index
+      });
+    }
   }
 
   render() {
-    const attrs = Util.getAttrs(this, this.props, { index: 'activeIndex' });
-    const tabs = this.props.renderTabs(this.props.index, this);
+    const useProps = Object.assign({},this.props,{
+      index:this.state.index
+    });
+
+    const attrs = Util.getAttrs(this, useProps, { index: 'activeIndex' });
+    const tabs = this.props.renderTabs(this.state.index, this);
 
     if (!this.tabPages) {
       this.tabPages = tabs.map((tab) => tab.content);
     } else {
-      this.tabPages[this.props.index] = tabs[this.props.index].content;
+      this.tabPages[this.state.index] = tabs[this.state.index].content;
     }
 
     return (
@@ -103,6 +118,18 @@ class Tabbar extends BasicComponent {
         </div>
       </ons-tabbar>
     );
+  }
+
+  updateIndex(e){
+    this.setState((s,p)=>{
+      return Object.assign({},s,{
+        index:e.index
+      });
+    });
+    if(this.props.onPostChange)
+    {
+      this.props.onPostChange(e);
+    }
   }
 }
 


### PR DESCRIPTION
Issue #2335 is happening due to the Tabbar components internal page cache being incorrectly updated when the Page component returned from the renderTabs function changes.

In Tabbar's render method:
```jsx
 const tabs = this.props.renderTabs(this.props.index, this);

 if (!this.tabPages) {
      this.tabPages = tabs.map((tab) => tab.content);
    } else {
      this.tabPages[this.props.index] = tabs[this.props.index].content;
    }
```
The first render of the component will populate tabPages with every tabs content. Subsequent renders will only update the current tab's content. A page's content fails to update when the 'index' prop is out of sync with the actual index that needs to be update. This can occur for two reasons:

1. No 'index' prop is being passed in.
2. The 'index' prop is being passed in and the user has swiped or clicked on a tab to navigate a different page.

So what happens in case 1? The default for the index prop is 0. As such, changes to the first tab's content will be made, all other tabs will be ignored.
```jsx
Tabbar.defaultProps = {
  index: 0
};
```

In case 2, the 'index' prop can be out of sync with the ons-tabbar's active tab index since it can change by means other than just updating the Tabbar's 'index' prop.

In Tabbar's componentWillReceiveProps method:
```jsx
 if (nextProps.index !== this.props.index && nextProps.index !== node.getActiveTabIndex()) {
      node.setActiveTab(nextProps.index, { reject: false });
    }
```


How do we solve this problem? The easiest solution would be to regenerate the entire tabPages cache on every render. This has the downside of removing the entire optimization and results in unnecessary reconciliation within react. A better solution is keeping the current pattern, but ensuring that the correct tab is updated. 

Conceptually, what we want is this:
```jsx
 const node = this._tabbar;
 const tabs = this.props.renderTabs(node.getActiveTabIndex(), this);

 if (!this.tabPages) {
      this.tabPages = tabs.map((tab) => tab.content);
    } else {
      this.tabPages[node.getActiveTabIndex()] = tabs[node.getActiveTabIndex()].content;
    }
```
Notice how the responsibility of deciding which tab's content gets updated has changed from the passed in 'index' prop to the ons-tabbar's current active tab. 

There are 2 issues with this solution though:
1. Changing ons-tabbar's active tab by a means internal to the web component (swiping / clicking a tab)  will not cause react to rerender, and the tab's content will not be updated.
2. It is not guaranteed that node.getActiveTabIndex() will return the value set in Tabbar's componentWillReceiveProps method by the time Tabbar's render method is called.

The first point seems like a non-issue, since renderTabs' output can't change without a rerender happening. It is an issue though. We can't be sure that renderTab's output hadn't changed during a prior rendering, which was thrown out by not updating tabPages to prevent unnecessary reconciliation. 

The second point results from the possibility of setting ons-tabbar's active tab being asynchronous. This appears to be rare, but happens when:
A.  A tab's page is not loaded.
B. platform.isUIWebView() is true.

To ensure that react rerenders the component and uses the correct tab index in response to the active tab changing, this patch tracks the active tab within Tabbar's state, which gets updated during the onPostChange event or in response to the 'index' prop changing. I have tested it with the example in issue #2335 to confirm it works, and I am unaware of any side-effects or bugs.








