### PR TITLE
Vue3 tabbar fixes

### DIFF
--- a/bindings/vue/vue-onsenui-examples/src/components/Tabbar.vue
+++ b/bindings/vue/vue-onsenui-examples/src/components/Tabbar.vue
@@ -1,9 +1,13 @@
 <template>
   <v-ons-page>
     <v-ons-toolbar>
-      <div class="left"><v-ons-toolbar-button @click="tabbarIndex--">Index--</v-ons-toolbar-button></div>
+      <div class="left">
+        <v-ons-toolbar-button @click="tabbarIndex--" :disabled="tabbarIndex <= 0">Index--</v-ons-toolbar-button>
+      </div>
       <div class="center">Index: {{tabbarIndex}} -- Show: <input type="checkbox" v-model="tabbarVisibility" /> - <button @click="tabs[0].props.test = 'Modified!'; tabs[1].badge = 2">Props</button></div>
-      <div class="right"><v-ons-toolbar-button @click="tabbarIndex++">Index++</v-ons-toolbar-button></div>
+      <div class="right">
+        <v-ons-toolbar-button @click="tabbarIndex++" :disabled="tabbarIndex >= tabs.length - 1">Index++</v-ons-toolbar-button>
+      </div>
     </v-ons-toolbar>
 
     <v-ons-tabbar

--- a/bindings/vue/vue-onsenui-examples/src/components/Tabbar.vue
+++ b/bindings/vue/vue-onsenui-examples/src/components/Tabbar.vue
@@ -4,7 +4,12 @@
       <div class="left">
         <v-ons-toolbar-button @click="tabbarIndex--" :disabled="tabbarIndex <= 0">Index--</v-ons-toolbar-button>
       </div>
-      <div class="center">Index: {{tabbarIndex}} -- Show: <input type="checkbox" v-model="tabbarVisibility" /> - <button @click="tabs[0].props.test = 'Modified!'; tabs[1].badge = 2">Props</button></div>
+      <div class="center">
+        Index: {{tabbarIndex}} -- Show:
+        <input type="checkbox" v-model="tabbarVisibility" /> -
+        <v-ons-button @click="tabs[0].props.test = 'Modified!'">Set Home prop</v-ons-button> -
+        <v-ons-button @click="tabs[1].badge++">Modify News badge</v-ons-button>
+      </div>
       <div class="right">
         <v-ons-toolbar-button @click="tabbarIndex++" :disabled="tabbarIndex >= tabs.length - 1">Index++</v-ons-toolbar-button>
       </div>

--- a/bindings/vue/vue-onsenui-examples/src/components/Tabbar.vue
+++ b/bindings/vue/vue-onsenui-examples/src/components/Tabbar.vue
@@ -13,7 +13,7 @@
     <v-ons-tabbar
       swipeable
       v-model:tabs="tabs"
-      :index="tabbarIndex"
+      v-model:index="tabbarIndex"
       :visible="tabbarVisibility"
       position="auto"
       @reactive="log('reactive')"

--- a/bindings/vue/vue-onsenui-examples/src/components/Tabbar.vue
+++ b/bindings/vue/vue-onsenui-examples/src/components/Tabbar.vue
@@ -6,7 +6,20 @@
       <div class="right"><v-ons-toolbar-button @click="tabbarIndex++">Index++</v-ons-toolbar-button></div>
     </v-ons-toolbar>
 
-    <v-ons-tabbar swipeable v-model:tabs="tabs" :index="tabbarIndex" :visible="tabbarVisibility" position="auto" @reactive="log('reactive')" @postchange="log('postchange')" @prechange="log('prechange')" @init="log('init')" @show="log('show')" @hide="log('hide')" @destroy="log('destroy')">
+    <v-ons-tabbar
+      swipeable
+      v-model:tabs="tabs"
+      :index="tabbarIndex"
+      :visible="tabbarVisibility"
+      position="auto"
+      @reactive="log('reactive')"
+      @postchange="log('postchange')"
+      @prechange="log('prechange')"
+      @init="log('init')"
+      @show="log('show')"
+      @hide="log('hide')"
+      @destroy="log('destroy')"
+    >
     </v-ons-tabbar>
   </v-ons-page>
 </template>

--- a/bindings/vue/vue-onsenui-examples/src/components/Tabbar.vue
+++ b/bindings/vue/vue-onsenui-examples/src/components/Tabbar.vue
@@ -65,7 +65,7 @@
         tabs: [
           {
             label: 'Home',
-            icon: 'ion-ios-home-outline',
+            icon: 'ion-ios-home',
             page: home,
             props: {
               test: 'This is a page prop.'
@@ -73,7 +73,7 @@
           },
           {
             label: 'News',
-            icon: 'ion-ios-bell',
+            icon: 'ion-ios-notifications',
             badge: 7,
             page: news
           },

--- a/bindings/vue/vue-onsenui-examples/src/components/Tabbar.vue
+++ b/bindings/vue/vue-onsenui-examples/src/components/Tabbar.vue
@@ -82,7 +82,7 @@
             icon: 'fa-cogs',
             page: settings
           }
-        ].map(markRaw)
+        ].map(tab => ({ ...tab, page: markRaw(tab.page) }))
       };
     },
 

--- a/bindings/vue/vue-onsenui/src/components/VOnsTab.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsTab.vue
@@ -1,5 +1,5 @@
 <template>
-  <ons-tab :active="active" :on-click.prop="action">
+  <ons-tab :active="coercedActive" :on-click.prop="action">
   </ons-tab>
 </template>
 
@@ -27,6 +27,15 @@
         if (runDefault) {
           this.tabbar.$el.setActiveTab(this.$el.index, { reject: false, ...this.tabbar.options });
         }
+      }
+    },
+
+    computed: {
+      coercedActive() {
+        // Returns null if active prop is false so the native ons-tab's active
+        // attribute will not be set. Without this, ons-tab's active attribute
+        // would be active="false" (i.e. set).
+        return this.active || null;
       }
     },
 

--- a/bindings/vue/vue-onsenui/src/components/VOnsTabbar.vue
+++ b/bindings/vue/vue-onsenui/src/components/VOnsTabbar.vue
@@ -47,7 +47,8 @@
         type: Function
       },
       tabbarStyle: {
-        type: null
+        type: Object,
+        default: {}
       }
     },
 


### PR DESCRIPTION
- Unset ons-tab active when VOnsTab active prop is false to fix all pages being active bug
- Set tabbarStyle prop default to an empty object to fix `visible` functionality
- Tabbar example formatting and clarity improvements