### PR TITLE
docs(vue): Remove manual/generated components distinction

### DIFF
--- a/vue-onsenui/src/components/index.js
+++ b/vue-onsenui/src/components/index.js
@@ -1,4 +1,3 @@
-// Generic components:
 export { default as VOnsToolbar } from './VOnsToolbar';
 export { default as VOnsBottomToolbar } from './VOnsBottomToolbar';
 export { default as VOnsToolbarButton } from './VOnsToolbarButton';
@@ -32,8 +31,6 @@ export { default as VOnsActionSheet } from './VOnsActionSheet';
 export { default as VOnsActionSheetButton } from './VOnsActionSheetButton';
 export { default as VOnsModal } from './VOnsModal';
 export { default as VOnsToast } from './VOnsToast';
-
-// Manual components:
 export { default as VOnsPopover } from './VOnsPopover';
 export { default as VOnsAlertDialog } from './VOnsAlertDialog';
 export { default as VOnsSpeedDial } from './VOnsSpeedDial';

--- a/vue3-onsenui/src/components/index.js
+++ b/vue3-onsenui/src/components/index.js
@@ -1,4 +1,3 @@
-// Generic components:
 export { default as VOnsToolbar } from './VOnsToolbar';
 export { default as VOnsBottomToolbar } from './VOnsBottomToolbar';
 export { default as VOnsToolbarButton } from './VOnsToolbarButton';
@@ -32,8 +31,6 @@ export { default as VOnsActionSheet } from './VOnsActionSheet';
 export { default as VOnsActionSheetButton } from './VOnsActionSheetButton';
 export { default as VOnsModal } from './VOnsModal';
 export { default as VOnsToast } from './VOnsToast';
-
-// Manual components:
 export { default as VOnsPopover } from './VOnsPopover';
 export { default as VOnsAlertDialog } from './VOnsAlertDialog';
 export { default as VOnsSpeedDial } from './VOnsSpeedDial';


### PR DESCRIPTION
We are no longer generating the Vue components as there are better ways
to deal with boilerplate code.