### PR TITLE
Change navigator lift animation on iOS to not animate the page behind

### DIFF
--- a/core/src/elements/ons-navigator/ios-lift-animator.js
+++ b/core/src/elements/ons-navigator/ios-lift-animator.js
@@ -50,12 +50,6 @@ export default class IOSLiftNavigatorAnimator extends NavigatorAnimator {
         .default(
           { transform: 'translate3D(0, 100%, 0)' },
           { transform: 'translate3D(0, 0, 0)' }
-        ),
-
-      animit(leavePage, this.def)
-        .default(
-          { transform: 'translate3D(0, 0, 0)', opacity: 1 },
-          { transform: 'translate3D(0, -10%, 0)', opacity: .9 }
         )
         .queue(done => {
           this.backgroundMask.remove();
@@ -79,23 +73,17 @@ export default class IOSLiftNavigatorAnimator extends NavigatorAnimator {
 
     animit.runAll(
 
-      animit(enterPage, this.def)
+      animit(leavePage, this.def)
         .default(
-          { transform: 'translate3D(0, -43px, 0)', opacity: .9 },
-          { transform: 'translate3D(0, 0, 0)', opacity: 1 }
+          { transform: 'translate3D(0, 0, 0)' },
+          { transform: 'translate3D(0, 100%, 0)' }
         )
         .queue(done => {
           this.backgroundMask.remove();
           unblock();
           callback();
           done();
-        }),
-
-      animit(leavePage, this.def)
-        .default(
-          { transform: 'translate3D(0, 0, 0)' },
-          { transform: 'translate3D(0, 100%, 0)' }
-        )
+        })
     );
   }
 }


### PR DESCRIPTION
I'm trying to use the lift transition to mimic the iOS modal transition, but the existing transition also animates the underlying page while it transitions. This is right for the iOS push transition, but not for the modal, so I'm wondering why the lift transition has it! I don't _think_ the current behaviour matches anything on iOS?

If you agree, I believe this very simple change makes the lift animation behaviour look more like iOS!