### PR TITLE
Vue 2/3: Remove listener props

### DIFF
--- a/vue-onsenui/src/components/VOnsCarousel.vue
+++ b/vue-onsenui/src/components/VOnsCarousel.vue
@@ -1,6 +1,5 @@
 <template>
   <ons-carousel
-    :on-swipe.prop="onSwipe"
     :initial-index="index"
     @postchange.self="$emit('update:index', $event.activeIndex)"
     v-on="unrecognizedListeners"
@@ -23,9 +22,6 @@
     props: {
       index: {
         type: Number
-      },
-      onSwipe: {
-        type: Function
       }
     },
 

--- a/vue-onsenui/src/components/VOnsTabbar.vue
+++ b/vue-onsenui/src/components/VOnsTabbar.vue
@@ -1,6 +1,5 @@
 <template>
   <ons-tabbar
-    :on-swipe.prop="onSwipe"
     :activeIndex="index"
     :modifier="normalizedModifier"
     v-on="unrecognizedListeners"
@@ -40,9 +39,6 @@
         validator(value) {
           return value.every(tab => ['icon', 'label', 'page'].some(prop => !!Object.getOwnPropertyDescriptor(tab, prop)));
         }
-      },
-      onSwipe: {
-        type: Function
       },
       tabbarStyle: {
         type: null

--- a/vue-onsenui/src/docs/VOnsCarousel.wcdoc
+++ b/vue-onsenui/src/docs/VOnsCarousel.wcdoc
@@ -11,14 +11,6 @@
  */
 
 /**
- * @attribute on-swipe
- * @type {Function}
- * @description
- *   [en]Hook called whenever the user slides the carousel. It gets a decimal index and an animationOptions object as arguments.[/en]
- *   [ja][/ja]
- */
-
-/**
  * @event update:index
  * @description
  *   [en]Fired right after user interaction. Useful to update `index` prop.[/en]

--- a/vue-onsenui/src/docs/VOnsPullHook.wcdoc
+++ b/vue-onsenui/src/docs/VOnsPullHook.wcdoc
@@ -9,11 +9,3 @@
  *   [en]This will be called in the `action` state if exists. The function will be given a `done` callback as it's first argument.[/en]
  *   [ja][/ja]
  */
-
-/**
- * @attribute on-pull
- * @type {Function}
- * @description
- *   [en]Hook called whenever the element is pulled. It gets the pulled distance ratio (scroll / height) and an animationOptions object as arguments.[/en]
- *   [ja][/ja]
- */

--- a/vue-onsenui/src/docs/VOnsTabbar.wcdoc
+++ b/vue-onsenui/src/docs/VOnsTabbar.wcdoc
@@ -19,14 +19,6 @@
  */
 
 /**
- * @attribute on-swipe
- * @type {Function}
- * @description
- *   [en]Hook called whenever the user slides the tabbar. It gets a decimal index and an animationOptions object as arguments.[/en]
- *   [ja][/ja]
- */
-
-/**
  * @attribute tabbar-style
  * @description
  *   [en]Optional style for the actual tabbar element. Accepts any Vue valid style.[/en]

--- a/vue3-onsenui/src/components/VOnsTabbar.vue
+++ b/vue3-onsenui/src/components/VOnsTabbar.vue
@@ -1,6 +1,5 @@
 <template>
   <ons-tabbar
-    :on-swipe.prop="onSwipe"
     :activeIndex="index"
     :modifier="normalizedModifier"
     @prechange.self="$nextTick(() => !$event.detail.canceled && $emit('update:index', $event.index))"
@@ -42,9 +41,6 @@
         validator(value) {
           return value.every(tab => ['icon', 'label', 'page'].some(prop => !!Object.getOwnPropertyDescriptor(tab, prop)));
         }
-      },
-      onSwipe: {
-        type: Function
       },
       tabbarStyle: {
         type: null

--- a/vue3-onsenui/src/docs/VOnsPullHook.wcdoc
+++ b/vue3-onsenui/src/docs/VOnsPullHook.wcdoc
@@ -9,11 +9,3 @@
  *   [en]This will be called in the `action` state if exists. The function will be given a `done` callback as it's first argument.[/en]
  *   [ja][/ja]
  */
-
-/**
- * @attribute on-pull
- * @type {Function}
- * @description
- *   [en]Hook called whenever the element is pulled. It gets the pulled distance ratio (scroll / height) and an animationOptions object as arguments.[/en]
- *   [ja][/ja]
- */

--- a/vue3-onsenui/src/docs/VOnsTabbar.wcdoc
+++ b/vue3-onsenui/src/docs/VOnsTabbar.wcdoc
@@ -19,14 +19,6 @@
  */
 
 /**
- * @attribute on-swipe
- * @type {Function}
- * @description
- *   [en]Hook called whenever the user slides the tabbar. It gets a decimal index and an animationOptions object as arguments.[/en]
- *   [ja][/ja]
- */
-
-/**
  * @attribute tabbar-style
  * @description
  *   [en]Optional style for the actual tabbar element. Accepts any Vue valid style.[/en]


### PR DESCRIPTION
Remove props in the form `on-<event>` which have been made superfluous by the core emitting the event. e.g. `on-swipe` no longer needed for VOnsCarousel since ons-carousel emits a `swipe` event.

Fixes #2908.