### PR TITLE
fix(swiper): Remove dirty fix for UIWebView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ dev
 
  ### BREAKING CHANGES
 
+ * UIWebView is no longer supported.
  * ons-navigator: If options are not set for popPage, it no longer defaults to the options set when the page was pushed.
 
 2.10.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ dev
  * ons-carousel: Fix wrong active index being set on resize for carousels with items narrower that the screen width. ([#2738](https://github.com/OnsenUI/OnsenUI/issues/2738))
  * ons-navigator: Fix bug where entry page data contains leave page data in postpop. ([#2575](https://github.com/OnsenUI/OnsenUI/issues/2575))
  * ons-navigator: Fix pushPage's callback being called by popPage. ([#2761](https://github.com/OnsenUI/OnsenUI/issues/2761))
+ * ons-carousel: Fix carousel not swiping when inside modal on iOS. ([#2572](https://github.com/OnsenUI/OnsenUI/issues/2572))
 
  ### BREAKING CHANGES
 

--- a/core/src/ons/internal/swiper.js
+++ b/core/src/ons/internal/swiper.js
@@ -147,41 +147,12 @@ export default class Swiper {
   }
 
   setActiveIndex(index, options = {}) {
+    console.log('set active index');
     this._setSwiping(true);
     index = Math.max(0, Math.min(index, this.itemCount - 1));
     const scroll = Math.max(0, Math.min(this.maxScroll, this._offset + this.itemNumSize * index));
 
-    if (platform.isUIWebView()) {
-      /* Dirty fix for #2231(https://github.com/OnsenUI/OnsenUI/issues/2231). begin */
-      const concat = arrayOfArray => Array.prototype.concat.apply([], arrayOfArray);
-      const contents = concat(
-        util.arrayFrom(this.target.children).map(page => {
-          return util.arrayFrom(page.children)
-            .filter(child => child.classList.contains('page__content'));
-        })
-      );
-
-      const map = new Map();
-      return (
-        new Promise(resolve => {
-          contents.forEach(content => {
-            map.set(content, content.getAttribute('class'));
-            content.classList.add('page__content--suppress-layer-creation')
-          });
-          requestAnimationFrame(resolve);
-        })
-        .then(() => this._changeTo(scroll, options))
-        .then(() => new Promise(resolve => {
-          contents.forEach(content => {
-            content.setAttribute('class', map.get(content));
-          });
-          requestAnimationFrame(resolve);
-        }))
-      );
-      /* end */
-    } else {
-      return this._changeTo(scroll, options);
-    }
+    return this._changeTo(scroll, options);
   }
 
   getActiveIndex(scroll = this._scroll) {


### PR DESCRIPTION
Also announces end of support for UIWebView in the CHANGELOG. The rest of the UIWebView code will be removed for the next minor release.

Fixes #2572.