### PR TITLE
fix(autostyle): Fix platform-specific animations throwing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ dev
 
  * ons.platform: isIOS now returns true for iPadOS. ([#2804](https://github.com/OnsenUI/OnsenUI/pull/2804)).
  * ons.platform: Only prompt input cursor for supported input types. ([#2803](https://github.com/OnsenUI/OnsenUI/issues/2803)).
+ * core: Fix animations not working for platform-specific animations.
 
 2.11.1
 ---

--- a/core/src/elements/ons-alert-dialog/index.js
+++ b/core/src/elements/ons-alert-dialog/index.js
@@ -42,8 +42,8 @@ const scheme = {
 
 const _animatorDict = {
   'none': AlertDialogAnimator,
-  'default': () => platform.isAndroid() ? AndroidAlertDialogAnimator : IOSAlertDialogAnimator,
-  'fade': () => platform.isAndroid() ? AndroidAlertDialogAnimator : IOSAlertDialogAnimator
+  'default': function () { return platform.isAndroid() ? AndroidAlertDialogAnimator : IOSAlertDialogAnimator },
+  'fade': function () { return platform.isAndroid() ? AndroidAlertDialogAnimator : IOSAlertDialogAnimator }
 };
 
 /**

--- a/core/src/elements/ons-dialog/index.js
+++ b/core/src/elements/ons-dialog/index.js
@@ -32,7 +32,7 @@ const scheme = {
 };
 
 const _animatorDict = {
-  'default': () => platform.isAndroid() ? AndroidDialogAnimator : IOSDialogAnimator,
+  'default': function () { return  platform.isAndroid() ? AndroidDialogAnimator : IOSDialogAnimator },
   'slide': SlideDialogAnimator,
   'none': DialogAnimator
 };

--- a/core/src/elements/ons-navigator/index.js
+++ b/core/src/elements/ons-navigator/index.js
@@ -35,10 +35,10 @@ import deviceBackButtonDispatcher from '../../ons/internal/device-back-button-di
 import {PageLoader, defaultPageLoader, instantPageLoader} from '../../ons/page-loader';
 
 const _animatorDict = {
-  'default': () => platform.isAndroid() ? MDFadeNavigatorAnimator : IOSSlideNavigatorAnimator,
-  'slide': () => platform.isAndroid() ? MDSlideNavigatorAnimator : IOSSlideNavigatorAnimator,
-  'lift': () => platform.isAndroid() ? MDLiftNavigatorAnimator : IOSLiftNavigatorAnimator,
-  'fade': () => platform.isAndroid() ? MDFadeNavigatorAnimator : IOSFadeNavigatorAnimator,
+  'default': function () { return platform.isAndroid() ? MDFadeNavigatorAnimator : IOSSlideNavigatorAnimator },
+  'slide': function () { return platform.isAndroid() ? MDSlideNavigatorAnimator : IOSSlideNavigatorAnimator },
+  'lift': function () { return platform.isAndroid() ? MDLiftNavigatorAnimator : IOSLiftNavigatorAnimator },
+  'fade': function () { return platform.isAndroid() ? MDFadeNavigatorAnimator : IOSFadeNavigatorAnimator },
   'slide-ios': IOSSlideNavigatorAnimator,
   'slide-md': MDSlideNavigatorAnimator,
   'lift-ios': IOSLiftNavigatorAnimator,


### PR DESCRIPTION
The error is thrown because platform-specific entires in animatorDict
are functions that return constructors, but are called as if they are
constructors. These entries were defined using arrow functions, which
are not constructable. This commit replaces the arrow functions with
regular functions, which are constructable.