### PR TITLE
fix(ons-popover): Add target property

### DIFF
--- a/onsenui/esm/elements/ons-popover.js
+++ b/onsenui/esm/elements/ons-popover.js
@@ -183,6 +183,22 @@ export default class PopoverElement extends BaseDialogElement {
    */
 
   /**
+   * @attribute target
+   * @type {String}
+   * @description
+   *   [en]Specifies the ID of the default element for the popover.[/en]
+   *   [ja]ポップオーバーの対象とするデフォルト要素のIDを指定します。[/ja]
+   */
+
+  /**
+   * @property target
+   * @type {String}
+   * @description
+   *   [en]Specifies the ID of the default element for the popover.[/en]
+   *   [ja]ポップオーバーの対象とするデフォルト要素のIDを指定します。[/ja]
+   */
+
+  /**
    * @attribute animation
    * @type {String}
    * @description
@@ -265,8 +281,12 @@ export default class PopoverElement extends BaseDialogElement {
   _toggleStyle(shouldShow, options = {}) {
     if (shouldShow) {
       this.style.display = 'block';
-      this._currentTarget = options.target;
-      this._positionPopover(options.target);
+      let target = options.target;
+      if (!target && this.target) {
+        target = document.getElementById(this.target);
+      }
+      this._currentTarget = target;
+      this._positionPopover(target);
     } else {
       this.style.display = 'none';
       this._clearStyles();
@@ -456,6 +476,10 @@ export default class PopoverElement extends BaseDialogElement {
       options.target = options.target.target;
     }
 
+    if (!options.target && this.target) {
+      options.target = document.getElementById(this.target);
+    }
+
     if (!(options.target instanceof HTMLElement)) {
      util.throw('Invalid target type or undefined');
     }
@@ -574,6 +598,7 @@ export default class PopoverElement extends BaseDialogElement {
 }
 
 util.defineBooleanProperties(PopoverElement, ['cover-target']);
+util.defineStringProperties(PopoverElement, ['target']);
 
 onsElements.Popover = PopoverElement;
 customElements.define('ons-popover', PopoverElement);

--- a/onsenui/esm/elements/ons-popover.spec.js
+++ b/onsenui/esm/elements/ons-popover.spec.js
@@ -2,14 +2,14 @@ import contentReady from '../ons/content-ready.js';
 
 describe('OnsPopoverElement', () => {
   let popover, target;
+  const targetElmId = 'test';
   const popoverDisplay = () => window.getComputedStyle(popover).getPropertyValue('display');
 
   beforeEach(done => {
-    popover = new ons.elements.Popover();
-    target = ons._util.createElement('<div>Target</div>');
-
-    document.body.appendChild(target);
+    popover = ons._util.createElement(`<ons-popover target="${targetElmId}">Test</ons-popover>`);
+    target = ons._util.createElement(`<div id="${targetElmId}"></div>`);
     document.body.appendChild(popover);
+    document.body.appendChild(target);
 
     contentReady(popover, done);
   });
@@ -83,6 +83,7 @@ describe('OnsPopoverElement', () => {
 
   describe('#show()', () => {
     it('throws an error when called with invalid targets', () => {
+      popover = ons._util.createElement(`<ons-popover>Test</ons-popover>`);
       expect(() => popover.show()).to.throw(Error);
       expect(() => popover.show(42)).to.throw(Error);
       expect(() => popover.show({})).to.throw(Error);
@@ -266,6 +267,27 @@ describe('OnsPopoverElement', () => {
 
       setImmediate(() => {
         expect(popover._popover.style.background).to.equal('blue');
+        done();
+      });
+    });
+  });
+
+  describe('\'target\' attribute', () => {
+    it ('works on show() as the default target', (done) => {
+      setImmediate(() => {
+        // expect(popover._popover.target).to.equal(targetElmId);
+        popover.show().then(() => {
+          window.getComputedStyle(popover).getPropertyValue('display');
+          done();
+        });
+      });
+    });
+
+    it ('works on visible as the default target', (done) => {
+      setImmediate(() => {
+        popover.visible = true;
+        expect(popover.target).to.equal(targetElmId);
+        window.getComputedStyle(popover).getPropertyValue('display');
         done();
       });
     });

--- a/onsenui/esm/onsenui.d.ts
+++ b/onsenui/esm/onsenui.d.ts
@@ -888,6 +888,10 @@ declare namespace ons {
      */
     coverTarget: boolean;
     /**
+     * @description Specifies the ID of the default element for the popover.
+     */
+    target: string;
+    /**
      * @description Retrieve the back- button handler.
      */
     onDeviceBackButton: any;


### PR DESCRIPTION
Added `target` property to set the default target of the popover.

Fixes #3003.