### PR TITLE
fix(ngx-onsenui): Replace ReflectiveInjector with StaticInjector

### DIFF
--- a/bindings/angular2/src/directives/ons-navigator.ts
+++ b/bindings/angular2/src/directives/ons-navigator.ts
@@ -1,7 +1,6 @@
 import {
   Component,
   Injector,
-  ReflectiveInjector,
   Directive,
   ElementRef,
   ComponentRef,
@@ -97,10 +96,13 @@ export class OnsNavigator implements OnDestroy {
       ({page, parent, params}: any, done: Function) => {
         this._zone.run(() => {
           const pageParams = new Params(params || {});
-          const injector = ReflectiveInjector.resolveAndCreate([
-            {provide: Params, useValue: pageParams},
-            {provide: OnsNavigator, useValue: this}
-          ], this._injector);
+          const injector = Injector.create({
+            providers: [
+              {provide: Params, useValue: pageParams},
+              {provide: OnsNavigator, useValue: this}
+            ],
+            parent: this._injector
+          });
 
           const factory = this._resolver.resolveComponentFactory(page);
           const selector = 'ons-navigator';

--- a/bindings/angular2/src/directives/ons-splitter.ts
+++ b/bindings/angular2/src/directives/ons-splitter.ts
@@ -6,7 +6,6 @@ import {
   ElementRef,
   Input,
   OnDestroy,
-  ReflectiveInjector,
   OnInit,
   ViewContainerRef,
   ComponentFactoryResolver,
@@ -91,10 +90,13 @@ export class OnsSplitterSide {
     return new ons.PageLoader(
       ({page, parent, params}: any, done: Function) => {
         this._zone.run(() => {
-          const injector = ReflectiveInjector.resolveAndCreate([
-            {provide: Params, useValue: new Params(params || {})},
-            {provide: OnsSplitterSide, useValue: this}
-          ], this._injector);
+          const injector = Injector.create({
+            providers: [
+              {provide: Params, useValue: new Params(params || {})},
+              {provide: OnsSplitterSide, useValue: this}
+            ],
+            parent: this._injector
+          });
 
           const factory = this._resolver.resolveComponentFactory(page);
           const pageComponentRef = this._viewContainer.createComponent(factory, 0, injector);
@@ -162,10 +164,13 @@ export class OnsSplitterContent {
 
     return new ons.PageLoader(
       ({page, parent, params}: any, done: Function) => {
-        const injector = ReflectiveInjector.resolveAndCreate([
-          {provide: Params, useValue: new Params(params || {})},
-          {provide: OnsSplitterContent, useValue: this}
-        ], this._injector);
+        const injector = Injector.create({
+          providers: [
+            {provide: Params, useValue: new Params(params || {})},
+            {provide: OnsSplitterContent, useValue: this}
+          ],
+          parent: this._injector
+        });
 
         const factory = this._resolver.resolveComponentFactory(page);
         const pageComponentRef = this._viewContainer.createComponent(factory, 0, injector);

--- a/bindings/angular2/src/ons/alert-dialog-factory.ts
+++ b/bindings/angular2/src/ons/alert-dialog-factory.ts
@@ -4,7 +4,6 @@ import {
   Injectable,
   ApplicationRef,
   ComponentRef,
-  ReflectiveInjector,
   Type,
   NgZone
 } from '@angular/core';
@@ -38,9 +37,12 @@ export class AlertDialogFactory {
       setImmediate(() => {
         this._zone.run(() => {
           const factory = this._resolver.resolveComponentFactory(componentType);
-          const injector = ReflectiveInjector.resolveAndCreate([
-            {provide: Params, useValue: new Params(params)}
-          ], this._injector);
+          const injector = Injector.create({
+            providers: [
+              {provide: Params, useValue: new Params(params)}
+            ],
+            parent: this._injector
+          });
           const componentRef = factory.create(injector);
           const rootElement = componentRef.location.nativeElement;
 

--- a/bindings/angular2/src/ons/dialog-factory.ts
+++ b/bindings/angular2/src/ons/dialog-factory.ts
@@ -4,7 +4,6 @@ import {
   Injectable,
   ApplicationRef,
   ComponentRef,
-  ReflectiveInjector,
   Type,
   NgZone
 } from '@angular/core';
@@ -38,9 +37,12 @@ export class DialogFactory {
       setImmediate(() => {
         this._zone.run(() => {
           const factory = this._resolver.resolveComponentFactory(componentType);
-          const injector = ReflectiveInjector.resolveAndCreate([
-            {provide: Params, useValue: new Params(params)}
-          ], this._injector);
+          const injector = Injector.create({
+            providers: [
+              {provide: Params, useValue: new Params(params)}
+            ],
+            parent: this._injector
+          });
           const componentRef = factory.create(injector);
           const rootElement = componentRef.location.nativeElement;
 

--- a/bindings/angular2/src/ons/modal-factory.ts
+++ b/bindings/angular2/src/ons/modal-factory.ts
@@ -4,7 +4,6 @@ import {
   Injectable,
   ApplicationRef,
   ComponentRef,
-  ReflectiveInjector,
   Type,
   NgZone
 } from '@angular/core';
@@ -38,9 +37,12 @@ export class ModalFactory {
       setImmediate(() => {
         this._zone.run(() => {
           const factory = this._resolver.resolveComponentFactory(componentType);
-          const injector = ReflectiveInjector.resolveAndCreate([
-            {provide: Params, useValue: new Params(params)}
-          ], this._injector);
+          const injector = Injector.create({
+            providers: [
+              {provide: Params, useValue: new Params(params)}
+            ],
+            parent: this._injector
+          });
           const componentRef = factory.create(injector);
           const rootElement = componentRef.location.nativeElement;
 

--- a/bindings/angular2/src/ons/popover-factory.ts
+++ b/bindings/angular2/src/ons/popover-factory.ts
@@ -6,7 +6,6 @@ import {
   ApplicationRef,
   ComponentRef,
   ViewContainerRef,
-  ReflectiveInjector,
   Type,
   NgZone
 } from '@angular/core';
@@ -40,9 +39,12 @@ export class PopoverFactory {
       setImmediate(() => {
         this._zone.run(() => {
           const factory = this._resolver.resolveComponentFactory(componentType);
-          const injector = ReflectiveInjector.resolveAndCreate([
-            {provide: Params, useValue: new Params(params)}
-          ], this._injector);
+          const injector = Injector.create({
+            providers: [
+              {provide: Params, useValue: new Params(params)}
+            ],
+            parent: this._injector
+          });
           const componentRef = factory.create(injector);
           const rootElement = componentRef.location.nativeElement;
 


### PR DESCRIPTION
This PR replaces `ReflectiveInjector`, which has been deprecated since v5, with `StaticInjector`. #2510