### PR TITLE
perf(core): call DOMContentLoaded and deviceready just once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 CHANGELOG
 ====
 
+dev
+---
+
+ ### Bug Fixes
+
+ * core: DOMContentReady and deviceready event listeners are removed after being invoked once. ([#2886](https://github.com/OnsenUI/OnsenUI/pull/2886)).
+
 2.11.2
 ---
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -43,5 +43,6 @@ List of code contributors (in no particular order):
 * [Jan Vincent Liwanag](https://github.com/jvliwanag)
 * [Kenji Kawanobe](https://github.com/kenji7157)
 * [Stan Janssen](https://github.com/stonjohnsson)
+* [Alexander S.](https://github.com/Sysix)
 
 Please add yourself if you're not on this list but feel that you should be.

--- a/core/src/ons/index.js
+++ b/core/src/ons/index.js
@@ -512,11 +512,11 @@ function waitDeviceReady() {
   const unlockDeviceReady = ons._readyLock.lock();
   window.addEventListener('DOMContentLoaded', () => {
     if (ons.isWebView()) {
-      window.document.addEventListener('deviceready', unlockDeviceReady, false);
+      window.document.addEventListener('deviceready', unlockDeviceReady, {once: true});
     } else {
       unlockDeviceReady();
     }
-  }, false);
+  }, {once: true});
 }
 
 /**


### PR DESCRIPTION
we don't need to listen for a second call, should never happend.