### PR TITLE
fix(ons-navigator): Remove leave page data from enter page in postpop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ dev
  * core: Fix status-bar-fill not being automatically set on iPadOS. ([#2745](https://github.com/OnsenUI/OnsenUI/issues/2745))
  * core: Fix isIPad returning false on iPadOS. ([#2621](https://github.com/OnsenUI/OnsenUI/issues/2621))
  * ons-carousel: Fix wrong active index being set on resize for carousels with items narrower that the screen width. ([#2738](https://github.com/OnsenUI/OnsenUI/issues/2738))
+ * ons-navigator: Fix bug where entry page data contains leave page data in postpop. ([#2575](https://github.com/OnsenUI/OnsenUI/issues/2575))
 
 2.10.10
 ---

--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -490,11 +490,14 @@ export default class NavigatorElement extends BaseElement {
       const leavePage = this.pages[length - 1];
       const enterPage = this.pages[length - 2];
 
-      options = util.extend({}, this.options || {}, leavePage.pushedOptions || {}, options);
+      options = util.extend({}, this.options || {}, options);
 
       if (options.data) {
         enterPage.data = util.extend({}, enterPage.data || {}, options.data || {});
       }
+
+      // add in leave page options once options.data has been set
+      options = util.extend({}, leavePage.pushedOptions || {}, options);
 
       const done = () => {
         update().then(() => {


### PR DESCRIPTION
Fixes #2575.