### PR TITLE
fix: this.visible cause attributeChangedCallback to trigger multiple times

### DIFF
--- a/onsenui/esm/elements/base/base-dialog.js
+++ b/onsenui/esm/elements/base/base-dialog.js
@@ -81,24 +81,15 @@ export default class BaseDialogElement extends BaseElement {
   }
 
   show(...args) {
-    return this._setVisible(true, ...args).then(dialog => {
-      this.visible = true;
-      return dialog;
-    });
+    return this._setVisible(true, ...args);
   }
 
   hide(...args) {
-    return this._setVisible(false, ...args).then(dialog => {
-      this.visible = false;
-      return dialog;
-    });
+    return this._setVisible(false, ...args);
   }
 
   toggle(...args) {
-    return this._setVisible(!this.visible, ...args).then(dialog => {
-      this.visible = this._visible;
-      return dialog;
-    });
+    return this._setVisible(!this.visible, ...args);
   }
 
   _setVisible(shouldShow, options = {}) {


### PR DESCRIPTION
1. multiple assignments of this.visible cause attributeChangedCallback to trigger multiple times
2. `this.visible` has been assigned a value in the `this._setVisible` function, and needs to be assigned again in other functions (repeated assignment)
4. fix https://github.com/OnsenUI/OnsenUI/issues/3066
