### PR TITLE
Fix ons-navigator.bringPageTop bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ dev
  ### Bug Fixes
 
  * ons-icon: Fix bug where Font Awesome v5 styles (far, fal, fab) were being ignored.
+ * ons-navigator: Fix bringPageTop not working if a page is defined inside ons-navigator tags.
 
 2.10.6
 ---

--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -884,10 +884,6 @@ export default class NavigatorElement extends BaseElement {
   _lastIndexOfPage(pageName) {
     let index;
     for (index = this.pages.length - 1; index >= 0; index--) {
-      if (!this._pageMap.has(this.pages[index])) {
-        util.throw('Incorrect state of pageMap');
-      }
-
       if (pageName === this._pageMap.get(this.pages[index])) {
         break;
       }

--- a/core/src/elements/ons-navigator/index.spec.js
+++ b/core/src/elements/ons-navigator/index.spec.js
@@ -341,6 +341,15 @@ describe('OnsNavigatorElement', () => {
         });
       });
     });
+
+    it('works when initial page is defined as child element', () => {
+      nav = ons._util.createElement(`
+        <ons-navigator page='hoge'><ons-page></ons-page></ons-navigator>
+      `);
+      document.body.appendChild(nav);
+
+      expect(() => nav.bringPageTop('hoge')).to.not.throw(Error);
+    });
   });
 
   describe('#insertPage()', () => {


### PR DESCRIPTION
Bug is when initial page is defined inside `ons-navigator` tags then any call to `ons-navigator.bringPageTop` will crash due to `ons-navigator._pageMap`.
