### PR TITLE
fix(core): Load polyfills before loading ons internals

### DIFF
--- a/core/src/index.esm.js
+++ b/core/src/index.esm.js
@@ -1,5 +1,5 @@
-import ons from './ons'; // External dependency, always hoisted
 import setup from './setup'; // Add polyfills
+import ons from './ons'; // External dependency, always hoisted
 
 setup(ons); // Setup initial listeners
 

--- a/core/src/index.umd.js
+++ b/core/src/index.umd.js
@@ -1,5 +1,5 @@
-import ons from './ons'; // Add ons internals
 import setup from './setup'; // Add polyfills
+import ons from './ons'; // Add ons internals
 
 // Add and register Custom Elements
 import './elements/ons-template';


### PR DESCRIPTION
This fixes the problem in the Angular 2 bindings where setImmediate was
being called before it was defined.