### PR TITLE
feat(ons-list-item): Add keep-tap-background-color property

### DIFF
--- a/onsenui/esm/elements/ons-list-item.js
+++ b/onsenui/esm/elements/ons-list-item.js
@@ -159,6 +159,22 @@ export default class ListItemElement extends BaseElement {
    */
 
   /**
+   * @attribute keep-tap-background-color
+   * @type {Boolean}
+   * @description
+   *  [en] Prevent from clearing the background color on `"touchmove"`, `"touchcancel"`, `"touchend"`, `"touchleave"`, `"mouseup"`, and `"mouseout"`. For this to work, the attribute "tappable" needs to be set.[/en]
+   *  [ja] この属性があると、`"touchmove"`, `"touchcancel"`, `"touchend"`, `"touchleave"`, `"mouseup"`, and `"mouseout"` イベント時に背景色がクリアされないようになります。[/ja]
+   */
+
+  /**
+   * @property keepTapBackgroundColor
+   * @type {Boolean}
+   * @description
+   *   [en] Prevent from clearing the background color on `"touchmove"`, `"touchcancel"`, `"touchend"`, `"touchleave"`, `"mouseup"`, and `"mouseout"`. For this to work, the attribute "tappable" needs to be set.[/en]
+   *   [ja] この属性があると、`"touchmove"`, `"touchcancel"`, `"touchend"`, `"touchleave"`, `"mouseup"`, and `"mouseout"` イベント時に背景色がクリアされないようになります。[/ja]
+   */
+
+  /**
    * @attribute expandable
    * @type {Boolean}
    * @description
@@ -372,6 +388,17 @@ export default class ListItemElement extends BaseElement {
     this.expanded = !this.expanded;
   }
 
+  /**
+   * @method clearTapBackgroundColor
+   * @signature clearTapBackgroundColor()
+   * @description
+   *   [en]Clear backgroundColor changed on tap or click. This method is helpful when `keep-tap-background-color` is `true`. [/en]
+   *   [ja]タップやクリックした時に効果が表示されるようになります。このメソッドは `keep-tap-background-color` が `true` のときに使用します。[/ja]
+   */
+  clearTapBackgroundColor() {
+    this._clearTapBackgroundColor();
+  }
+
   _animateExpansion() {
     // Stops the animation from running in the case where the list item should start already expanded
     const expandedAtStartup = this.expanded && this.classList.contains('list-item--expanded');
@@ -511,12 +538,18 @@ export default class ListItemElement extends BaseElement {
 
   _onRelease() {
     this.tapped = false;
-    this.style.backgroundColor = this._originalBackgroundColor || '';
+    if (!this.keepTapBackgroundColor) {
+      this._clearTapBackgroundColor();
+    }
     styler.clear(this, 'transition boxShadow');
+  }
+
+  _clearTapBackgroundColor() {
+    this.style.backgroundColor = this._originalBackgroundColor || '';
   }
 }
 
-util.defineBooleanProperties(ListItemElement, ['expanded', 'expandable', 'tappable', 'lock-on-drag']);
+util.defineBooleanProperties(ListItemElement, ['expanded', 'expandable', 'tappable', 'lock-on-drag', 'keep-tap-background-color']);
 util.defineStringProperties(ListItemElement, ['animation', 'tap-background-color']);
 
 onsElements.ListItem = ListItemElement;

--- a/onsenui/esm/elements/ons-list-item.spec.js
+++ b/onsenui/esm/elements/ons-list-item.spec.js
@@ -200,24 +200,58 @@ describe('OnsListItemElement', () => {
   });
 
   describe('#_onRelease()', () => {
-    it('should restore the background color.', () => {
-      const origColor = 'rgb(250, 250, 250)';
-      const newColor = 'rgb(255, 255, 255)';
+    let origColor;
+    let newColor;
+    let elt;
+    let dummyEvent;
+    beforeEach(() => {
+      origColor = 'rgb(250, 250, 250)';
+      newColor = 'rgb(255, 255, 255)';
 
-      var elt = ons._util.createElement('<div>content</div>');
+      elt = ons._util.createElement('<div>content</div>');
 
       listItem.appendChild(elt);
 
-      const dummyEvent = {
+      dummyEvent = {
         target: elt
       };
+    });
 
+    it('should restore the background color.', () => {
       listItem.setAttribute('tappable', true);
       listItem.setAttribute('tap-background-color', newColor);
       listItem.style.backgroundColor = origColor;
       listItem._onTouch(dummyEvent);
       expect(listItem.style.backgroundColor).to.equal(newColor);
       listItem._onRelease();
+      expect(listItem.style.backgroundColor).to.equal(origColor);
+
+      listItem.removeChild(elt);
+    });
+
+    it('should not restore the background color when \'tap-background-color\` is true.', () => {
+      listItem.setAttribute('tappable', true);
+      listItem.setAttribute('tap-background-color', newColor);
+      listItem.setAttribute('keep-tap-background-color', true);
+      listItem.style.backgroundColor = origColor;
+      listItem._onTouch(dummyEvent);
+      expect(listItem.style.backgroundColor).to.equal(newColor);
+      listItem._onRelease();
+      expect(listItem.style.backgroundColor).to.equal(newColor);
+
+      listItem.removeChild(elt);
+    });
+
+    it('should restore the background color when \'clearTapBackgroundColor()\` is called.', () => {
+      listItem.setAttribute('tappable', true);
+      listItem.setAttribute('tap-background-color', newColor);
+      listItem.setAttribute('keep-tap-background-color', true);
+      listItem.style.backgroundColor = origColor;
+      listItem._onTouch(dummyEvent);
+      expect(listItem.style.backgroundColor).to.equal(newColor);
+      listItem._onRelease();
+      expect(listItem.style.backgroundColor).to.equal(newColor);
+      listItem.clearTapBackgroundColor();
       expect(listItem.style.backgroundColor).to.equal(origColor);
 
       listItem.removeChild(elt);

--- a/onsenui/esm/onsenui.d.ts
+++ b/onsenui/esm/onsenui.d.ts
@@ -1244,6 +1244,10 @@ declare namespace ons {
      */
     hideExpansion(): void;
     /**
+     * @description Clear backgroundColor changed on tap or click. This method is helpful when `keep-tap-background-color` is `true`.
+     */
+    clearTapBackgroundColor(): void;
+    /**
      * @description For expandable list items, specifies whether the expandable content is expanded or not.
      **/
     expanded: boolean;
@@ -1259,6 +1263,10 @@ declare namespace ons {
      * @description Prevent vertical scrolling when the user drags horizontally.
      **/
     lockOnDrag: boolean;
+    /**
+     * @description Prevent from clearing the background color on `"touchmove"`, `"touchcancel"`, `"touchend"`, `"touchleave"`, `"mouseup"`, and `"mouseout"`. For this to work, the attribute "tappable" needs to be set.
+     */
+    keepTapBackgroundColor: boolean;
     /**
      * @description The animation used when showing and hiding the expandable content. Can be either `"default"` or `"none"`.
      **/

--- a/react-onsenui/src/components/ListItem.jsx
+++ b/react-onsenui/src/components/ListItem.jsx
@@ -37,6 +37,17 @@ const propTypes = {
   tapBackgroundColor: PropTypes.string,
 
   /**
+   * @name keepTapBackgroundColor
+   * @type bool
+   * @description
+   *  [en]
+   *  Prevent from clearing the background color on `"touchmove"`, `"touchcancel"`, `"touchend"`, `"touchleave"`, `"mouseup"`, and `"mouseout"`. For this to work, the attribute "tappable" needs to be set.
+   *  [/en]
+   *  [ja][/ja]
+   */
+  keepTapBackgroundColor: PropTypes.bool,
+
+  /**
    * @name lockOnDrag
    * @type bool
    * @description


### PR DESCRIPTION
Added `keep-tap-background-color` property to prevent from clearing the background color on `"touchmove"`, `"touchcancel"`, `"touchend"`, `"touchleave"`, `"mouseup"`, and `"mouseout"`. For this to work, the attribute "tappable" needs to be set.

Fixes #2626.