### PR TITLE
feat(vue3): Make the ESM build the default for bundlers

### DIFF
--- a/vue3-onsenui-examples/src/main.js
+++ b/vue3-onsenui-examples/src/main.js
@@ -1,6 +1,8 @@
 import { createApp } from 'vue';
 
-import VueOnsen from 'vue-onsenui'; // umd
+import VueOnsen from 'vue-onsenui';
+import * as components from 'vue-onsenui/esm/components';
+
 import Vuex from 'vuex';
 
 import App from './App.vue';
@@ -8,15 +10,11 @@ import App from './App.vue';
 import 'onsenui/css/onsenui.css';
 import 'onsenui/css/onsen-css-components.css';
 
-// import VueOnsen from 'vue-onsenui/esm'; // esm
-// // import * as VOns from 'vue-onsenui/esm/components';
-// // Object.values(VOns).forEach(component => Vue.component(component.name, component));
-// import VOnsPage from '../src/components/VOnsPage';
-// import VOnsToolbar from '../src/components/VOnsToolbar';
-// Vue.component(VOnsPage.name, VOnsPage);
-// Vue.component(VOnsToolbar.name, VOnsToolbar);
-
 const app = createApp(App);
+
+// Register all vue-onsenui components
+Object.values(components).forEach(component =>
+  app.component(component.name, component));
 
 app.use(VueOnsen);
 app.use(Vuex);

--- a/vue3-onsenui/CHANGELOG.md
+++ b/vue3-onsenui/CHANGELOG.md
@@ -6,6 +6,7 @@ dev
 
  ### BREAKING CHANGES
 
+ * The ESM build is now the default when vue-onsenui is used with a bundler. When using the ESM build, components must be registered using `app.component` before they can be used.
  * For v-model, `modelValue` prop and `update:modelValue` event are now used instead of `modelProp` prop and `modelEvent` event. However, the `modelEvent` *prop* is unchanged.
  * VOnsLazyRepeat: The renderItem prop should be a function that returns an *object* describing a Vue component.
 

--- a/vue3-onsenui/package.json
+++ b/vue3-onsenui/package.json
@@ -15,6 +15,7 @@
     "lint": "eslint \"src/**/*.js\" \"src/**/*.vue\""
   },
   "main": "dist/vue-onsenui.js",
+  "module": "esm/index.js",
   "files": [
     "dist",
     "esm"


### PR DESCRIPTION
This is a breaking change since it will require that users using the
default build will now be using ESM instead of UMD, and therefore must
register vue-onsenui components in their app before use.