### PR TITLE
Add module field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:skip-build": "gulp test --disable-warnings --skip-build"
   },
   "main": "js/onsenui.js",
+  "module": "esm/index.js",
   "typings": "js/onsenui.d.ts",
   "files": [
     "bower.json",


### PR DESCRIPTION
This will allow usage through eg. unpkg.com using `<script src="https://unpkg.com/onsenui?module" type="module"></script>`

It would probably also allow tree shaking to work when bundling with rollup et al.

Be sure to test this with various bundlers before merging ;)
I found [the commit](https://github.com/OnsenUI/OnsenUI/commit/eb909909c49f99c2fc6bb5c573a850527e589364) that removed this saying "temporarily", so perhaps it's time to include again?