### PR TITLE
Vue 3: Navigator and Popover fixes

### DIFF
--- a/onsenui/CHANGELOG.md
+++ b/onsenui/CHANGELOG.md
@@ -2,6 +2,13 @@
 CHANGELOG
 ====
 
+dev
+---
+
+ ### New Features
+
+ * ons-navigator: Add `swipeToPop` and `onsBackButton` keys to `postpop` event for detecting what triggered the pop.
+
 2.12.1
 ---
 

--- a/onsenui/esm/elements/ons-back-button.js
+++ b/onsenui/esm/elements/ons-back-button.js
@@ -202,7 +202,7 @@ export default class BackButtonElement extends BaseElement {
       if (!event.defaultPrevented) {
         const navigator = util.findParent(this, 'ons-navigator');
         if (navigator) {
-          navigator.popPage({...this.options, _onsBackButton: true});
+          navigator.popPage({...this.options, onsBackButton: true});
         }
       }
     });

--- a/onsenui/esm/elements/ons-navigator.js
+++ b/onsenui/esm/elements/ons-navigator.js
@@ -243,6 +243,12 @@ export default class NavigatorElement extends BaseElement {
    * @param {Object} event.leavePage
    *   [en]Object of the previous page.[/en]
    *   [ja]popされて消えるページのオブジェクト。[/ja]
+   * @param {Object} event.swipeToPop
+   *   [en]True if the pop was triggered by the user swiping to pop.[/en]
+   *   [ja][/ja]
+   * @param {Object} event.onsBackButton
+   *   [en]True if the pop was caused by pressing an ons-back-button.[/en]
+   *   [ja][/ja]
    */
 
   /**
@@ -326,7 +332,7 @@ export default class NavigatorElement extends BaseElement {
           const animationOptions = { duration: swipeAnimator.durationSwipe, timing: swipeAnimator.timingSwipe };
           this._onSwipe && this._onSwipe(ratio, animationOptions);
           util.triggerElementEvent(this, 'swipe', { ratio, animationOptions });
-          this[this.swipeMax ? 'swipeMax' : 'popPage']({ animator: swipeAnimator, _swipeToPop: true });
+          this[this.swipeMax ? 'swipeMax' : 'popPage']({ animator: swipeAnimator, swipeToPop: true });
           swipeAnimator = null;
         },
         swipeMid: (distance, width) => {
@@ -535,8 +541,8 @@ export default class NavigatorElement extends BaseElement {
             leavePage,
             enterPage,
             navigator: this,
-            _swipeToPop: !!options._swipeToPop,        // whether the pop was triggered by the user swiping
-            _onsBackButton: !!options._onsBackButton   // whether the pop was triggered by clicking ons-back-button
+            swipeToPop: !!options.swipeToPop,        // whether the pop was triggered by the user swiping
+            onsBackButton: !!options.onsBackButton   // whether the pop was triggered by clicking ons-back-button
           });
 
           options.callback && options.callback(enterPage);

--- a/vue3-onsenui-examples/src/components/Navigator.vue
+++ b/vue3-onsenui-examples/src/components/Navigator.vue
@@ -1,14 +1,13 @@
 <template>
   <v-ons-page>
     <v-ons-navigator swipeable
-      :page-stack="pageStack"
-      animation="none"
+      v-model:page-stack="pageStack"
       @postpush="log('postpush!')"
       @show="log('show from navigator!')"
 
       @push="pageStack = [...pageStack, $event]"
       @reset="pageStack = [pageStack[0]]"
-      @pop="pageStack.pop()"
+      @pop="packStage = pageStack.slice(0, -1)"
       @replace="pageStack = [...pageStack.slice(0, -1), $event]"
     >
     </v-ons-navigator>

--- a/vue3-onsenui-examples/src/components/NavigatorPinia.vue
+++ b/vue3-onsenui-examples/src/components/NavigatorPinia.vue
@@ -1,31 +1,30 @@
 <template>
   <v-ons-page>
-    <v-ons-navigator swipeable :page-stack="pageStack" :pop-page="popPage"></v-ons-navigator>
+  <v-ons-navigator swipeable v-model:page-stack="pageStack"></v-ons-navigator>
   </v-ons-page>
 </template>
 
 <script>
   import { markRaw } from 'vue';
-  import { defineStore, mapActions, mapState } from 'pinia';
+  import { defineStore, mapActions, mapWritableState } from 'pinia';
 
   const usePageStackStore = defineStore('pageStack', {
     state: () => ({ pageStack: [] }),
     actions: {
       pushPage(page) {
         if (page instanceof Array) {
-          this.pageStack.push(...page.map(markRaw))
+          this.pageStack = [...this.pageStack, ...page.map(markRaw)];
         } else {
-          this.pageStack.push(markRaw(page));
+          this.pageStack = [...this.pageStack, markRaw(page)];
         }
       },
       popPage() {
         if (this.pageStack.length > 1) {
-          this.pageStack.pop();
+          this.pageStack = this.pageStack.slice(0, -1);
         }
       },
       replacePage(page) {
-        this.pageStack.pop();
-        this.pageStack.push(page);
+        this.pageStack = [...this.pageStack.slice(0, -1), markRaw(page)]
       },
       resetPageStack() {
         this.pageStack = [this.pageStack[0]];
@@ -96,7 +95,7 @@
 
 	export default {
     computed: {
-      ...mapState(usePageStackStore, ['pageStack'])
+      ...mapWritableState(usePageStackStore, ['pageStack'])
     },
     beforeMount() {
       this.pushPage(page1);

--- a/vue3-onsenui/CHANGELOG.md
+++ b/vue3-onsenui/CHANGELOG.md
@@ -14,6 +14,7 @@ dev
  * VOnsNavigator: The `pageStack` prop is no longer mutated directly. Instead use `v-model:pageStack` to keep the `pageStack` prop in sync.
  * VOnsNavigator: The `pageStack` prop no longer responds to array mutatation methods (e.g. Array.prototype.pop). The whole `pageStack` value must be replaced (e.g. by using Array.prototype.slice) to trigger a visual change.
  * VOnsNavigator: The `popPage` prop has been removed. Use `@deviceBackButton.prevent` and VOnsBackButton's `@click.prevent` to override default pop behaviour.
+ * VOnsPopover: The `target` prop must be a Vue ref.
 
  ### Bug Fixes
 

--- a/vue3-onsenui/src/components/VOnsNavigator.vue
+++ b/vue3-onsenui/src/components/VOnsNavigator.vue
@@ -126,7 +126,7 @@
       },
       _checkUserInteraction(event) {
         // update the internal page stack in the case where user swiped to pop or clicked ons-back-button
-        if (event._swipeToPop || event._onsBackButton) {
+        if (event.swipeToPop || event.onsBackButton) {
           this._popPage();
         }
       },

--- a/vue3-onsenui/src/components/VOnsPopover.vue
+++ b/vue3-onsenui/src/components/VOnsPopover.vue
@@ -24,10 +24,7 @@
 
     computed: {
       normalizedTarget() {
-        if (this.target && this.target.__isVue) {
-          return this.target.$el;
-        }
-        return this.target;
+        return this.target.$el || this.target;
       },
       normalizedOptions() {
         if (this.target) {

--- a/vue3-onsenui/src/docs/VOnsPopover.wcdoc
+++ b/vue3-onsenui/src/docs/VOnsPopover.wcdoc
@@ -4,9 +4,9 @@
 
 /**
  * @attribute target
- * @type {Ref|String|Event|HTMLElement}
+ * @type {Ref}
  * @description
- *   [en]Target element. Can be either a Vue component reference, a CSS selector, an event object or a DOM element. It can also be provided as `options.target`.[/en]
+ *   [en]Target element. Must be a Vue ref.[/en]
  *   [ja][/ja]
  */
 


### PR DESCRIPTION
- feat(ons-navigator): Make postpop's onsBackButton and swipeToPop public
- fix(vue3): Only allow Vue ref in VOnsPopover's target prop
- examples(vue3): Update navigator examples for v-model etc.
