### PR TITLE
fix(ons.notification): Only set cursor for supported input types

### DIFF
--- a/core/src/ons/notification.js
+++ b/core/src/ons/notification.js
@@ -232,7 +232,10 @@ notification._createAlertDialog = (...params) => new Promise(resolve => {
         if (el.input && options.isPrompt && options.autofocus) {
           const strLength = el.input.value.length;
           el.input.focus();
-          el.input.setSelectionRange(strLength, strLength);
+          if (el.input.type &&
+            ['text', 'search', 'url', 'tel', 'password'].includes(el.input.type)) {
+            el.input.setSelectionRange(strLength, strLength);
+          }
         }
       });
   });


### PR DESCRIPTION
See here for an explanation of unsupported input types:
https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange

Fixes #2803.