### PR TITLE
Vue 3 warning fixes

### DIFF
--- a/bindings/vue/package-lock.json
+++ b/bindings/vue/package-lock.json
@@ -2669,7 +2669,6 @@
         "merge-source-map": "^1.1.0",
         "postcss": "^7.0.14",
         "postcss-selector-parser": "^6.0.2",
-        "prettier": "^1.18.2",
         "source-map": "~0.6.1",
         "vue-template-es2015-compiler": "^1.9.0"
       },
@@ -5371,7 +5370,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -12050,9 +12048,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
       "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -17112,9 +17107,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.38.4.tgz",
       "integrity": "sha512-B0LcJhjiwKkTl79aGVF/u5KdzsH8IylVfV56Ut6c9ouWLJcUK17T83aZBetNYSnZtXf2OHD4+2PbmRW+Fp5ulg==",
       "dev": true,
-      "dependencies": {
-        "fsevents": "~2.3.1"
-      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -20516,10 +20508,8 @@
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dev": true,
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.1"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -21984,7 +21974,6 @@
         "thread-loader": "^2.1.3",
         "url-loader": "^2.2.0",
         "vue-loader": "^15.9.2",
-        "vue-loader-v16": "npm:vue-loader@^16.1.0",
         "vue-style-loader": "^4.1.2",
         "webpack": "^4.0.0",
         "webpack-bundle-analyzer": "^3.8.0",
@@ -22290,9 +22279,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -24284,7 +24270,6 @@
       "integrity": "sha512-9VoFlm/9vhynKNGM+HA7qBsoQSUEnuG5i5kcFI9vTLLrh8A0fxrwUyVLLppO6T1sAZ6vrKdQFnEkjL+RkRAwWQ==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.11.0",
         "@babel/helper-compilation-targets": "^7.9.6",
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -24297,7 +24282,6 @@
         "@vue/babel-plugin-jsx": "^1.0.0-0",
         "@vue/babel-preset-jsx": "^1.1.2",
         "babel-plugin-dynamic-import-node": "^2.3.3",
-        "core-js": "^3.6.5",
         "core-js-compat": "^3.6.5",
         "semver": "^6.1.0"
       },
@@ -39218,7 +39202,6 @@
         "postcss-selector-parser": "^2.2.3",
         "source-map": "^0.6.1",
         "vue-hot-reload-api": "^2.1.0",
-        "vue-template-compiler": "^2.4.4",
         "vue-template-es2015-compiler": "^1.5.3"
       },
       "dependencies": {

--- a/bindings/vue/vue-onsenui-examples/src/App.vue
+++ b/bindings/vue/vue-onsenui-examples/src/App.vue
@@ -1,0 +1,57 @@
+<template>
+  <v-ons-page>
+    <v-ons-toolbar>
+
+      <div class="left">
+        <v-ons-toolbar-button
+          @click.prevent="backToList"
+          v-show="currentView !== mainList"
+        >
+          Main list
+        </v-ons-toolbar-button>
+      </div>
+
+      <div class="center">{{ title }}</div>
+    </v-ons-toolbar>
+
+    <div class="content">
+      <keep-alive>
+        <component
+          :is="currentView"
+          :examples="examples"
+          :changeExample="changeExample"
+        ></component>
+      </keep-alive>
+    </div>
+  </v-ons-page>
+</template>
+
+<script>
+
+import * as examples from './components';
+import MainList from './MainList.vue';
+
+export default {
+  name: 'App',
+
+  data() {
+    return {
+      MainList,
+      examples,
+      title: 'Main List',
+      currentView: MainList
+    }
+  },
+
+  methods: {
+    changeExample(key) {
+      this.title = key;
+      this.currentView = this.examples[key];
+    },
+    backToList() {
+      this.title = 'Main List';
+      this.currentView = MainList;
+    }
+  }
+}
+</script>

--- a/bindings/vue/vue-onsenui-examples/src/MainList.vue
+++ b/bindings/vue/vue-onsenui-examples/src/MainList.vue
@@ -1,0 +1,20 @@
+<template>
+  <div>
+    <v-ons-page>
+      <v-ons-list>
+        <v-ons-list-item v-for="(example, key) in examples" :key="key" @click="changeExample(key)" modifier="chevron">
+          <div class="center">{{ key }}</div>
+        </v-ons-list-item>
+      </v-ons-list>
+    </v-ons-page>
+  </div>
+</template>
+
+<script>
+
+export default {
+  name: 'MainList',
+  props: ['examples', 'changeExample']
+}
+
+</script>

--- a/bindings/vue/vue-onsenui-examples/src/main.js
+++ b/bindings/vue/vue-onsenui-examples/src/main.js
@@ -1,8 +1,9 @@
 import { createApp } from 'vue';
-import * as examples from './components';
 
 import VueOnsen from 'vue-onsenui'; // umd
 import Vuex from 'vuex';
+
+import App from './App.vue';
 
 import 'onsenui/css/onsenui.css';
 import 'onsenui/css/onsen-css-components.css';
@@ -15,59 +16,9 @@ import 'onsenui/css/onsen-css-components.css';
 // Vue.component(VOnsPage.name, VOnsPage);
 // Vue.component(VOnsToolbar.name, VOnsToolbar);
 
-const mainList = {
-  template: `
-  <div>
-    <v-ons-page>
-      <v-ons-list>
-        <v-ons-list-item v-for="(example, key) in examples" :key="key" @click="changeExample(key)" modifier="chevron">
-          <div class="center">{{ key }}</div>
-        </v-ons-list-item>
-      </v-ons-list>
-    </v-ons-page>
-  </div>
-  `,
-  props: ['examples', 'changeExample']
-};
-
-const app = createApp({
-  el: '#app',
-  components: { ...examples },
-  template: `
-    <v-ons-page>
-      <v-ons-toolbar>
-        <div class="left"><v-ons-toolbar-button @click.prevent="backToList" v-show="currentView !== mainList">Main list</v-ons-toolbar-button></div>
-        <div class="center">{{ title }}</div>
-      </v-ons-toolbar>
-
-      <div class="content">
-        <keep-alive>
-          <div :is="currentView" :examples="examples" :changeExample="changeExample"></div>
-        </keep-alive>
-      </div>
-    </v-ons-page>
-  `,
-
-  data() {
-    return {
-      mainList,
-      examples,
-      title: 'Main List',
-      currentView: mainList
-    }
-  },
-
-  methods: {
-    changeExample(key) {
-      this.title = key;
-      this.currentView = this.examples[key];
-    },
-    backToList() {
-      this.title = 'Main List';
-      this.currentView = mainList;
-    }
-  }
-});
+const app = createApp(App);
 
 app.use(VueOnsen);
 app.use(Vuex);
+
+app.mount('#app');

--- a/bindings/vue/vue-onsenui/gulpfile.babel.js
+++ b/bindings/vue/vue-onsenui/gulpfile.babel.js
@@ -81,7 +81,7 @@ gulp.task('generate-components', (done) => {
 
     return `
 <template>
-  <${domElement} v-on="unrecognizedListeners"${modifier ? ' :modifier="normalizedModifier"' : ''}>
+  <${domElement}${modifier ? ' :modifier="normalizedModifier"' : ''}>
     <slot></slot>
   </${domElement}>
 </template>

--- a/bindings/vue/vue-onsenui/gulpfile.babel.js
+++ b/bindings/vue/vue-onsenui/gulpfile.babel.js
@@ -76,8 +76,10 @@ gulp.task('generate-components', (done) => {
   const camelize = string => string.toLowerCase().replace(/-([a-z])/g, (m, l) => l.toUpperCase());
   const generate = (baseName, baseMixins = '') => {
     const domElement = 'ons-' + baseName;
-    const mixins = 'deriveEvents' + (baseMixins ? `, ${baseMixins.trim().split(/\s+/).join(', ')}` : '');
-    const modifier = mixins.indexOf('modifier') !== -1;
+    const commaSeparatedBaseMixins = baseMixins ? `, ${baseMixins.trim().split(/\s+/).join(', ')}` : '';
+    const mixinsImport = 'deriveEvents' + commaSeparatedBaseMixins;
+    const mixinsKey = 'deriveEvents(name)' + commaSeparatedBaseMixins;
+    const modifier = mixinsImport.indexOf('modifier') !== -1;
 
     return `
 <template>
@@ -89,11 +91,13 @@ gulp.task('generate-components', (done) => {
 <script>
   /* This file was generated automatically by 'generate-components' task in bindings/vue/gulpfile.babel.js */
   import 'onsenui/esm/elements/${domElement}';
-  import { ${mixins} } from '../mixins';
+  import { ${mixinsImport} } from '../mixins';
+
+  const name = 'v-${domElement}';
 
   export default {
-    name: 'v-${domElement}',
-    mixins: [${mixins}]
+    name,
+    mixins: [${mixinsKey}]
   };
 </script>
     `.trim();

--- a/bindings/vue/vue-onsenui/gulpfile.babel.js
+++ b/bindings/vue/vue-onsenui/gulpfile.babel.js
@@ -1,6 +1,6 @@
 import 'babel-polyfill';
 
-import corePkg from '../../package.json';
+import corePkg from '../../../package.json';
 import gulp from 'gulp';
 import * as glob from 'glob';
 import path from'path';

--- a/bindings/vue/vue-onsenui/rollup.config.esm.js
+++ b/bindings/vue/vue-onsenui/rollup.config.esm.js
@@ -39,7 +39,11 @@ export default {
     banner,
   },
   plugins: [
-    vue(),
+    vue({
+      compilerOptions: {
+        isCustomElement: tag => tag.startsWith('ons-')
+      }
+    }),
     resolve(),
     eslint({
       exclude: [

--- a/bindings/vue/vue-onsenui/rollup.config.umd.js
+++ b/bindings/vue/vue-onsenui/rollup.config.umd.js
@@ -48,7 +48,11 @@ export default {
       include: './src/components/*.vue',
       'import \'onsenui/esm/elements/': '// \'',
     }),
-    vue(),
+    vue({
+      compilerOptions: {
+        isCustomElement: tag => tag.startsWith('ons-')
+      }
+    }),
     babel(babelrc),
     progress(),
     filesize(),

--- a/bindings/vue/vue-onsenui/rollup.config.umd.js
+++ b/bindings/vue/vue-onsenui/rollup.config.umd.js
@@ -20,8 +20,8 @@ babelrc.babelrc = babelrc.presets[0][1].modules = false;
 babelrc.plugins = ['external-helpers'];
 babelrc.exclude = [local('node_modules/**'), local('../../build/**')];
 
-const globals = { 'onsenui': 'ons', 'onsenui/esm': 'ons' },
-  external = id => /^onsenui/.test(id),
+const globals = { 'vue': 'Vue', 'onsenui': 'ons' },
+  external = [ 'vue', 'onsenui' ],
   banner = `/* ${pkg.name} v${pkg.version} - ${dateformat(new Date(), 'yyyy-mm-dd')} */\n`;
 
 export default {

--- a/bindings/vue/vue-onsenui/src/components/VOnsActionSheet.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsActionSheet.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-action-sheet';
   import { deriveEvents, hidable, hasOptions, dialogCancel, deriveDBB, portal, modifier } from '../mixins';
 
+  const name = 'v-ons-action-sheet';
+
   export default {
-    name: 'v-ons-action-sheet',
-    mixins: [deriveEvents, hidable, hasOptions, dialogCancel, deriveDBB, portal, modifier]
+    name,
+    mixins: [deriveEvents(name), hidable, hasOptions, dialogCancel, deriveDBB, portal, modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsActionSheet.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsActionSheet.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-action-sheet v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-action-sheet :modifier="normalizedModifier">
     <slot></slot>
   </ons-action-sheet>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsActionSheetButton.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsActionSheetButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-action-sheet-button v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-action-sheet-button :modifier="normalizedModifier">
     <slot></slot>
   </ons-action-sheet-button>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsActionSheetButton.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsActionSheetButton.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-action-sheet-button';
   import { deriveEvents, modifier } from '../mixins';
 
+  const name = 'v-ons-action-sheet-button';
+
   export default {
-    name: 'v-ons-action-sheet-button',
-    mixins: [deriveEvents, modifier]
+    name,
+    mixins: [deriveEvents(name), modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsAlertDialog.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsAlertDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-alert-dialog v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-alert-dialog :modifier="normalizedModifier">
     <div class="alert-dialog-title">
       <slot name="title">{{title}}</slot>
     </div>

--- a/bindings/vue/vue-onsenui/src/components/VOnsAlertDialog.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsAlertDialog.vue
@@ -18,9 +18,11 @@
   import 'onsenui/esm/elements/ons-alert-dialog';
   import { hidable, hasOptions, dialogCancel, deriveEvents, deriveDBB, portal, modifier } from '../mixins';
 
+  const name = 'v-ons-alert-dialog';
+
   export default {
-    name: 'v-ons-alert-dialog',
-    mixins: [hidable, hasOptions, dialogCancel, deriveEvents, deriveDBB, portal, modifier],
+    name,
+    mixins: [hidable, hasOptions, dialogCancel, deriveEvents(name), deriveDBB, portal, modifier],
 
     props: {
       title: {

--- a/bindings/vue/vue-onsenui/src/components/VOnsAlertDialogButton.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsAlertDialogButton.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-alert-dialog-button';
   import { deriveEvents, modifier } from '../mixins';
 
+  const name = 'v-ons-alert-dialog-button';
+
   export default {
-    name: 'v-ons-alert-dialog-button',
-    mixins: [deriveEvents, modifier]
+    name,
+    mixins: [deriveEvents(name), modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsAlertDialogButton.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsAlertDialogButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-alert-dialog-button v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-alert-dialog-button :modifier="normalizedModifier">
     <slot></slot>
   </ons-alert-dialog-button>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsBackButton.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsBackButton.vue
@@ -12,6 +12,7 @@
     name: 'v-ons-back-button',
     inject: ['navigator'],
     mixins: [modifier],
+    emits: ['click'],
 
     methods: {
       action() {

--- a/bindings/vue/vue-onsenui/src/components/VOnsBottomToolbar.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsBottomToolbar.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-bottom-toolbar';
   import { deriveEvents, modifier } from '../mixins';
 
+  const name = 'v-ons-bottom-toolbar';
+
   export default {
-    name: 'v-ons-bottom-toolbar',
-    mixins: [deriveEvents, modifier]
+    name,
+    mixins: [deriveEvents(name), modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsBottomToolbar.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsBottomToolbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-bottom-toolbar v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-bottom-toolbar :modifier="normalizedModifier">
     <slot></slot>
   </ons-bottom-toolbar>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsButton.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-button v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-button :modifier="normalizedModifier">
     <slot></slot>
   </ons-button>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsButton.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsButton.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-button';
   import { deriveEvents, modifier } from '../mixins';
 
+  const name = 'v-ons-button';
+
   export default {
-    name: 'v-ons-button',
-    mixins: [deriveEvents, modifier]
+    name,
+    mixins: [deriveEvents(name), modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsCard.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsCard.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-card';
   import { deriveEvents, modifier } from '../mixins';
 
+  const name = 'v-ons-card';
+
   export default {
-    name: 'v-ons-card',
-    mixins: [deriveEvents, modifier]
+    name,
+    mixins: [deriveEvents(name), modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsCard.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-card v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-card :modifier="normalizedModifier">
     <slot></slot>
   </ons-card>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsCarousel.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsCarousel.vue
@@ -15,9 +15,11 @@
   import 'onsenui/esm/elements/ons-carousel';
   import { hasOptions, deriveEvents } from '../mixins';
 
+  const name = 'v-ons-carousel';
+
   export default {
-    name: 'v-ons-carousel',
-    mixins: [hasOptions, deriveEvents],
+    name,
+    mixins: [hasOptions, deriveEvents(name)],
 
     props: {
       index: {
@@ -27,6 +29,7 @@
         type: Function
       }
     },
+    emits: ['update:index'],
 
     watch: {
       index() {

--- a/bindings/vue/vue-onsenui/src/components/VOnsCarousel.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsCarousel.vue
@@ -3,7 +3,6 @@
     :on-swipe.prop="onSwipe"
     :initial-index="index"
     @postchange.self="$emit('update:index', $event.activeIndex)"
-    v-on="unrecognizedListeners"
   >
     <div>
       <slot></slot>

--- a/bindings/vue/vue-onsenui/src/components/VOnsCarouselItem.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsCarouselItem.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-carousel-item';
   import { deriveEvents } from '../mixins';
 
+  const name = 'v-ons-carousel-item';
+
   export default {
-    name: 'v-ons-carousel-item',
-    mixins: [deriveEvents]
+    name,
+    mixins: [deriveEvents(name)]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsCarouselItem.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsCarouselItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-carousel-item v-on="unrecognizedListeners">
+  <ons-carousel-item>
     <slot></slot>
   </ons-carousel-item>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsCheckbox.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsCheckbox.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-checkbox';
   import { deriveEvents, modelCheckbox, modifier } from '../mixins';
 
+  const name = 'v-ons-checkbox';
+
   export default {
-    name: 'v-ons-checkbox',
-    mixins: [deriveEvents, modelCheckbox, modifier]
+    name,
+    mixins: [deriveEvents(name), modelCheckbox, modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsCheckbox.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsCheckbox.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-checkbox v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-checkbox :modifier="normalizedModifier">
     <slot></slot>
   </ons-checkbox>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsCol.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsCol.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-col v-on="unrecognizedListeners">
+  <ons-col>
     <slot></slot>
   </ons-col>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsCol.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsCol.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-col';
   import { deriveEvents } from '../mixins';
 
+  const name = 'v-ons-col';
+
   export default {
-    name: 'v-ons-col',
-    mixins: [deriveEvents]
+    name,
+    mixins: [deriveEvents(name)]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsDialog.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsDialog.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-dialog';
   import { deriveEvents, hidable, hasOptions, dialogCancel, deriveDBB, portal, modifier } from '../mixins';
 
+  const name = 'v-ons-dialog';
+
   export default {
-    name: 'v-ons-dialog',
-    mixins: [deriveEvents, hidable, hasOptions, dialogCancel, deriveDBB, portal, modifier]
+    name,
+    mixins: [deriveEvents(name), hidable, hasOptions, dialogCancel, deriveDBB, portal, modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsDialog.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-dialog v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-dialog :modifier="normalizedModifier">
     <slot></slot>
   </ons-dialog>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsFab.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsFab.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-fab v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-fab :modifier="normalizedModifier">
     <slot></slot>
   </ons-fab>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsFab.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsFab.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-fab';
   import { deriveEvents, hidable, modifier } from '../mixins';
 
+  const name = 'v-ons-fab';
+
   export default {
-    name: 'v-ons-fab',
-    mixins: [deriveEvents, hidable, modifier]
+    name,
+    mixins: [deriveEvents(name), hidable, modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsIcon.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-icon v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-icon :modifier="normalizedModifier">
     <slot></slot>
   </ons-icon>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsIcon.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsIcon.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-icon';
   import { deriveEvents, modifier } from '../mixins';
 
+  const name = 'v-ons-icon';
+
   export default {
-    name: 'v-ons-icon',
-    mixins: [deriveEvents, modifier]
+    name,
+    mixins: [deriveEvents(name), modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsInput.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-input v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-input :modifier="normalizedModifier">
     <slot></slot>
   </ons-input>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsInput.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsInput.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-input';
   import { deriveEvents, modelInput, modifier } from '../mixins';
 
+  const name = 'v-ons-input';
+
   export default {
-    name: 'v-ons-input',
-    mixins: [deriveEvents, modelInput, modifier]
+    name,
+    mixins: [deriveEvents(name), modelInput, modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsList.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsList.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-list';
   import { deriveEvents, modifier } from '../mixins';
 
+  const name = 'v-ons-list';
+
   export default {
-    name: 'v-ons-list',
-    mixins: [deriveEvents, modifier]
+    name,
+    mixins: [deriveEvents(name), modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsList.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsList.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-list v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-list :modifier="normalizedModifier">
     <slot></slot>
   </ons-list>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsListHeader.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsListHeader.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-list-header';
   import { deriveEvents, modifier } from '../mixins';
 
+  const name = 'v-ons-list-header';
+
   export default {
-    name: 'v-ons-list-header',
-    mixins: [deriveEvents, modifier]
+    name,
+    mixins: [deriveEvents(name), modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsListHeader.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsListHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-list-header v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-list-header :modifier="normalizedModifier">
     <slot></slot>
   </ons-list-header>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsListItem.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsListItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-list-item v-on="unrecognizedListeners" :modifier="normalizedModifier" v-on:expansion="onExpansion">
+  <ons-list-item :modifier="normalizedModifier" v-on:expansion="onExpansion">
     <slot></slot>
   </ons-list-item>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsListItem.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsListItem.vue
@@ -8,14 +8,17 @@
   import 'onsenui/esm/elements/ons-list-item';
   import { deriveEvents, modifier } from '../mixins';
 
+  const name = 'v-ons-list-item';
+
   export default {
-    name: 'v-ons-list-item',
-    mixins: [deriveEvents, modifier],
+    name,
+    mixins: [deriveEvents(name), modifier],
     props: {
       expanded: {
         type: Boolean
       }
     },
+    emits: ['update:expanded'],
     methods: {
       onExpansion() {
         if (this.expanded !== this.$el.expanded) {

--- a/bindings/vue/vue-onsenui/src/components/VOnsListTitle.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsListTitle.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-list-title';
   import { deriveEvents, modifier } from '../mixins';
 
+  const name = 'v-ons-list-title';
+
   export default {
-    name: 'v-ons-list-title',
-    mixins: [deriveEvents, modifier]
+    name,
+    mixins: [deriveEvents(name), modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsListTitle.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsListTitle.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-list-title v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-list-title :modifier="normalizedModifier">
     <slot></slot>
   </ons-list-title>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsModal.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-modal v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-modal :modifier="normalizedModifier">
     <slot></slot>
   </ons-modal>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsModal.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsModal.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-modal';
   import { deriveEvents, hidable, hasOptions, deriveDBB, portal, modifier } from '../mixins';
 
+  const name = 'v-ons-modal';
+
   export default {
-    name: 'v-ons-modal',
-    mixins: [deriveEvents, hidable, hasOptions, deriveDBB, portal, modifier]
+    name,
+    mixins: [deriveEvents(name), hidable, hasOptions, deriveDBB, portal, modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsNavigator.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsNavigator.vue
@@ -16,9 +16,11 @@
   import 'onsenui/esm/elements/ons-navigator';
   import { hasOptions, selfProvider, deriveEvents, deriveDBB } from '../mixins';
 
+  const name = 'v-ons-navigator';
+
   export default {
-    name: 'v-ons-navigator',
-    mixins: [hasOptions, selfProvider, deriveEvents, deriveDBB],
+    name,
+    mixins: [hasOptions, selfProvider, deriveEvents(name), deriveDBB],
 
     props: {
       pageStack: {

--- a/bindings/vue/vue-onsenui/src/components/VOnsPage.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsPage.vue
@@ -11,9 +11,11 @@
   import 'onsenui/esm/elements/ons-page';
   import { deriveEvents, deriveDBB, modifier } from '../mixins';
 
+  const name = 'v-ons-page';
+
   export default {
-    name: 'v-ons-page',
-    mixins: [deriveEvents, deriveDBB, modifier],
+    name,
+    mixins: [deriveEvents(name), deriveDBB, modifier],
 
     props: {
       infiniteScroll: {

--- a/bindings/vue/vue-onsenui/src/components/VOnsPage.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsPage.vue
@@ -2,7 +2,6 @@
   <ons-page
     :on-infinite-scroll.prop="infiniteScroll"
     :modifier="normalizedModifier"
-    v-on="unrecognizedListeners"
   >
     <slot></slot>
   </ons-page>

--- a/bindings/vue/vue-onsenui/src/components/VOnsPopover.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsPopover.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-popover v-on="unrecognizedListeners">
+  <ons-popover>
     <slot></slot>
   </ons-popover>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsPopover.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsPopover.vue
@@ -8,9 +8,11 @@
   import 'onsenui/esm/elements/ons-popover';
   import { hidable, hasOptions, dialogCancel, deriveEvents, deriveDBB, portal } from '../mixins';
 
+  const name = 'v-ons-popover';
+
   export default {
-    name: 'v-ons-popover',
-    mixins: [hidable, hasOptions, dialogCancel, deriveEvents, deriveDBB, portal],
+    name,
+    mixins: [hidable, hasOptions, dialogCancel, deriveEvents(name), deriveDBB, portal],
 
     props: {
       target: {

--- a/bindings/vue/vue-onsenui/src/components/VOnsProgressBar.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsProgressBar.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-progress-bar';
   import { deriveEvents, modifier } from '../mixins';
 
+  const name = 'v-ons-progress-bar';
+
   export default {
-    name: 'v-ons-progress-bar',
-    mixins: [deriveEvents, modifier]
+    name,
+    mixins: [deriveEvents(name), modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsProgressBar.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsProgressBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-progress-bar v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-progress-bar :modifier="normalizedModifier">
     <slot></slot>
   </ons-progress-bar>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsProgressCircular.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsProgressCircular.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-progress-circular v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-progress-circular :modifier="normalizedModifier">
     <slot></slot>
   </ons-progress-circular>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsProgressCircular.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsProgressCircular.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-progress-circular';
   import { deriveEvents, modifier } from '../mixins';
 
+  const name = 'v-ons-progress-circular';
+
   export default {
-    name: 'v-ons-progress-circular',
-    mixins: [deriveEvents, modifier]
+    name,
+    mixins: [deriveEvents(name), modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsPullHook.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsPullHook.vue
@@ -11,9 +11,11 @@
   import 'onsenui/esm/elements/ons-pull-hook';
   import { deriveEvents } from '../mixins';
 
+  const name = 'v-ons-pull-hook';
+
   export default {
-    name: 'v-ons-pull-hook',
-    mixins: [deriveEvents],
+    name,
+    mixins: [deriveEvents(name)],
 
     props: {
       action: {

--- a/bindings/vue/vue-onsenui/src/components/VOnsPullHook.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsPullHook.vue
@@ -2,7 +2,6 @@
   <ons-pull-hook
     :on-action.prop="action"
     :on-pull.prop="onPull"
-    v-on="unrecognizedListeners"
   >
     <slot></slot>
   </ons-pull-hook>

--- a/bindings/vue/vue-onsenui/src/components/VOnsRadio.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsRadio.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-radio';
   import { deriveEvents, modelRadio, modifier } from '../mixins';
 
+  const name = 'v-ons-radio';
+
   export default {
-    name: 'v-ons-radio',
-    mixins: [deriveEvents, modelRadio, modifier]
+    name,
+    mixins: [deriveEvents(name), modelRadio, modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsRadio.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsRadio.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-radio v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-radio :modifier="normalizedModifier">
     <slot></slot>
   </ons-radio>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsRange.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsRange.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-range v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-range :modifier="normalizedModifier">
     <slot></slot>
   </ons-range>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsRange.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsRange.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-range';
   import { deriveEvents, modelInput, modifier } from '../mixins';
 
+  const name = 'v-ons-range';
+
   export default {
-    name: 'v-ons-range',
-    mixins: [deriveEvents, modelInput, modifier]
+    name,
+    mixins: [deriveEvents(name), modelInput, modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsRipple.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsRipple.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-ripple';
   import { deriveEvents } from '../mixins';
 
+  const name = 'v-ons-ripple';
+
   export default {
-    name: 'v-ons-ripple',
-    mixins: [deriveEvents]
+    name,
+    mixins: [deriveEvents(name)]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsRipple.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsRipple.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-ripple v-on="unrecognizedListeners">
+  <ons-ripple>
     <slot></slot>
   </ons-ripple>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsRow.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsRow.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-row';
   import { deriveEvents } from '../mixins';
 
+  const name = 'v-ons-row';
+
   export default {
-    name: 'v-ons-row',
-    mixins: [deriveEvents]
+    name,
+    mixins: [deriveEvents(name)]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsRow.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsRow.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-row v-on="unrecognizedListeners">
+  <ons-row>
     <slot></slot>
   </ons-row>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsSearchInput.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsSearchInput.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-search-input';
   import { deriveEvents, modelInput, modifier } from '../mixins';
 
+  const name = 'v-ons-search-input';
+
   export default {
-    name: 'v-ons-search-input',
-    mixins: [deriveEvents, modelInput, modifier]
+    name,
+    mixins: [deriveEvents(name), modelInput, modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsSearchInput.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsSearchInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-search-input v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-search-input :modifier="normalizedModifier">
     <slot></slot>
   </ons-search-input>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsSegment.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsSegment.vue
@@ -8,10 +8,13 @@
   import 'onsenui/esm/elements/ons-segment';
   import { deriveEvents } from '../mixins';
 
-  export default {
-    name: 'v-ons-segment',
-    mixins: [deriveEvents],
+  const name = 'v-ons-segment';
 
+  export default {
+    name,
+    mixins: [deriveEvents(name)],
+
+    emits: ['update:index'],
     props: {
       index: {
         type: Number

--- a/bindings/vue/vue-onsenui/src/components/VOnsSelect.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsSelect.vue
@@ -24,6 +24,7 @@
         default: 'input'
       }
     },
+    emits: ['modelEvent'],
     computed: {
       selectedValue: {
         get() {

--- a/bindings/vue/vue-onsenui/src/components/VOnsSpeedDial.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsSpeedDial.vue
@@ -22,7 +22,6 @@
     data() {
       return {
         handlers: {
-          ...this.unrecognizedListeners,
           open: this.userInteraction,
           close: this.userInteraction
         }

--- a/bindings/vue/vue-onsenui/src/components/VOnsSpeedDial.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsSpeedDial.vue
@@ -8,9 +8,13 @@
   import 'onsenui/esm/elements/ons-speed-dial';
   import { hidable, deriveEvents } from '../mixins';
 
+  const name = 'v-ons-speed-dial';
+
   export default {
-    name: 'v-ons-speed-dial',
-    mixins: [deriveEvents, hidable],
+    name,
+    mixins: [deriveEvents(name), hidable],
+
+    emits: ['update:open', 'click'],
 
     props: {
       open: {

--- a/bindings/vue/vue-onsenui/src/components/VOnsSpeedDialItem.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsSpeedDialItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-speed-dial-item v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-speed-dial-item :modifier="normalizedModifier">
     <slot></slot>
   </ons-speed-dial-item>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsSpeedDialItem.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsSpeedDialItem.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-speed-dial-item';
   import { deriveEvents, modifier } from '../mixins';
 
+  const name = 'v-ons-speed-dial-item';
+
   export default {
-    name: 'v-ons-speed-dial-item',
-    mixins: [deriveEvents, modifier]
+    name,
+    mixins: [deriveEvents(name), modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsSplitter.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsSplitter.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-splitter v-on="unrecognizedListeners">
+  <ons-splitter>
     <slot></slot>
   </ons-splitter>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsSplitter.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsSplitter.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-splitter';
   import { deriveEvents, selfProvider, deriveDBB } from '../mixins';
 
+  const name = 'v-ons-splitter';
+
   export default {
-    name: 'v-ons-splitter',
-    mixins: [deriveEvents, selfProvider, deriveDBB]
+    name,
+    mixins: [deriveEvents(name), selfProvider, deriveDBB]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsSplitterContent.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsSplitterContent.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-splitter-content';
   import { deriveEvents } from '../mixins';
 
+  const name = 'v-ons-splitter-content';
+
   export default {
-    name: 'v-ons-splitter-content',
-    mixins: [deriveEvents]
+    name,
+    mixins: [deriveEvents(name)]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsSplitterContent.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsSplitterContent.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-splitter-content v-on="unrecognizedListeners">
+  <ons-splitter-content>
     <slot></slot>
   </ons-splitter-content>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsSplitterMask.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsSplitterMask.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-splitter-mask v-on="unrecognizedListeners">
+  <ons-splitter-mask>
     <slot></slot>
   </ons-splitter-mask>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsSplitterMask.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsSplitterMask.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-splitter-mask';
   import { deriveEvents } from '../mixins';
 
+  const name = 'v-ons-splitter-mask';
+
   export default {
-    name: 'v-ons-splitter-mask',
-    mixins: [deriveEvents]
+    name,
+    mixins: [deriveEvents(name)]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsSplitterSide.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsSplitterSide.vue
@@ -22,7 +22,6 @@
     data() {
       return {
         handlers: {
-          ...this.unrecognizedListeners,
           postopen: this.userInteraction,
           postclose: this.userInteraction,
           modechange: this.userInteraction

--- a/bindings/vue/vue-onsenui/src/components/VOnsSplitterSide.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsSplitterSide.vue
@@ -8,10 +8,13 @@
   import 'onsenui/esm/elements/ons-splitter-side';
   import { hasOptions, deriveEvents } from '../mixins';
 
-  export default {
-    name: 'v-ons-splitter-side',
-    mixins: [hasOptions, deriveEvents],
+  const name = 'v-ons-splitter-side';
 
+  export default {
+    name,
+    mixins: [hasOptions, deriveEvents(name)],
+
+    emits: ['update:open'],
     props: {
       open: {
         type: Boolean,

--- a/bindings/vue/vue-onsenui/src/components/VOnsSwitch.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsSwitch.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-switch';
   import { deriveEvents, modelCheckbox, modifier } from '../mixins';
 
+  const name = 'v-ons-switch';
+
   export default {
-    name: 'v-ons-switch',
-    mixins: [deriveEvents, modelCheckbox, modifier]
+    name,
+    mixins: [deriveEvents(name), modelCheckbox, modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsSwitch.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsSwitch.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-switch v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-switch :modifier="normalizedModifier">
     <slot></slot>
   </ons-switch>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsTab.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsTab.vue
@@ -17,6 +17,7 @@
         type: Boolean
       }
     },
+    emits: ['click'],
 
     methods: {
       action() {

--- a/bindings/vue/vue-onsenui/src/components/VOnsTabbar.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsTabbar.vue
@@ -27,10 +27,13 @@
   import 'onsenui/esm/elements/ons-tabbar';
   import { deriveEvents, hasOptions, hidable, selfProvider, modifier } from '../mixins';
 
-  export default {
-    name: 'v-ons-tabbar',
-    mixins: [deriveEvents, hasOptions, hidable, selfProvider, modifier],
+  const name = 'v-ons-tabbar';
 
+  export default {
+    name,
+    mixins: [deriveEvents(name), hasOptions, hidable, selfProvider, modifier],
+
+    emits: ['update:index'],
     props: {
       index: {
         type: Number

--- a/bindings/vue/vue-onsenui/src/components/VOnsToast.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsToast.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-toast v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-toast :modifier="normalizedModifier">
     <slot></slot>
   </ons-toast>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsToast.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsToast.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-toast';
   import { deriveEvents, hidable, hasOptions, deriveDBB, portal, modifier } from '../mixins';
 
+  const name = 'v-ons-toast';
+
   export default {
-    name: 'v-ons-toast',
-    mixins: [deriveEvents, hidable, hasOptions, deriveDBB, portal, modifier]
+    name,
+    mixins: [deriveEvents(name), hidable, hasOptions, deriveDBB, portal, modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsToolbar.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsToolbar.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-toolbar';
   import { deriveEvents, hidable, modifier } from '../mixins';
 
+  const name = 'v-ons-toolbar';
+
   export default {
-    name: 'v-ons-toolbar',
-    mixins: [deriveEvents, hidable, modifier]
+    name,
+    mixins: [deriveEvents(name), hidable, modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/components/VOnsToolbar.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsToolbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-toolbar v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-toolbar :modifier="normalizedModifier">
     <slot></slot>
   </ons-toolbar>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsToolbarButton.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsToolbarButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-toolbar-button v-on="unrecognizedListeners" :modifier="normalizedModifier">
+  <ons-toolbar-button :modifier="normalizedModifier">
     <slot></slot>
   </ons-toolbar-button>
 </template>

--- a/bindings/vue/vue-onsenui/src/components/VOnsToolbarButton.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsToolbarButton.vue
@@ -9,8 +9,10 @@
   import 'onsenui/esm/elements/ons-toolbar-button';
   import { deriveEvents, modifier } from '../mixins';
 
+  const name = 'v-ons-toolbar-button';
+
   export default {
-    name: 'v-ons-toolbar-button',
-    mixins: [deriveEvents, modifier]
+    name,
+    mixins: [deriveEvents(name), modifier]
   };
 </script>

--- a/bindings/vue/vue-onsenui/src/mixins/common.js
+++ b/bindings/vue/vue-onsenui/src/mixins/common.js
@@ -65,6 +65,8 @@ const selfProvider = {
 
 // Common event for Dialogs
 const dialogCancel = {
+  emits: [ 'update:visible' ],
+
   mounted() {
     this.$on('dialog-cancel', () => this.$emit('update:visible', false));
   }

--- a/bindings/vue/vue-onsenui/src/mixins/derive.js
+++ b/bindings/vue/vue-onsenui/src/mixins/derive.js
@@ -1,4 +1,6 @@
-import { camelize, eventToHandler, handlerToProp } from '../internal/util';
+import ons from 'onsenui';
+
+import { camelize, eventToHandler, handlerToProp, capitalize } from '../internal/util';
 
 /* Private */
 const _setupDBB = component => {
@@ -42,7 +44,9 @@ const deriveDBB = {
   }
 };
 
-const deriveEvents = {
+const deriveEvents = elementName => ({
+  emits: ons.elements[capitalize(camelize(elementName.slice(6)))].events,
+
   computed: {
     unrecognizedListeners() {
       const name = camelize('-' + this.$options.name.slice(6));
@@ -75,6 +79,6 @@ const deriveEvents = {
     });
     this._handlers = null;
   }
-};
+});
 
 export { deriveDBB, deriveEvents };

--- a/bindings/vue/vue-onsenui/src/mixins/model.js
+++ b/bindings/vue/vue-onsenui/src/mixins/model.js
@@ -16,6 +16,7 @@ const modelInput = {
       default: 'input'
     }
   },
+  emits: [model.event],
 
   methods: {
     _updateValue() {


### PR DESCRIPTION
Various fixes for Vue 3 upgrade:

- Add ons- elements to the custom elements whitelist in rollup config
- Externalize vue properly in the UMD rollup config
- Split Vue examples entry file into single file components. Examples app now loads but with lots of warnings and some examples not working properly.
- Remove most instances of unrecognizedListeners (no longer need in Vue 3)
- Add emits key for components that emit events. Fixes #2849.