### PR TITLE
Vue3 navigator fixes

### DIFF
--- a/bindings/vue/vue-onsenui-examples/src/components/Navigator.vue
+++ b/bindings/vue/vue-onsenui-examples/src/components/Navigator.vue
@@ -16,6 +16,8 @@
 </template>
 
 <script>
+  import { markRaw } from 'vue';
+
   const log = (...args) => console.log(...args);
 
   const myToolbar = {
@@ -66,9 +68,9 @@
     methods: {
       log,
       push() {
-        this.$emit('push', page3);
-        this.$emit('push', page3);
-        this.$emit('push', page3);
+        this.$emit('push', markRaw(page3));
+        this.$emit('push', markRaw(page3));
+        this.$emit('push', markRaw(page3));
       }
     },
     props: {
@@ -102,12 +104,12 @@
     methods: {
       log,
       push() {
-        this.$emit('push', {
+        this.$emit('push', markRaw({
           extends: page2,
           onsNavigatorProps: {
             myProp: 'This is a navigator prop'
           }
-        });
+        }));
       }
     },
     components: { myToolbar },
@@ -119,7 +121,7 @@
 	export default {
     data() {
       return {
-        pageStack: [page1]
+        pageStack: [markRaw(page1)]
       };
     },
     methods: {

--- a/bindings/vue/vue-onsenui/src/components/VOnsNavigator.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsNavigator.vue
@@ -78,8 +78,12 @@
         return Promise.resolve();
       },
       _animate({ lastLength, currentLength, lastTopPage, currentTopPage, restoreScroll }) {
-        const pushedOptions = this.pageRefs[this.pageRefs.length - 1].onsNavigatorOptions
-          || currentTopPage.__vue__.onsNavigatorOptions
+        const pushedOptions =
+          // onsNavigatorOptions defined inside component's data property
+          this.pageRefs[this.pageRefs.length - 1].onsNavigatorOptions
+          // onsNavigatorOptions defined at same level as data and methods
+          || this.pageStack[this.pageStack.length - 1].onsNavigatorOptions
+          // onsNavigatorOptions is not defined
           || {};
 
         // Push

--- a/bindings/vue/vue-onsenui/src/components/VOnsNavigator.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsNavigator.vue
@@ -27,8 +27,8 @@
       },
       popPage: {
         type: Function,
-        default(props) {
-          props.pageStack.pop();
+        default() {
+          this.pageStack.pop();
         }
       }
     },

--- a/bindings/vue/vue-onsenui/src/components/VOnsNavigator.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsNavigator.vue
@@ -53,7 +53,7 @@
       },
       _eachPage(start, end, cb) {
         for (let i = start; i < end; i++) {
-          cb(this.pageStack[i].$el);
+          cb(this.$children[i].$el);
         }
       },
       _reattachPage(pageElement, position = null, restoreScroll) {
@@ -112,7 +112,7 @@
       },
       _checkSwipe(event) {
         if (this.$el.hasAttribute('swipeable') &&
-          event.leavePage !== this.$el.lastChild && event.leavePage === this.pageStack[this.pageStack.length - 1].$el
+          event.leavePage !== this.$el.lastChild && event.leavePage === this.$children[this.$children.length - 1].$el
         ) {
           this.popPage();
         }
@@ -121,7 +121,7 @@
 
     watch: {
       pageStack(after, before) {
-        if (this.$el.hasAttribute('swipeable') && this.pageStack.length !== this.$el.children.length) {
+        if (this.$el.hasAttribute('swipeable') && this.$children.length !== this.$el.children.length) {
           return;
         }
 
@@ -132,13 +132,13 @@
         }
 
         const propWasMutated = after === before; // Can be mutated or replaced
-        const lastTopPage = this.pageStack[this.pageStack.length - 1].$el;
+        const lastTopPage = this.$children[this.$children.length - 1].$el;
         const scrollElement = this._findScrollPage(lastTopPage);
         const scrollValue = scrollElement.scrollTop || 0;
 
         this._pageStackUpdate = {
           lastTopPage,
-          lastLength: propWasMutated ? this.pageStack.length : before.length,
+          lastLength: propWasMutated ? this.$children.length : before.length,
           currentLength: !propWasMutated && after.length,
           restoreScroll: () => scrollElement.scrollTop = scrollValue
         };
@@ -149,10 +149,10 @@
 
     updated() {
       if (this._pageStackUpdate) {
-        let currentTopPage = this.pageStack[this.pageStack.length - 1].$el;
+        let currentTopPage = this.$children[this.$children.length - 1].$el;
         let { lastTopPage, currentLength } = this._pageStackUpdate;
         const { lastLength, restoreScroll } = this._pageStackUpdate;
-        currentLength = currentLength === false ? this.pageStack.length : currentLength;
+        currentLength = currentLength === false ? this.$children.length : currentLength;
 
         if (currentTopPage !== lastTopPage) {
           this._ready = this._animate({ lastLength, currentLength, lastTopPage, currentTopPage, restoreScroll });

--- a/bindings/vue/vue-onsenui/src/components/VOnsNavigator.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsNavigator.vue
@@ -78,7 +78,7 @@
         return Promise.resolve();
       },
       _animate({ lastLength, currentLength, lastTopPage, currentTopPage, restoreScroll }) {
-        const pushedOptions = this.pageStack[this.pageStack.length - 1].onsNavigatorOptions
+        const pushedOptions = this.pageRefs[this.pageRefs.length - 1].onsNavigatorOptions
           || currentTopPage.__vue__.onsNavigatorOptions
           || {};
 


### PR DESCRIPTION
- Replace `this.$children`
- Replace `__vue__`
- Stop trying to access props argument in props default function
- Use refs when getting data from the navigator page stack
- Silence warnings with `markRaw`
-  Fix onsNavigatorOptions as top-level property not working