### PR TITLE
[ons-row.js]: Add link to Layout guide

### DIFF
--- a/core/src/elements/ons-row.js
+++ b/core/src/elements/ons-row.js
@@ -25,7 +25,7 @@ import BaseElement from './base/base-element';
  *   [en]Represents a row in the grid system. Use with `<ons-col>` to layout components.[/en]
  *   [ja]グリッドシステムにて行を定義します。ons-colとともに使用し、コンポーネントの配置に使用します。[/ja]
  * @codepen GgujC {wide}
- * @guide theming.html
+ * @guide features.html
  *   [en]Layouting guide[/en]
  *   [ja]レイアウト調整[/ja]
  * @seealso ons-col


### PR DESCRIPTION
This fixes #2586.
I found the problem, in page https://onsen.io/v2/api/js/ons-row.html when we click on "Layouting guide", we are directed to "Theme Customization" page. 

I changed the link.  