### PR TITLE
fix(ons-navigator): Stop navigator running when non-existent page pushed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ dev
  * ons-tab: Fall back to icon if active-icon not set when updating button content. ([#2720](https://github.com/OnsenUI/OnsenUI/pull/2720))
  * ons-fab: Stop fab scrolling with viewport when wrapped in another element. ([#2778](https://github.com/OnsenUI/OnsenUI/issues/2778))
  * ons.notification: Resolve toast when hide is called before timeout. ([#2755](https://github.com/OnsenUI/OnsenUI/issues/2755))
+ * ons-navigator: Fix navigator still running when non-existent page is pushed. ([#2740](https://github.com/OnsenUI/OnsenUI/issues/2740))
 
 2.10.10
 ---

--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -581,6 +581,9 @@ export default class NavigatorElement extends BaseElement {
       this._pageLoader.load({page, parent: this, params: options.data}, pageElement => {
         prepare(pageElement);
         resolve();
+      }, error => {
+        this._isRunning = false;
+        throw error;
       });
     }));
   }

--- a/core/src/ons/page-loader.js
+++ b/core/src/ons/page-loader.js
@@ -18,13 +18,13 @@ import util from './util';
 import internal from './internal';
 
 // Default implementation for global PageLoader.
-function loadPage({page, parent, params = {}}, done) {
+function loadPage({page, parent, params = {}}, done, error) {
   internal.getPageHTMLAsync(page).then(html => {
     const pageElement = util.createElement(html);
     parent.appendChild(pageElement);
 
     done(pageElement);
-  });
+  }).catch(e => error(e));
 }
 
 function unloadPage(element) {
@@ -63,15 +63,16 @@ export class PageLoader {
    * @param {Element} options.parent A location to load page.
    * @param {Object} [options.params] Extra parameters for ons-page.
    * @param {Function} done Take an object that has "element" property and "unload" function.
+   * @param {Function} error Function called when there is an error.
    */
-  load({page, parent, params = {}}, done) {
+  load({page, parent, params = {}}, done, error) {
     this._loader({page, parent, params}, pageElement => {
       if (!(pageElement instanceof Element)) {
         throw Error('pageElement must be an instance of Element.');
       }
 
       done(pageElement);
-    });
+    }, error);
   }
 
   unload(pageElement) {


### PR DESCRIPTION
This fix adds an error callback to the page loader. A better fix is to
rewrite the page loader to use Promises instead of the old callback
style. But that's a big enough task for a separate issue.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises#Creating_a_Promise_around_an_old_callback_API

Fixes #2740.