### PR TITLE
add max-height attribute to ons-pull-hook

### DIFF
--- a/bindings/angular1/views/pullHook.js
+++ b/bindings/angular1/views/pullHook.js
@@ -61,7 +61,7 @@ limitations under the License.
 
     MicroEvent.mixin(PullHookView);
 
-    $onsen.derivePropertiesFromElement(PullHookView, ['state', 'onPull', 'pullDistance', 'height', 'thresholdHeight', 'disabled']);
+    $onsen.derivePropertiesFromElement(PullHookView, ['state', 'onPull', 'pullDistance', 'height', 'thresholdHeight', 'maxHeight', 'disabled']);
 
     return PullHookView;
   });

--- a/bindings/react/src/components/PullHook.jsx
+++ b/bindings/react/src/components/PullHook.jsx
@@ -132,6 +132,15 @@ PullHook.propTypes = {
   thresholdHeight: PropTypes.number,
 
   /**
+   * @name maxHeight
+   * @type number
+   * @description
+   *  [en] The max height of the pull hook in pixels when threshold is a negative value. The default value is 96.[/en]
+   *  [ja][/ja]
+   */
+  maxHeight: PropTypes.number,
+
+  /**
    * @name fixedContent
    * @type number
    * @description

--- a/core/src/elements/ons-pull-hook.js
+++ b/core/src/elements/ons-pull-hook.js
@@ -96,6 +96,14 @@ export default class PullHookElement extends BaseElement {
    */
 
   /**
+   * @attribute max-height
+   * @type {String}
+   * @description
+   *   [en]Specify the max height when threshold-height is a negative value. The component won't be pulled down further than this height. The default value is "96px". A negative value will disable this property.[/en]
+   *   [ja]TODO need jp desc[/ja]
+   */
+
+  /**
    * @attribute fixed-content
    * @description
    *   [en]If this attribute is set the content of the page will not move when pulling.[/en]
@@ -207,7 +215,7 @@ export default class PullHookElement extends BaseElement {
         this._setState(STATE_INITIAL);
       }
 
-      this._translateTo(scroll);
+      this._translateTo(th > 0 ? scroll : Math.min(scroll, this.maxHeight));
     }
   }
 
@@ -221,7 +229,7 @@ export default class PullHookElement extends BaseElement {
     if (this._currentTranslation > 0) {
       const scroll = this._currentTranslation;
 
-      if (scroll > this.height) {
+      if (scroll >= this.height) {
         this._finish();
       } else {
         this._translateTo(0, {animate: true});
@@ -311,6 +319,25 @@ export default class PullHookElement extends BaseElement {
 
   get thresholdHeight() {
     return parseInt(this.getAttribute('threshold-height') || '96', 10);
+  }
+
+  /**
+   * @property maxHeight
+   * @type {Number}
+   * @description
+   *   [en]The maxHeight of the pull hook in pixels. The default value is `96px`.[/en]
+   *   [ja][/ja]
+   */
+  set maxHeight(value) {
+    if (!util.isInteger(value)) {
+      throwType('maxHeight', 'integer');
+    }
+
+    this.setAttribute('max-height', `${value}px`);
+  }
+
+  get maxHeight() {
+    return parseInt(this.getAttribute('max-height') || '96', 10);
   }
 
   _setState(state, noEvent) {

--- a/core/src/elements/ons-pull-hook.spec.js
+++ b/core/src/elements/ons-pull-hook.spec.js
@@ -213,6 +213,18 @@ describe('OnsPullHookElement', () => {
     });
   });
 
+  describe('#maxHeight', () => {
+    it('is 96 by default', () => {
+      expect(pullHook.maxHeight).to.equal(96);
+    });
+
+    it('changes the "max-height" attribute', () => {
+      pullHook.maxHeight = 100;
+      expect(pullHook.maxHeight).to.equal(100);
+      expect(pullHook.getAttribute('max-height')).to.equal('100px');
+    });
+  });
+
   describe('#state', () => {
     it('returns the state', () => {
       pullHook.setAttribute('state', 'hoge');

--- a/core/src/onsenui.d.ts
+++ b/core/src/onsenui.d.ts
@@ -558,6 +558,11 @@ declare namespace ons {
      */
     thresholdHeight: string;
     /**
+     * @param {Number} maxHeight Desired max height when thresholdHeight is negative
+     * @description The maxHeight of the pull hook in pixels when thresholdHeight is negative. The default value is `96px`.
+     */
+    thresholdHeight: string;
+    /**
     * @description The current number of pixels the pull hook has moved.
     */
     state: string;


### PR DESCRIPTION
## Expected behavior

When `threshold-height` attribute is a negative value, the pull hook should prevent itself from being pulled too far. And developer should be able to specify the max distance (`max-height` attribute) a user can pull the component

## Current behavior

When `threshold-height` attribute is a negative value, a user can pull the pull-hook component to an indefinite distance which may make the layout look weird.

## Proposed solution

The proposed the change adds an `max-height` attribute to the `ons-pull-hook` component, by which a developer can specify how far a user can pull it when `threshold-height` is disabled.