### PR TITLE
Ensure correct page return, when inserting several pages at once

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,0 +1,5 @@
+# Patches on top of OnsenUI
+
+
+* 2024-04-10 [#2 Store page meta info of last loaded page](doc/patches/02_store-page-meta-info.md)
+* 2024-02-15 [#1 Wrong page element returned, when inserting several pages](doc/patches/01_wrong-page-element-returned.md)

--- a/doc/patches/01_wrong-page-element-returned.md
+++ b/doc/patches/01_wrong-page-element-returned.md
@@ -1,0 +1,48 @@
+# Patch #1 (2024-02-15)
+## Wrong page element returned, when inserting several pages
+
+__Environment__
+
+Onsen UI Version:
+<!-- e.g. 2.9.2 -->
+- 2.12.8
+
+Framework:
+<!-- e.g. Vue 2.5.0 -->
+- JavaScript
+
+Framework binding:
+<!-- e.g. vue-onsenui 2.5.1 -->
+- none
+
+Additional libraries:
+<!-- e.g. jQuery 3.3.1 -->
+- none
+
+Platform:
+<!-- e.g. Android 8.1 Cordova, iOS 11.3 Safari, Windows 10 Chrome -->
+- Windows 10 Chome
+
+__Encountered problem__
+<!-- Outline the behaviour you're seeing, and what you would expect to see -->
+
+When inserting several Pages at the same time, the resolved Promise does not return the correct page elements.
+
+__How to reproduce__
+<!-- Write a detailed step-by-step on how to reproduce your issue -->
+
+```js
+['my-page-1.html', 'my-page-2.html', 'my-page-3.html'].forEach((page) => {
+   document.querySelector('ons-navigator').insertPage(0, page).then((el) => {
+     console.log(el); // always returns my-page-3
+   });
+})
+```
+
+The problem is, that the insertPage method return pages[index] instead of the actual page element. When pages are added at the "same" time, like a loop, then the last element "wins", as there is some delay between the promise resolving.
+
+
+
+
+Fixed with commits:
+* https://github.com/magynhard/OnsenUI/commit/5ead78980a432e35b91d62a59a288097299e6af1

--- a/doc/patches/02_store-page-meta-info.md
+++ b/doc/patches/02_store-page-meta-info.md
@@ -1,0 +1,35 @@
+# Patch #2 (2024-04-10)
+## Store page meta info of last loaded page
+
+
+__Encountered problem__
+
+When a page is loaded, additional meta info like file path can be very helpful, so this information should be provided.
+
+__How to reproduce__
+
+```js
+document.addEventListener('init', function (event) {
+    // The event only contains the element, but no other page details
+});
+```
+
+__Solution__
+
+```js
+document.addEventListener('init', function (event) {
+  console.log(ons._meta); // provies additional info
+    //  {
+    //      PageLoader: {
+    //          page: "views/example.html", 
+    //          parent: HTMLElement, 
+    //          params: {}
+    //      }
+    // }
+});
+```
+
+
+
+Done with commits:
+* https://github.com/magynhard/OnsenUI/commit/b04374d9494c48b09235152aa2f6998a23e19685

--- a/onsenui/README.md
+++ b/onsenui/README.md
@@ -1,3 +1,9 @@
+```diff
+- Patched fork of OnsenUI, as OnsenUI project seems not really to be maintained any more. 
+```
+
+You can find a list of all applied patches [here](PATCHES.md).
+
 
 <p align="center"><a href="https://onsen.io/" target="_blank"><img width="140" src="https://onsenui.github.io/art/logos/onsenui-logo-1.png"></a></p>
 

--- a/onsenui/esm/elements/ons-navigator.js
+++ b/onsenui/esm/elements/ons-navigator.js
@@ -756,8 +756,7 @@ export default class NavigatorElement extends BaseElement {
         this.topPage.updateBackButton(true);
 
         setTimeout(() => {
-          pageElement = null;
-          resolve(this.pages[index]);
+          resolve(pageElement);
         }, 1000 / 60);
       });
     });

--- a/onsenui/esm/ons/page-loader.js
+++ b/onsenui/esm/ons/page-loader.js
@@ -70,7 +70,15 @@ export class PageLoader {
       if (!(pageElement instanceof Element)) {
         throw Error('pageElement must be an instance of Element.');
       }
-
+      // store meta info
+      if (ons) {
+        if(!ons._meta) {
+            ons._meta = {};
+        }
+        ons._meta.PageLoader = {
+            page, parent, params
+        };
+      }
       done(pageElement);
     }, error);
   }

--- a/onsenui/esm/ons/page-loader.js
+++ b/onsenui/esm/ons/page-loader.js
@@ -72,7 +72,7 @@ export class PageLoader {
       }
       // store meta info
       if (ons) {
-        if(!ons._meta) {
+        if (!ons._meta) {
             ons._meta = {};
         }
         ons._meta.PageLoader = {

--- a/onsenui/karma.conf.js
+++ b/onsenui/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'js/onsenui.js',
+      'js/onsenui.magynhard.js',
       'test/unit/setup.js',
       `test/unit/browser-${global.KARMA_BROWSER}.js`, // no error occurs even if not found
       global.KARMA_DISABLE_WARNINGS ? 'test/unit/disable-warnings.js' : null,

--- a/onsenui/package.json
+++ b/onsenui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onsenui",
-  "version": "2.100.1",
+  "version": "2.100.2",
   "description": "HTML5 Mobile Framework & UI Components",
   "private": false,
   "scripts": {

--- a/onsenui/package.json
+++ b/onsenui/package.json
@@ -1,11 +1,11 @@
 {
   "name": "onsenui",
-  "version": "2.12.8",
+  "version": "2.100.1",
   "description": "HTML5 Mobile Framework & UI Components",
   "private": false,
   "scripts": {
     "build": "npm run build:umd && npm run build:css",
-    "build:umd": "rollup --config && uglifyjs js/onsenui.js -c -m --comments '/onsenui v/' --output js/onsenui.min.js",
+    "build:umd": "rollup --config && uglifyjs js/onsenui.magynhard.js -c -m --comments '/onsenui v/' --output js/onsenui.magynhard.min.js",
     "build:css": "npm run build:css:lint && npm run build:css:core && npm run build:css:components && npm run build:css:minify",
     "build:css:minify": "npm run build:css:minify:onsenui && npm run build:css:minify:onsenuicore && npm run build:css:minify:component",
     "build:css:minify:onsenui": "cleancss 'css/onsenui.css' --batch --batch-suffix '.min' --inline none --with-rebase -o css/",
@@ -23,7 +23,7 @@
     "test:unit": "node scripts/unit-test.js",
     "test:core-dts": "node scripts/core-dts-test.js"
   },
-  "main": "js/onsenui.js",
+  "main": "js/onsenui.magynhard.js",
   "module": "esm/index.js",
   "typings": "esm/onsenui.d.ts",
   "files": [

--- a/onsenui/rollup.config.js
+++ b/onsenui/rollup.config.js
@@ -18,7 +18,7 @@ export default [
   {
     input: `${srcDir}/index.umd.js`,
     output: {
-      file: `${buildDir}/onsenui.js`,
+      file: `${buildDir}/onsenui.magynhard.js`,
       format: 'umd',
       name: 'ons',
       sourcemap: 'inline',


### PR DESCRIPTION
Fixes issue #3076 by resolving the actual page element instead of the index which is wrong in the described use case.