### PR TITLE
fix(ons): Fix setImmediate not defined bug for ES modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ dev
  * ons.platform: Only prompt input cursor for supported input types. ([#2803](https://github.com/OnsenUI/OnsenUI/issues/2803)).
  * core: Fix animations not working for platform-specific animations.
  * ons-fab: Fix fab not being positioned relative to tab page. ([#2810](https://github.com/OnsenUI/OnsenUI/issues/2810)).
+ * core: Fix setImmediate not defined for ESM bug.
 
 2.11.1
 ---

--- a/core/src/ons/internal/internal.js
+++ b/core/src/ons/internal/internal.js
@@ -101,20 +101,6 @@ window.document.addEventListener('_templateloaded', function(e) {
   }
 }, false);
 
-internal.waitDOMContentLoaded(function() {
-  register('script[type="text/ons-template"]');
-  register('script[type="text/template"]');
-  register('script[type="text/ng-template"]');
-  register('template');
-
-  function register(query) {
-    const templates = window.document.querySelectorAll(query);
-    for (let i = 0; i < templates.length; i++) {
-      internal.templateStore.set(templates[i].getAttribute('id'), templates[i].textContent || templates[i].content);
-    }
-  }
-});
-
 /**
  * @param {String} page
  * @return {Promise}

--- a/core/src/setup.js
+++ b/core/src/setup.js
@@ -2,8 +2,23 @@ import './ons/platform'; // This file must be loaded before Custom Elements poly
 import './polyfills/index.js';
 import './vendor/index.js';
 import './ons/microevent.js';
+import internal from './ons/internal';
 
 export default function setup(ons) {
+  internal.waitDOMContentLoaded(function() {
+    register('script[type="text/ons-template"]');
+    register('script[type="text/template"]');
+    register('script[type="text/ng-template"]');
+    register('template');
+
+    function register(query) {
+      const templates = window.document.querySelectorAll(query);
+      for (let i = 0; i < templates.length; i++) {
+        internal.templateStore.set(templates[i].getAttribute('id'), templates[i].textContent || templates[i].content);
+      }
+    }
+  });
+
   if (window._onsLoaded) {
     ons._util.warn('Onsen UI is loaded more than once.');
   }


### PR DESCRIPTION
ons.internal was calling a polyfill before it was created. This happens
because ons is an external import so it is hoisted, but setup is inlined
at build time, so the ons code was running before the setup code.

This was supposed to be fixed by #2735 but that fix only worked for UMD,
not for ESM.