### PR TITLE
feat: add safe area inset API for newer iPhones

### DIFF
--- a/onsenui/css/css-components-src/iphonex-support/global.css
+++ b/onsenui/css/css-components-src/iphonex-support/global.css
@@ -10,22 +10,22 @@
   --iphonex-safe-area-inset-left-landscape: 44px;
 }
 
-@supports (padding: env(safe-area-inset-top)) {
+@supports (padding: max(env(safe-area-inset-top, 0px), 0px)) {
   @media (orientation: portrait) {
     :root {
-      --iphonex-safe-area-inset-top-portrait: env(safe-area-inset-top);
-      --iphonex-safe-area-inset-right-portrait: env(safe-area-inset-right);
-      --iphonex-safe-area-inset-bottom-portrait: env(safe-area-inset-bottom);
-      --iphonex-safe-area-inset-left-portrait: env(safe-area-inset-left);
+      --iphonex-safe-area-inset-top-portrait: max(env(safe-area-inset-top, 0px), 44px);
+      --iphonex-safe-area-inset-right-portrait: env(safe-area-inset-right, 0px);
+      --iphonex-safe-area-inset-bottom-portrait: max(env(safe-area-inset-bottom, 0px), 34px);
+      --iphonex-safe-area-inset-left-portrait: env(safe-area-inset-left, 0px);
     }
   }
 
   @media (orientation: landscape) {
     :root {
-      --iphonex-safe-area-inset-top-landscape: env(safe-area-inset-top);
-      --iphonex-safe-area-inset-right-landscape: env(safe-area-inset-right);
-      --iphonex-safe-area-inset-bottom-landscape: env(safe-area-inset-bottom);
-      --iphonex-safe-area-inset-left-landscape: env(safe-area-inset-left);
+      --iphonex-safe-area-inset-top-landscape: env(safe-area-inset-top, 0px);
+      --iphonex-safe-area-inset-right-landscape: max(env(safe-area-inset-right, 0px), 44px);
+      --iphonex-safe-area-inset-bottom-landscape: max(env(safe-area-inset-bottom, 0px), 21px);
+      --iphonex-safe-area-inset-left-landscape: max(env(safe-area-inset-left, 0px), 44px);
     }
   }
 }

--- a/onsenui/css/css-components-src/iphonex-support/global.css
+++ b/onsenui/css/css-components-src/iphonex-support/global.css
@@ -10,22 +10,22 @@
   --iphonex-safe-area-inset-left-landscape: 44px;
 }
 
-@media (orientation: portrait) {
-  :root {
-    /* env() returns the exact value with fallback */
-    --iphonex-safe-area-inset-top-portrait: env(safe-area-inset-top, 44px);
-    --iphonex-safe-area-inset-right-portrait: env(safe-area-inset-right, 0px);
-    --iphonex-safe-area-inset-bottom-portrait: env(safe-area-inset-bottom, 34px);
-    --iphonex-safe-area-inset-left-portrait: env(safe-area-inset-left, 0px);
+@supports (padding: env(safe-area-inset-top)) {
+  @media (orientation: portrait) {
+    :root {
+      --iphonex-safe-area-inset-top-portrait: env(safe-area-inset-top);
+      --iphonex-safe-area-inset-right-portrait: env(safe-area-inset-right);
+      --iphonex-safe-area-inset-bottom-portrait: env(safe-area-inset-bottom);
+      --iphonex-safe-area-inset-left-portrait: env(safe-area-inset-left);
+    }
   }
-}
 
-@media (orientation: landscape) {
-  :root {
-    /* env() returns the exact value with fallback */
-    --iphonex-safe-area-inset-top-landscape: env(safe-area-inset-top, 0px);
-    --iphonex-safe-area-inset-right-landscape: env(safe-area-inset-right, 44px);
-    --iphonex-safe-area-inset-bottom-landscape: env(safe-area-inset-bottom, 21px);
-    --iphonex-safe-area-inset-left-landscape: env(safe-area-inset-left, 44px);
+  @media (orientation: landscape) {
+    :root {
+      --iphonex-safe-area-inset-top-landscape: env(safe-area-inset-top);
+      --iphonex-safe-area-inset-right-landscape: env(safe-area-inset-right);
+      --iphonex-safe-area-inset-bottom-landscape: env(safe-area-inset-bottom);
+      --iphonex-safe-area-inset-left-landscape: env(safe-area-inset-left);
+    }
   }
 }

--- a/onsenui/css/css-components-src/iphonex-support/global.css
+++ b/onsenui/css/css-components-src/iphonex-support/global.css
@@ -9,3 +9,23 @@
   --iphonex-safe-area-inset-bottom-landscape: 21px;
   --iphonex-safe-area-inset-left-landscape: 44px;
 }
+
+@media (orientation: portrait) {
+  :root {
+    /* env() returns the exact value with fallback */
+    --iphonex-safe-area-inset-top-portrait: env(safe-area-inset-top, 44px);
+    --iphonex-safe-area-inset-right-portrait: env(safe-area-inset-right, 0px);
+    --iphonex-safe-area-inset-bottom-portrait: env(safe-area-inset-bottom, 34px);
+    --iphonex-safe-area-inset-left-portrait: env(safe-area-inset-left, 0px);
+  }
+}
+
+@media (orientation: landscape) {
+  :root {
+    /* env() returns the exact value with fallback */
+    --iphonex-safe-area-inset-top-landscape: env(safe-area-inset-top, 0px);
+    --iphonex-safe-area-inset-right-landscape: env(safe-area-inset-right, 44px);
+    --iphonex-safe-area-inset-bottom-landscape: env(safe-area-inset-bottom, 21px);
+    --iphonex-safe-area-inset-left-landscape: env(safe-area-inset-left, 44px);
+  }
+}

--- a/onsenui/esm/elements/ons-action-sheet/animator.js
+++ b/onsenui/esm/elements/ons-action-sheet/animator.js
@@ -120,9 +120,11 @@ export class IOSActionSheetAnimator extends ActionSheetAnimator {
     this.maskTiming = 'linear';
     this.maskDuration = 0.2;
     if (iPhoneXPatch.isIPhoneXPortraitPatchActive()) {
-      this.liftAmount = 'calc(100% + 48px)';
+      const bottom = iPhoneXPatch.getSafeAreaLengths().bottom;
+      this.liftAmount = `calc(100% + ${bottom + 14}px)`; // bottom safe area + 14px extra margin (from action-sheet.css)
     } else if (iPhoneXPatch.isIPhoneXLandscapePatchActive()) {
-      this.liftAmount = 'calc(100% + 33px)';
+      const bottom = iPhoneXPatch.getSafeAreaLengths().bottom;
+      this.liftAmount = `calc(100% + ${bottom + 12}px)`; // bottom safe area + 12px extra margin (from action-sheet.css)
     } else {
       this.liftAmount = document.body.clientHeight / 2.0 - 1 + 'px'; // avoid Forced Synchronous Layout
     }

--- a/onsenui/esm/elements/ons-toast/ascend-animator.js
+++ b/onsenui/esm/elements/ons-toast/ascend-animator.js
@@ -34,13 +34,7 @@ export default class AscendToastAnimator extends ToastAnimator {
     if (platform.isAndroid()) {
       this.ascension = 48; // Toasts are always 1 line
     } else {
-      if (iPhoneXPatch.isIPhoneXPortraitPatchActive()) {
-        this.ascension = 98; // 64 + 34
-      } else if (iPhoneXPatch.isIPhoneXLandscapePatchActive()) {
-        this.ascension = 85; // 64 + 21
-      } else {
-        this.ascension = 64;
-      }
+      this.ascension = 64 + iPhoneXPatch.getSafeAreaLengths().bottom;
     }
   }
 

--- a/onsenui/esm/elements/ons-toast/fall-animator.js
+++ b/onsenui/esm/elements/ons-toast/fall-animator.js
@@ -28,11 +28,8 @@ export default class FallToastAnimator extends ToastAnimator {
 
   constructor({ timing = 'ease', delay = 0, duration = 0.35 } = {}) {
     super({ timing, delay, duration });
-    if (iPhoneXPatch.isIPhoneXPortraitPatchActive()) {
-      this.fallAmount = 'calc(-100% - 44px)';
-    } else {
-      this.fallAmount = '-100%';
-    }
+    const top = iPhoneXPatch.getSafeAreaLengths().top;
+    this.fallAmount = top > 0 ? `calc(-100% - ${top}px)` : '-100%';
   }
 
   /**
@@ -79,12 +76,8 @@ export default class FallToastAnimator extends ToastAnimator {
   }
 
   _updatePosition(toast, cleanUp) {
-    let correctTop;
-    if (iPhoneXPatch.isIPhoneXPortraitPatchActive()) {
-      correctTop = '44px';
-    } else {
-      correctTop = '0';
-    }
+    const topInset = iPhoneXPatch.getSafeAreaLengths().top;
+    const correctTop = topInset > 0 ? `${topInset}px` : '0';
 
     if (toast.style.top !== correctTop) {
       toast.style.top = correctTop;

--- a/onsenui/esm/elements/ons-toast/lift-animator.js
+++ b/onsenui/esm/elements/ons-toast/lift-animator.js
@@ -29,13 +29,8 @@ export default class LiftToastAnimator extends ToastAnimator {
   constructor({ timing = 'ease', delay = 0, duration = 0.35 } = {}) {
     super({ timing, delay, duration });
     this.bodyHeight = document.body.clientHeight; // avoid Forced Synchronous Layout
-    if (iPhoneXPatch.isIPhoneXPortraitPatchActive()) {
-      this.liftAmount = 'calc(100% + 34px)';
-    } else if (iPhoneXPatch.isIPhoneXLandscapePatchActive()) {
-      this.liftAmount = 'calc(100% + 21px)';
-    } else {
-      this.liftAmount = '100%';
-    }
+    const bottom = iPhoneXPatch.getSafeAreaLengths().bottom;
+    this.liftAmount = bottom > 0 ? `calc(100% + ${bottom}px)` : '100%';
   }
 
   /**

--- a/onsenui/esm/ons/iphonex-patch.js
+++ b/onsenui/esm/ons/iphonex-patch.js
@@ -15,6 +15,8 @@ limitations under the License.
 
 */
 
+import platform from './platform.js';
+
 // This object should not be exposed to users. Please keep this private.
 const iPhoneXPatch = {};
 
@@ -31,60 +33,29 @@ iPhoneXPatch.isIPhoneXLandscapePatchActive = () => {
  * Returns the safe area lengths based on the current state of the safe areas.
  */
 iPhoneXPatch.getSafeAreaLengths = () => {
-  let safeAreaLengths;
-  if (iPhoneXPatch.isIPhoneXPortraitPatchActive()) {
-    safeAreaLengths = {
-      top: 44,
-      right: 0,
-      bottom: 34,
-      left: 0
-    };
-  } else if (iPhoneXPatch.isIPhoneXLandscapePatchActive()) {
-    safeAreaLengths = {
-      top: 0,
-      right: 44,
-      bottom: 21,
-      left: 44
-    };
-  } else {
-    safeAreaLengths = {
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0
-    };
+  if (iPhoneXPatch.isIPhoneXPortraitPatchActive() || iPhoneXPatch.isIPhoneXLandscapePatchActive()) {
+    return platform.getSafeAreaInsets();
   }
 
-  return safeAreaLengths;
+  return {
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0
+  };
 };
 
 /**
  * Returns the safe area rect based on the current state of the safe areas.
  */
 iPhoneXPatch.getSafeAreaDOMRect = () => {
-  let safeAreaRect;
-  if (iPhoneXPatch.isIPhoneXPortraitPatchActive()) {
-    safeAreaRect = {
-      x: 0,
-      y: 44, /* 0 + 44 (top safe area) */
-      width: window.innerWidth,
-      height: window.innerHeight - 78 /* height - 44 (top safe area) - 34 (bottom safe area) */
-    };
-  } else if (iPhoneXPatch.isIPhoneXLandscapePatchActive()) {
-    safeAreaRect = {
-      x: 44, /* 0 + 44 (left safe area) */
-      y: 0,
-      width: window.innerWidth - 88, /* width - 44 (left safe area) - 34 (right safe area) */
-      height: window.innerHeight - 21 /* height - 21 (bottom safe area) */
-    };
-  } else {
-    safeAreaRect = {
-      x: 0,
-      y: 0,
-      width: window.innerWidth,
-      height: window.innerHeight
-    };
-  }
+  const insets = iPhoneXPatch.getSafeAreaLengths();
+  const safeAreaRect = {
+    x: insets.left,
+    y: insets.top,
+    width: window.innerWidth - insets.left - insets.right,
+    height: window.innerHeight - insets.top - insets.bottom
+  };
 
   return {
     ...safeAreaRect,

--- a/onsenui/esm/ons/platform.js
+++ b/onsenui/esm/ons/platform.js
@@ -165,51 +165,17 @@ class Platform {
     }
 
     const isPortrait = window.innerHeight > window.innerWidth;
-    let insets = { top: 0, right: 0, bottom: 0, left: 0 };
+    const suffix = isPortrait ? 'portrait' : 'landscape';
 
-    // Determine device based on screen size
-    const width = window.screen.width;
-    const height = window.screen.height;
+    const root = document.documentElement;
+    const computedStyle = getComputedStyle(root);
 
-    if ((width === 375 && height === 812) || (width === 812 && height === 375)) {
-       // X, XS, 11 Pro, 12 Mini, 13 Mini
-      insets = isPortrait ? { top: 44, right: 0, bottom: 34, left: 0 } :
-       { top: 0, right: 44, bottom: 21, left: 44 };
-    } else if ((width === 414 && height === 896) || (width === 896 && height === 414)) {
-       // XS Max, XR, 11, 11 Pro Max
-      insets = isPortrait ? { top: 44, right: 0, bottom: 34, left: 0 } :
-       { top: 0, right: 44, bottom: 21, left: 44 };
-    } else if ((width === 390 && height === 844) || (width === 844 && height === 390)) {
-       // 12, 12 Pro, 13, 13 Pro, 14
-      insets = isPortrait ? { top: 47, right: 0, bottom: 34, left: 0 } :
-       { top: 0, right: 47, bottom: 21, left: 47 };
-    } else if ((width === 428 && height === 926) || (width === 926 && height === 428)) {
-       // 12 Pro Max, 13 Pro Max, 14 Plus
-      insets = isPortrait ? { top: 47, right: 0, bottom: 34, left: 0 } :
-       { top: 0, right: 47, bottom: 21, left: 47 };
-    } else if ((width === 393 && height === 852) || (width === 852 && height === 393)) {
-       // 14 Pro, 15, 15 Pro, 16
-      insets = isPortrait ? { top: 59, right: 0, bottom: 34, left: 0 } :
-       { top: 0, right: 59, bottom: 21, left: 59 };
-    } else if ((width === 430 && height === 932) || (width === 932 && height === 430)) {
-       // 14 Pro Max, 15 Plus, 15 Pro Max, 16 Plus
-      insets = isPortrait ? { top: 59, right: 0, bottom: 34, left: 0 } :
-       { top: 0, right: 59, bottom: 21, left: 59 };
-    } else if ((width === 402 && height === 874) || (width === 874 && height === 402)) {
-       // 16 Pro, 17, 17 Pro
-      insets = isPortrait ? { top: 62, right: 0, bottom: 34, left: 0 } :
-       { top: 20, right: 62, bottom: 20, left: 62 };
-    } else if ((width === 440 && height === 956) || (width === 956 && height === 440)) {
-       // 16 Pro Max, 17 Pro Max
-      insets = isPortrait ? { top: 62, right: 0, bottom: 34, left: 0 } :
-       { top: 20, right: 62, bottom: 20, left: 62 };
-    } else if ((width === 420 && height === 912) || (width === 912 && height === 420)) {
-       // Air
-      insets = isPortrait ? { top: 68, right: 0, bottom: 34, left: 0 } :
-       { top: 20, right: 68, bottom: 20, left: 68 };
-    }
+    const top = parseInt(computedStyle.getPropertyValue(`--iphonex-safe-area-inset-top-${suffix}`), 10) || 0;
+    const right = parseInt(computedStyle.getPropertyValue(`--iphonex-safe-area-inset-right-${suffix}`), 10) || 0;
+    const bottom = parseInt(computedStyle.getPropertyValue(`--iphonex-safe-area-inset-bottom-${suffix}`), 10) || 0;
+    const left = parseInt(computedStyle.getPropertyValue(`--iphonex-safe-area-inset-left-${suffix}`), 10) || 0;
 
-    return insets;
+    return { top, right, bottom, left };
   }
 
   /**

--- a/onsenui/esm/ons/platform.js
+++ b/onsenui/esm/ons/platform.js
@@ -152,6 +152,49 @@ class Platform {
   }
 
   /**
+   * @method getSafeAreaInsets
+   * @signature getSafeAreaInsets()
+   * @description
+   *   [en]Returns the safe area insets for the current device and orientation in pixels. Returns {top: 0, right: 0, bottom: 0, left: 0} if not applicable.[/en]
+   *   [ja]現在のデバイスと向きのセーフエリアのインセットをピクセル単位で返します。該当しない場合は {top: 0, right: 0, bottom: 0, left: 0} を返します。[/ja]
+   * @return {Object}
+   */
+  getSafeAreaInsets() {
+    if (!this.isIPhone()) {
+      return { top: 0, right: 0, bottom: 0, left: 0 };
+    }
+
+    const isPortrait = window.innerHeight > window.innerWidth;
+    let insets = { top: 0, right: 0, bottom: 0, left: 0 };
+
+    // Determine device based on screen size
+    const width = window.screen.width;
+    const height = window.screen.height;
+
+    if ((width === 375 && height === 812) || (width === 812 && height === 375)) { // X, XS, 11 Pro, 12 Mini, 13 Mini
+      insets = isPortrait ? { top: 44, right: 0, bottom: 34, left: 0 } : { top: 0, right: 44, bottom: 21, left: 44 };
+    } else if ((width === 414 && height === 896) || (width === 896 && height === 414)) { // XS Max, XR, 11, 11 Pro Max
+      insets = isPortrait ? { top: 44, right: 0, bottom: 34, left: 0 } : { top: 0, right: 44, bottom: 21, left: 44 };
+    } else if ((width === 390 && height === 844) || (width === 844 && height === 390)) { // 12, 12 Pro, 13, 13 Pro, 14
+      insets = isPortrait ? { top: 47, right: 0, bottom: 34, left: 0 } : { top: 0, right: 47, bottom: 21, left: 47 };
+    } else if ((width === 428 && height === 926) || (width === 926 && height === 428)) { // 12 Pro Max, 13 Pro Max, 14 Plus
+      insets = isPortrait ? { top: 47, right: 0, bottom: 34, left: 0 } : { top: 0, right: 47, bottom: 21, left: 47 };
+    } else if ((width === 393 && height === 852) || (width === 852 && height === 393)) { // 14 Pro, 15, 15 Pro, 16
+      insets = isPortrait ? { top: 59, right: 0, bottom: 34, left: 0 } : { top: 0, right: 59, bottom: 21, left: 59 };
+    } else if ((width === 430 && height === 932) || (width === 932 && height === 430)) { // 14 Pro Max, 15 Plus, 15 Pro Max, 16 Plus
+      insets = isPortrait ? { top: 59, right: 0, bottom: 34, left: 0 } : { top: 0, right: 59, bottom: 21, left: 59 };
+    } else if ((width === 402 && height === 874) || (width === 874 && height === 402)) { // 16 Pro, 17, 17 Pro
+      insets = isPortrait ? { top: 62, right: 0, bottom: 34, left: 0 } : { top: 0, right: 62, bottom: 21, left: 62 };
+    } else if ((width === 440 && height === 956) || (width === 956 && height === 440)) { // 16 Pro Max, 17 Pro Max
+      insets = isPortrait ? { top: 62, right: 0, bottom: 34, left: 0 } : { top: 0, right: 62, bottom: 21, left: 62 };
+    } else if ((width === 420 && height === 912) || (width === 912 && height === 420)) { // Air
+      insets = isPortrait ? { top: 59, right: 0, bottom: 34, left: 0 } : { top: 0, right: 59, bottom: 21, left: 59 };
+    }
+
+    return insets;
+  }
+
+  /**
    * @method isIPad
    * @signature isIPad()
    * @description

--- a/onsenui/esm/ons/platform.js
+++ b/onsenui/esm/ons/platform.js
@@ -171,24 +171,42 @@ class Platform {
     const width = window.screen.width;
     const height = window.screen.height;
 
-    if ((width === 375 && height === 812) || (width === 812 && height === 375)) { // X, XS, 11 Pro, 12 Mini, 13 Mini
-      insets = isPortrait ? { top: 44, right: 0, bottom: 34, left: 0 } : { top: 0, right: 44, bottom: 21, left: 44 };
-    } else if ((width === 414 && height === 896) || (width === 896 && height === 414)) { // XS Max, XR, 11, 11 Pro Max
-      insets = isPortrait ? { top: 44, right: 0, bottom: 34, left: 0 } : { top: 0, right: 44, bottom: 21, left: 44 };
-    } else if ((width === 390 && height === 844) || (width === 844 && height === 390)) { // 12, 12 Pro, 13, 13 Pro, 14
-      insets = isPortrait ? { top: 47, right: 0, bottom: 34, left: 0 } : { top: 0, right: 47, bottom: 21, left: 47 };
-    } else if ((width === 428 && height === 926) || (width === 926 && height === 428)) { // 12 Pro Max, 13 Pro Max, 14 Plus
-      insets = isPortrait ? { top: 47, right: 0, bottom: 34, left: 0 } : { top: 0, right: 47, bottom: 21, left: 47 };
-    } else if ((width === 393 && height === 852) || (width === 852 && height === 393)) { // 14 Pro, 15, 15 Pro, 16
-      insets = isPortrait ? { top: 59, right: 0, bottom: 34, left: 0 } : { top: 0, right: 59, bottom: 21, left: 59 };
-    } else if ((width === 430 && height === 932) || (width === 932 && height === 430)) { // 14 Pro Max, 15 Plus, 15 Pro Max, 16 Plus
-      insets = isPortrait ? { top: 59, right: 0, bottom: 34, left: 0 } : { top: 0, right: 59, bottom: 21, left: 59 };
-    } else if ((width === 402 && height === 874) || (width === 874 && height === 402)) { // 16 Pro, 17, 17 Pro
-      insets = isPortrait ? { top: 62, right: 0, bottom: 34, left: 0 } : { top: 0, right: 62, bottom: 21, left: 62 };
-    } else if ((width === 440 && height === 956) || (width === 956 && height === 440)) { // 16 Pro Max, 17 Pro Max
-      insets = isPortrait ? { top: 62, right: 0, bottom: 34, left: 0 } : { top: 0, right: 62, bottom: 21, left: 62 };
-    } else if ((width === 420 && height === 912) || (width === 912 && height === 420)) { // Air
-      insets = isPortrait ? { top: 59, right: 0, bottom: 34, left: 0 } : { top: 0, right: 59, bottom: 21, left: 59 };
+    if ((width === 375 && height === 812) || (width === 812 && height === 375)) {
+       // X, XS, 11 Pro, 12 Mini, 13 Mini
+      insets = isPortrait ? { top: 44, right: 0, bottom: 34, left: 0 } :
+       { top: 0, right: 44, bottom: 21, left: 44 };
+    } else if ((width === 414 && height === 896) || (width === 896 && height === 414)) {
+       // XS Max, XR, 11, 11 Pro Max
+      insets = isPortrait ? { top: 44, right: 0, bottom: 34, left: 0 } :
+       { top: 0, right: 44, bottom: 21, left: 44 };
+    } else if ((width === 390 && height === 844) || (width === 844 && height === 390)) {
+       // 12, 12 Pro, 13, 13 Pro, 14
+      insets = isPortrait ? { top: 47, right: 0, bottom: 34, left: 0 } :
+       { top: 0, right: 47, bottom: 21, left: 47 };
+    } else if ((width === 428 && height === 926) || (width === 926 && height === 428)) {
+       // 12 Pro Max, 13 Pro Max, 14 Plus
+      insets = isPortrait ? { top: 47, right: 0, bottom: 34, left: 0 } :
+       { top: 0, right: 47, bottom: 21, left: 47 };
+    } else if ((width === 393 && height === 852) || (width === 852 && height === 393)) {
+       // 14 Pro, 15, 15 Pro, 16
+      insets = isPortrait ? { top: 59, right: 0, bottom: 34, left: 0 } :
+       { top: 0, right: 59, bottom: 21, left: 59 };
+    } else if ((width === 430 && height === 932) || (width === 932 && height === 430)) {
+       // 14 Pro Max, 15 Plus, 15 Pro Max, 16 Plus
+      insets = isPortrait ? { top: 59, right: 0, bottom: 34, left: 0 } :
+       { top: 0, right: 59, bottom: 21, left: 59 };
+    } else if ((width === 402 && height === 874) || (width === 874 && height === 402)) {
+       // 16 Pro, 17, 17 Pro
+      insets = isPortrait ? { top: 62, right: 0, bottom: 34, left: 0 } :
+       { top: 20, right: 62, bottom: 20, left: 62 };
+    } else if ((width === 440 && height === 956) || (width === 956 && height === 440)) {
+       // 16 Pro Max, 17 Pro Max
+      insets = isPortrait ? { top: 62, right: 0, bottom: 34, left: 0 } :
+       { top: 20, right: 62, bottom: 20, left: 62 };
+    } else if ((width === 420 && height === 912) || (width === 912 && height === 420)) {
+       // Air
+      insets = isPortrait ? { top: 68, right: 0, bottom: 34, left: 0 } :
+       { top: 20, right: 68, bottom: 20, left: 68 };
     }
 
     return insets;

--- a/onsenui/esm/onsenui.d.ts
+++ b/onsenui/esm/onsenui.d.ts
@@ -260,6 +260,12 @@ declare namespace ons {
     function isIPhone(): boolean;
 
     /**
+     * @description Returns the safe area insets for the current device and orientation in pixels
+     * @return {{ top: number; right: number; bottom: number; left: number }}
+     */
+    function getSafeAreaInsets(): { top: number; right: number; bottom: number; left: number };
+
+    /**
      * @description Returns whether the device is iPhone X
      * @return {Boolean}
      */

--- a/package-lock.json
+++ b/package-lock.json
@@ -39003,7 +39003,7 @@
       }
     },
     "onsenui": {
-      "version": "2.12.8",
+      "version": "2.12.9",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.15.0",


### PR DESCRIPTION
SafeAreaのサイズを個別に設定

メディアクエリーと定義済みスタイルシート定数を使って、LandscapeとPortraitの
セーフエリアを取得するようにしました。


==============================================================
以下は、PRの当初のコメントだが、スタイルシートから取得するように変更したので、無効です

この修正によりJavaScriptの
onsenui/esm/ons/iphonex-patch.js
の
iPhoneXPatch.getSafeAreaLengths
はデバイスごとに異なるセーフエリアを返すようになったが、しかし、CSSの
onsenui/css/src/iphonex-patch.css
onsenui/css/css-components-src/iphonex-support
とは別。特に
onsenui/css/css-components-src/iphonex-support
は
onsenui/css/css-components-src/iphonex-support/global.css
に定義されている
```
:root {
  --iphonex-safe-area-inset-top-portrait: 44px;
  --iphonex-safe-area-inset-right-portrait: 0;
  --iphonex-safe-area-inset-bottom-portrait: 34px;
  --iphonex-safe-area-inset-left-portrait: 0;

  --iphonex-safe-area-inset-top-landscape: 0;
  --iphonex-safe-area-inset-right-landscape: 44px;
  --iphonex-safe-area-inset-bottom-landscape: 21px;
  --iphonex-safe-area-inset-left-landscape: 44px;
}
```
などの定数 var(--iphonex-safe-area-inset-bottom-landscape)を使って計算している
ため、iPhoneXPatch.getSafeAreaLengthsに影響せず同じ値になってしまう。

