### PR TITLE
Replace gulp with rollup for UMD build

### DIFF
--- a/bindings/vue/vue-onsenui/package.json
+++ b/bindings/vue/vue-onsenui/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "cd ../../ && gulp serve --vue",
     "build": "cross-env NODE_ENV=production gulp build && npm run build:helper-json",
+    "build:umd": "rollup -c rollup.config.umd.js",
     "build:helper-json": "(cd ../../ && npm run build:docs) && gulp build:helper-json",
     "prepublish": "npm run build",
     "test": "gulp test",

--- a/bindings/vue/vue-onsenui/package.json
+++ b/bindings/vue/vue-onsenui/package.json
@@ -7,6 +7,7 @@
     "dev": "cd ../../ && gulp serve --vue",
     "build": "cross-env NODE_ENV=production gulp build && npm run build:helper-json",
     "build:umd": "rollup -c rollup.config.umd.js",
+    "build:minify": "uglifyjs dist/vue-onsenui.js -c -m --comments '/vue-onsenui/' --output dist/vue-onsenui.min.js",
     "build:helper-json": "(cd ../../ && npm run build:docs) && gulp build:helper-json",
     "prepublish": "npm run build",
     "test": "gulp test",

--- a/bindings/vue/vue-onsenui/rollup.config.js
+++ b/bindings/vue/vue-onsenui/rollup.config.js
@@ -24,7 +24,7 @@ babelrc.plugins = ['external-helpers'];
 babelrc.exclude = [local('node_modules/**'), local('../../build/**')];
 
 const globals = { 'onsenui': 'ons', 'onsenui/esm': 'ons' },
-  external = id => /onsenui/.test(id),
+  external = id => /^onsenui/.test(id),
   banner = `/* ${pkg.name} v${pkg.version} - ${dateformat(new Date(), 'yyyy-mm-dd')} */\n`;
 
 const builds = [

--- a/bindings/vue/vue-onsenui/rollup.config.umd.js
+++ b/bindings/vue/vue-onsenui/rollup.config.umd.js
@@ -12,7 +12,6 @@ import filesize from 'rollup-plugin-filesize';
 import progress from 'rollup-plugin-progress';
 import visualizer from 'rollup-plugin-visualizer';
 import vue from 'rollup-plugin-vue';
-import execute from 'rollup-plugin-execute';
 
 const local = (...args) => path.resolve(__dirname, ...args);
 
@@ -56,7 +55,6 @@ export default {
     visualizer({
       filename: 'module-stats.umd.html',
       sourcemap: true,
-    }),
-    execute(`node_modules/.bin/uglifyjs dist/${pkg.name}.js -c -m --comments '/${pkg.name}/' --output dist/${pkg.name}.min.js`),
+    })
   ]
 }

--- a/bindings/vue/vue-onsenui/rollup.config.umd.js
+++ b/bindings/vue/vue-onsenui/rollup.config.umd.js
@@ -1,0 +1,62 @@
+import path from 'path';
+import pkg from './package.json';
+import corePkg from '../../../package.json';
+import dateformat from 'dateformat';
+
+// Rollup plugins
+import babel from 'rollup-plugin-babel';
+import { eslint } from 'rollup-plugin-eslint';
+import resolve from 'rollup-plugin-node-resolve';
+import replace from 'rollup-plugin-replace';
+import filesize from 'rollup-plugin-filesize';
+import progress from 'rollup-plugin-progress';
+import visualizer from 'rollup-plugin-visualizer';
+import vue from 'rollup-plugin-vue';
+import execute from 'rollup-plugin-execute';
+
+const local = (...args) => path.resolve(__dirname, ...args);
+
+const babelrc = Object.assign({}, corePkg.babel);
+babelrc.babelrc = babelrc.presets[0][1].modules = false;
+babelrc.plugins = ['external-helpers'];
+babelrc.exclude = [local('node_modules/**'), local('../../build/**')];
+
+const globals = { 'onsenui': 'ons', 'onsenui/esm': 'ons' },
+  external = id => /^onsenui/.test(id),
+  banner = `/* ${pkg.name} v${pkg.version} - ${dateformat(new Date(), 'yyyy-mm-dd')} */\n`;
+
+export default {
+  input: 'src/index.umd.js',
+  external,
+  output: {
+    file: 'dist/vue-onsenui.js',
+    format: 'umd',
+    name: 'VueOnsen',
+    sourcemap: 'inline',
+    globals,
+    banner,
+  },
+  plugins: [
+    eslint({
+      include: [
+        'src/**/*.js',
+        'src/**/*.vue',
+      ],
+    }),
+    resolve({ extensions: ['.js', '.vue'] }),
+    replace({
+      // Remove undefined imports to slightly reduce UMD bundle size
+      include: './src/components/*.vue',
+      'import \'onsenui/esm/elements/': '// \'',
+    }),
+    vue(),
+    babel(babelrc),
+    progress(),
+    filesize(),
+    visualizer({
+      filename: 'module-stats.umd.html',
+      sourcemap: true,
+    }),
+    execute(`node_modules/.bin/uglifyjs dist/${pkg.name}.js -c -m --comments '/${pkg.name}/' --output dist/${pkg.name}.min.js`),
+  ]
+}


### PR DESCRIPTION
This PR replaces gulp with an npm script for the UMD build. It also adds a minify npm script.

Note that the build is currently broken due to old packages and won't work until the dependencies are bumped to Vue 3.

Fixes #2855.