### PR TITLE
feat: fix issue-3042 (modelInputNumber)

### DIFF
--- a/vue-onsenui/src/mixins/model.js
+++ b/vue-onsenui/src/mixins/model.js
@@ -48,7 +48,7 @@ const modelInputNumber = {
   mixins: [modelInput],
   methods: {
     _onModelEvent(event) {
-      this.$emit('update:modelValue', event.target.valueAsNumber);
+      this.$emit(model.event, event.target.valueAsNumber);
     }
   }
 }


### PR DESCRIPTION
Fix the issue 3042.

The event `update:modelValue` is for onsenui-vue3.
But `model.event` is correct for onsenui-vue.

