### PR TITLE
fix(ons-icon): Fix bug where Font Awesome v5 styles were being ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 CHANGELOG
 ====
 
+dev
+---
+
+ ### Bug Fixes
+
+ * ons-icon: Fix bug where Font Awesome v5 styles (far, fal, fab) were being ignored.
+
 2.10.6
 ---
 

--- a/core/src/elements/ons-icon.js
+++ b/core/src/elements/ons-icon.js
@@ -182,7 +182,10 @@ export default class IconElement extends BaseElement {
       classList.push('ons-icon--ion');
     } else if (iconName.indexOf('fa-') === 0) {
       classList.push(iconName);
-      classList.push('fa');
+      // default icon style to Font Awesome Solid if icon style is not specified already
+      if (!(this.classList.contains('far') || this.classList.contains('fab') || this.classList.contains('fal'))) {
+        classList.push('fa');
+      }
     } else if (iconName.indexOf('md-') === 0)  {
       classList.push('zmdi');
       classList.push('zmdi-' + iconName.split(/-(.+)?/)[1]);

--- a/core/src/elements/ons-icon.spec.js
+++ b/core/src/elements/ons-icon.spec.js
@@ -82,6 +82,39 @@ describe('OnsIconElement', () => {
       expect(element.classList.contains('zmdi-face')).to.be.true;
       ons.platform.select('');
     });
+
+    it('defaults to Font Awesome Solid if icon style is not specified', () => {
+      const element = new ons.elements.Icon();
+      element.setAttribute('icon', 'fa-circle');
+      expect(element.classList.contains('fa')).to.be.true;
+      expect(element.classList.contains('far')).to.not.be.true;
+      expect(element.classList.contains('fal')).to.not.be.true;
+      expect(element.classList.contains('fab')).to.not.be.true;
+    });
+
+    it('supports Font Awesome Regular icon style', () => {
+      const element = new ons.elements.Icon();
+      element.classList.add('far');
+      element.setAttribute('icon', 'fa-circle');
+      expect(element.classList.contains('far')).to.be.true;
+      expect(element.classList.contains('fa')).to.not.be.true;
+    });
+
+    it('supports Font Awesome Brands icon style', () => {
+      const element = new ons.elements.Icon();
+      element.classList.add('fab');
+      element.setAttribute('icon', 'fa-circle');
+      expect(element.classList.contains('fab')).to.be.true;
+      expect(element.classList.contains('fa')).to.not.be.true;
+    });
+
+    it('supports Font Awesome Light icon style', () => {
+      const element = new ons.elements.Icon();
+      element.classList.add('fal');
+      element.setAttribute('icon', 'fa-circle');
+      expect(element.classList.contains('fal')).to.be.true;
+      expect(element.classList.contains('fa')).to.not.be.true;
+    });
   });
 
   describe('size attribute', () => {


### PR DESCRIPTION
Spotted by Discord user AndyGroff:

```
Hey all! Currently using the Angular 2+ and am having trouble getting the far version of font awesome icons to show up.
I'm using code like this: <ons-icon class="voteable far" icon="fa-circle" size="40px"></ons-icon>
manually appending the class far works to get the proper class on there, but onsen is appending the class fa afterwards which overrides the far class. Is there any way to make it not append the fa class?
```

(Note: bug exists for all frameworks, not just Angular 2+)