### PR TITLE
fix(ons-tab): Show active-icon for initially active tab in Angular 2+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 CHANGELOG
 ====
 
-2.10.9
+dev
 ---
+
+ ### Bug Fixes
+
+ * ons-tab: Show active-icon for initially active tab in Angular 2+. ([#2656](https://github.com/OnsenUI/OnsenUI/issues/2656)).
 
  ### Misc
 

--- a/bindings/angular2/examples/tabbar.ts
+++ b/bindings/angular2/examples/tabbar.ts
@@ -56,8 +56,8 @@ export class PageComponent {
       <ons-tabbar swipeable animation="none" position="auto" (swipe)="onSwipe($event)">
         <div class="tabbar__content"></div>
         <div class="tabbar">
-          <ons-tab label="Page1" icon="ion-ios-home" [page]="home" active></ons-tab>
-          <ons-tab label="Page2" icon="ion-ios-help" [page]="page"></ons-tab>
+          <ons-tab label="Page1" icon="ion-ios-home" [page]="home" active active-icon="ion-ios-square"></ons-tab>
+          <ons-tab label="Page2" icon="ion-ios-help" [page]="page" active-icon="ion-ios-square"></ons-tab>
           <ons-tab label="Page3" icon="ion-ios-square" [page]="page"></ons-tab>
         </div>
       </ons-tabbar>

--- a/core/src/elements/ons-tab.js
+++ b/core/src/elements/ons-tab.js
@@ -194,7 +194,7 @@ export default class TabElement extends BaseElement {
       iconWrapper = iconWrapper || util.createElement('<div class="tabbar__icon"><ons-icon></ons-icon></div>');
       const icon = iconWrapper.children[0];
       const fix = (last => () => icon.attributeChangedCallback('icon', last, this.getAttribute('icon')))(icon.getAttribute('icon'));
-      icon.setAttribute('icon', this.getAttribute('icon'));
+      icon.setAttribute('icon', this.getAttribute(this.isActive() ? 'active-icon' : 'icon'));
       iconWrapper.parentElement !== button && button.insertBefore(iconWrapper, button.firstChild);
 
       // dirty fix for https://github.com/OnsenUI/OnsenUI/issues/1654


### PR DESCRIPTION
Fixes #2656.

Includes example to show the problem.