### PR TITLE
Add resolutions for iPhone16 Pro and iPhone16 Pro Max

### DIFF
--- a/onsenui/esm/ons/platform.js
+++ b/onsenui/esm/ons/platform.js
@@ -135,7 +135,15 @@ class Platform {
 
           // 14 Pro
         window.screen.width === 393 && window.screen.height === 852 ||// portrait
-        window.screen.width === 852 && window.screen.height === 393 // landscape
+        window.screen.width === 852 && window.screen.height === 393 ||// landscape
+
+        // 16 Pro
+        window.screen.width === 402 && window.screen.height === 874 || // portrait
+        window.screen.width === 874 && window.screen.height === 402 ||// landscape
+
+        // 16 Pro Max
+        window.screen.width === 440 && window.screen.height === 956 || // portrait
+        window.screen.width === 956 && window.screen.height === 440 // landscape
       );
   }
 


### PR DESCRIPTION
This fixes the problem that isIPhoneX() returns false for iPhone 16 Pro, and 16 Pro Max.
https://onsen.io/v2/guide/iphonex.html