### PR TITLE
Renamed deprecated react lifecyles to remove the warnings in React 16.9

### DIFF
--- a/bindings/react/src/components/BackButton.jsx
+++ b/bindings/react/src/components/BackButton.jsx
@@ -38,7 +38,7 @@ class BackButton extends SimpleWrapper {
     this._updateOnClick(this.props);
   }
 
-  componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(props) {
     this._updateOnClick(props);
   }
 }

--- a/bindings/react/src/components/BaseDialog.jsx
+++ b/bindings/react/src/components/BaseDialog.jsx
@@ -53,7 +53,7 @@ class BaseDialog extends React.Component {
     this.renderPortal(this.props, false, this.props.onDeviceBackButton);
   }
 
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     this.renderPortal(newProps, this.props.isOpen);
     if (newProps.onDeviceBackButton !== undefined) {
       this.node.firstChild.onDeviceBackButton = newProps.onDeviceBackButton;

--- a/bindings/react/src/components/LazyList.jsx
+++ b/bindings/react/src/components/LazyList.jsx
@@ -74,7 +74,7 @@ class LazyList extends BasicComponent {
     };
   }
 
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     var helpProps = {
       ...this.props,
       ...newProps

--- a/bindings/react/src/components/Navigator.jsx
+++ b/bindings/react/src/components/Navigator.jsx
@@ -308,7 +308,7 @@ class Navigator extends BasicComponent {
     this.forceUpdate();
   }
 
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     if (newProps.onDeviceBackButton !== undefined) {
       this._navi.onDeviceBackButton = newProps.onDeviceBackButton;
     }

--- a/bindings/react/src/components/Page.jsx
+++ b/bindings/react/src/components/Page.jsx
@@ -54,7 +54,7 @@ class Page extends BasicComponent {
     }
   }
 
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     if (newProps.onDeviceBackButton !== undefined) {
       ReactDOM.findDOMNode(this).onDeviceBackButton = newProps.onDeviceBackButton;
     }

--- a/bindings/react/src/components/RouterNavigator.jsx
+++ b/bindings/react/src/components/RouterNavigator.jsx
@@ -191,7 +191,7 @@ class RouterNavigator extends BasicComponent {
     this.update();
   }
 
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     const processStack = [...newProps.routeConfig.processStack];
 
     if (newProps.onDeviceBackButton !== undefined) {

--- a/bindings/react/src/components/Segment.jsx
+++ b/bindings/react/src/components/Segment.jsx
@@ -52,7 +52,7 @@ class Segment extends BasicComponent {
     return false;
   }
 
-  componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(props) {
     const node = findDOMNode(this);
 
     if (this.props.index !== props.index && props.index !== node.getActiveButtonIndex()) {

--- a/bindings/react/src/components/Splitter.jsx
+++ b/bindings/react/src/components/Splitter.jsx
@@ -50,7 +50,7 @@ class Splitter extends SimpleWrapper {
     }
   }
 
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     if (newProps.onDeviceBackButton !== undefined) {
       ReactDOM.findDOMNode(this).onDeviceBackButton = newProps.onDeviceBackButton;
     }

--- a/bindings/react/src/components/SplitterSide.jsx
+++ b/bindings/react/src/components/SplitterSide.jsx
@@ -56,7 +56,7 @@ class SplitterSide extends BasicComponent {
   componentDidMount() {
     super.componentDidMount();
     this.node = ReactDOM.findDOMNode(this);
-    this.componentWillReceiveProps(this.props);
+    this.UNSAFE_componentWillReceiveProps(this.props);
 
     this.node.addEventListener('postopen', this.onOpen);
     this.node.addEventListener('postclose', this.onClose);
@@ -73,7 +73,7 @@ class SplitterSide extends BasicComponent {
     this.node.removeEventListener('modechange', this.onModeChange);
   }
 
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     if (newProps.isOpen) {
       this.node.open();
     } else {

--- a/bindings/react/src/components/Tabbar.jsx
+++ b/bindings/react/src/components/Tabbar.jsx
@@ -66,7 +66,7 @@ class Tabbar extends BasicComponent {
     node.removeEventListener('reactive', this.onReactive);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const node = this._tabbar;
     if (nextProps.index !== this.props.index && nextProps.index !== node.getActiveTabIndex()) {
       node.setActiveTab(nextProps.index, { reject: false });

--- a/bindings/react/src/components/Toolbar.jsx
+++ b/bindings/react/src/components/Toolbar.jsx
@@ -43,7 +43,7 @@ class Toolbar extends SimpleWrapper {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.visible !== nextProps.visible) {
       ReactDOM.findDOMNode(this).setVisibility(nextProps.visible);
     }


### PR DESCRIPTION
React 16.9 started to display long warnings in the console regarding deprecated lifecyles. These warnings make development very difficult.

This PR only removes the warnings. It does not remove the deprecated lifecyles. This is a stop-gap solution just to make development easier when using React 16.9. There is still a need to properly update the logic to use the correct lifecyles