### PR TITLE
Update ListItem.jsx

### DIFF
--- a/bindings/react/src/components/ListItem.jsx
+++ b/bindings/react/src/components/ListItem.jsx
@@ -27,6 +27,7 @@ class ListItem extends SimpleWrapper {
   componentDidMount() {
     super.componentDidMount();
     this.node = ReactDOM.findDOMNode(this);
+    this.node.expanded = this.props.expanded === true
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
Hello !

Property 'expanded' is not initialized upon component mounting.
This solves a glitch when an expandable ListItem is first tapped : all ListItem expandable siblings get instantly opened and close.