### PR TITLE
Fallback to attr icon when ons-tab updates button content

### DIFF
--- a/core/src/elements/ons-tab.js
+++ b/core/src/elements/ons-tab.js
@@ -194,7 +194,11 @@ export default class TabElement extends BaseElement {
       iconWrapper = iconWrapper || util.createElement('<div class="tabbar__icon"><ons-icon></ons-icon></div>');
       const icon = iconWrapper.children[0];
       const fix = (last => () => icon.attributeChangedCallback('icon', last, this.getAttribute('icon')))(icon.getAttribute('icon'));
-      icon.setAttribute('icon', this.getAttribute(this.isActive() ? 'active-icon' : 'icon'));
+      if (this.hasAttribute('icon') && this.hasAttribute('active-icon')) {
+        icon.setAttribute('icon', this.getAttribute(this.isActive() ? 'active-icon' : 'icon'));
+      } else if (this.hasAttribute('icon')) {
+        icon.setAttribute('icon', this.getAttribute('icon'));
+      }
       iconWrapper.parentElement !== button && button.insertBefore(iconWrapper, button.firstChild);
 
       // dirty fix for https://github.com/OnsenUI/OnsenUI/issues/1654


### PR DESCRIPTION
## Expected behavior

When updating the tab attribute, e.g. `badge`, while the tab is active, the icon should fallback to the `icon` attribute if the `active-icon` attribute is not specified.

## Current behavior

In `setActive` method, it behaves as expected by implicitly not updating the icon if the `active-icon` attributed is not specified. However, in `_updateButtonContent` it will set icon to null if the `active-icon` is not specified.

## Temporary solution

I can currently workaround the issue by explicitly set the `active-icon` attribute to the same value as the `icon` attribute. But the proposed the change would make the behavior consistent.