### PR TITLE
fix(gulpfile): Stop fonts being included in onsenui-core.css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 CHANGELOG
 ====
 
-2.10.9
+dev
 ---
 
  ### Misc
@@ -10,6 +10,7 @@ CHANGELOG
  * Upgrade Font Awesome to v5.8.1
  * Upgrade Ionicons to v4.5.5
  * Upgrade Material Design icons to v2.2.0
+ * Stop fonts being included in onsenui-core.css
 
 2.10.8
 ---

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -39,6 +39,7 @@ import rawAngularRollupConfig from './bindings/angular1/rollup.config.js';
 
 // Configurations
 const rawRollupConfigs = [].concat(rawCoreRollupConfig, rawAngularRollupConfig);
+// make an object of rollup configs where each entry in object is: config name -> config
 const rollupConfigs = rawRollupConfigs.reduce((r, c) => (r[c.output.name] = c) && r, {});
 const babelrc = Object.assign({}, pkg.babel);
 babelrc.babelrc = babelrc.presets[0][1].modules = false;
@@ -489,9 +490,9 @@ function clean() {
 function coreCss() {
   const buildPath = 'build/css/';
   const core = (name, fonts) => gulp.src([
-      (fonts ? '' : '!') + 'core/css/fonts.css',
       'core/css/common.css',
       'core/css/*.css',
+      (fonts ? '' : '!') + 'core/css/fonts.css',
     ])
     .pipe($.concat(`${name}.css`))
     .pipe($.insert.prepend(`/*! ${pkg.name} - v${pkg.version} - ${dateformat(new Date(), 'yyyy-mm-dd')} */\n`))


### PR DESCRIPTION
Fixes #2668.

Since Gulp 4, negative globs need to come after a positive glob.
https://gulpjs.com/docs/en/getting-started/explaining-globs