### PR TITLE
Unrecognized listener fixes

### DIFF
--- a/bindings/vue/vue-onsenui/src/components/VOnsNavigator.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsNavigator.vue
@@ -136,30 +136,42 @@
     },
 
     watch: {
-      pageStack(after, before) {
-        if (this.$el.hasAttribute('swipeable') && this.pageRefs.length !== this.$el.children.length) {
-          return;
-        }
+      pageStack: {
+        handler(after, before) {
+          // Set inheritAttrs to false to stop custom event listeners being
+          // applied to the native ons-page element. They are already applied to
+          // the native ons-navigator element (which will fire native ons-page
+          // events due to bubbling) so without this listeners for events fired
+          // by ons-page (e.g. 'show') would be called twice.
+          this.pageStack.forEach(page => page.inheritAttrs = false);
 
-        // watcher triggered by undoing a canceled push or pop
-        if (this._canceled) {
-          this._canceled = null;
-          return;
-        }
+          if (this.$el) { // if mounted
+            if (this.$el.hasAttribute('swipeable') && this.pageRefs.length !== this.$el.children.length) {
+              return;
+            }
 
-        const propWasMutated = after === before; // Can be mutated or replaced
-        const lastTopPage = this.pageRefs[this.pageRefs.length - 1].$el;
-        const scrollElement = this._findScrollPage(lastTopPage);
-        const scrollValue = scrollElement.scrollTop || 0;
+            // watcher triggered by undoing a canceled push or pop
+            if (this._canceled) {
+              this._canceled = null;
+              return;
+            }
 
-        this._pageStackUpdate = {
-          lastTopPage,
-          lastLength: propWasMutated ? this.pageRefs.length : before.length,
-          currentLength: !propWasMutated && after.length,
-          restoreScroll: () => scrollElement.scrollTop = scrollValue
-        };
+            const propWasMutated = after === before; // Can be mutated or replaced
+            const lastTopPage = this.pageRefs[this.pageRefs.length - 1].$el;
+            const scrollElement = this._findScrollPage(lastTopPage);
+            const scrollValue = scrollElement.scrollTop || 0;
 
-        // this.$nextTick(() => { }); // Waits too long, updated() hook is faster and prevents flickerings
+            this._pageStackUpdate = {
+              lastTopPage,
+              lastLength: propWasMutated ? this.pageRefs.length : before.length,
+              currentLength: !propWasMutated && after.length,
+              restoreScroll: () => scrollElement.scrollTop = scrollValue
+            };
+
+            // this.$nextTick(() => { }); // Waits too long, updated() hook is faster and prevents flickerings
+          }
+        },
+        immediate: true
       }
     },
 

--- a/bindings/vue/vue-onsenui/src/components/VOnsNavigator.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsNavigator.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-navigator @postpop.self="_checkSwipe" :options.prop="options" v-on="unrecognizedListeners">
+  <ons-navigator @postpop.self="_checkSwipe" :options.prop="options">
     <component
       v-for="page in pageStack"
       :is="page"

--- a/bindings/vue/vue-onsenui/src/components/VOnsTabbar.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsTabbar.vue
@@ -62,6 +62,17 @@
         if (this.index !== this.$el.getActiveTabIndex()) {
           this.$el.setActiveTab(this.index, { reject: false, ...this.options });
         }
+      },
+      tabs: {
+        handler() {
+          // Set inheritAttrs to false to stop custom event listeners being
+          // applied to the native ons-page element. They are already applied to
+          // the native ons-tabbar element (which will fire native ons-page
+          // events due to bubbling) so without this listeners for events fired
+          // by ons-page (e.g. 'show') would be called twice.
+          this.tabs.forEach(tab => tab.page.inheritAttrs = false);
+        },
+        immediate: true
       }
     }
   };

--- a/bindings/vue/vue-onsenui/src/mixins/derive.js
+++ b/bindings/vue/vue-onsenui/src/mixins/derive.js
@@ -48,16 +48,13 @@ const deriveEvents = elementName => ({
   emits: ons.elements[capitalize(camelize(elementName.slice(6)))].events,
 
   computed: {
+    // Returns all listeners that aren't listed in the component's `emits` key.
     unrecognizedListeners() {
       const name = camelize('-' + this.$options.name.slice(6));
-      const listeners = Object.fromEntries(Object.entries(this.$attrs)
-        .filter(([attribute, handler]) => /^on[^a-z]/.test(attribute)));
-      return Object.keys(listeners || {})
-        .filter(k => (this.$ons.elements[name].events || []).indexOf(k) === -1)
-        .reduce((r, k) => {
-          r[k] = listeners[k];
-          return r;
-        }, {});
+      // Listeners are prefixed with 'on' e.g. 'onShow' so we test for that
+      const isListener = ([attribute]) => /^on[^a-z]/.test(attribute);
+
+      return Object.fromEntries(Object.entries(this.$attrs).filter(isListener));
     }
   },
 


### PR DESCRIPTION
- Remove unneeded root node unrecognizedListeners on VOnsNavigator
- Stop unneeded filtering of this.$attrs for ons native events
- Stop v-ons-navigator custom listeners firing twice where listener is a native ons-page event e.g. show
- Stop v-ons-tabbar custom listeners firing twice where listener is a native ons-page event e.g. show