### PR TITLE
fix(onsenui): resolve safe area insets via used-value instead of parseInt

### DIFF
--- a/onsenui/esm/ons/platform.js
+++ b/onsenui/esm/ons/platform.js
@@ -167,15 +167,32 @@ class Platform {
     const isPortrait = window.innerHeight > window.innerWidth;
     const suffix = isPortrait ? 'portrait' : 'landscape';
 
-    const root = document.documentElement;
-    const computedStyle = getComputedStyle(root);
+    // The --iphonex-safe-area-inset-* custom properties hold unevaluated
+    // max()/env() expressions, so reading them via getPropertyValue() returns a
+    // string like "max(0px, 44px)" and parseInt() yields NaN (-> 0). Apply the
+    // variables to a real property on a probe element instead: the browser
+    // resolves max()/env() at used-value time, so getComputedStyle() returns
+    // concrete pixels.
+    const probe = document.createElement('div');
+    probe.style.cssText =
+      'position:absolute;top:0;left:0;width:0;height:0;visibility:hidden;pointer-events:none;' +
+      `padding-top:var(--iphonex-safe-area-inset-top-${suffix}, 0px);` +
+      `padding-right:var(--iphonex-safe-area-inset-right-${suffix}, 0px);` +
+      `padding-bottom:var(--iphonex-safe-area-inset-bottom-${suffix}, 0px);` +
+      `padding-left:var(--iphonex-safe-area-inset-left-${suffix}, 0px);`;
+    document.documentElement.appendChild(probe);
 
-    const top = parseInt(computedStyle.getPropertyValue(`--iphonex-safe-area-inset-top-${suffix}`), 10) || 0;
-    const right = parseInt(computedStyle.getPropertyValue(`--iphonex-safe-area-inset-right-${suffix}`), 10) || 0;
-    const bottom = parseInt(computedStyle.getPropertyValue(`--iphonex-safe-area-inset-bottom-${suffix}`), 10) || 0;
-    const left = parseInt(computedStyle.getPropertyValue(`--iphonex-safe-area-inset-left-${suffix}`), 10) || 0;
+    const computedStyle = getComputedStyle(probe);
+    const insets = {
+      top: parseFloat(computedStyle.paddingTop) || 0,
+      right: parseFloat(computedStyle.paddingRight) || 0,
+      bottom: parseFloat(computedStyle.paddingBottom) || 0,
+      left: parseFloat(computedStyle.paddingLeft) || 0
+    };
 
-    return { top, right, bottom, left };
+    probe.remove();
+
+    return insets;
   }
 
   /**

--- a/onsenui/esm/ons/platform.spec.js
+++ b/onsenui/esm/ons/platform.spec.js
@@ -121,6 +121,55 @@ describe('ons.platform', () => {
     });
   });
 
+  describe('#getSafeAreaInsets()', () => {
+    let styleEl;
+
+    beforeEach(() => {
+      // Mirror the shipped iphonex-support/global.css rules so the custom
+      // properties hold unevaluated max()/env() expressions, as on a real
+      // device. This guards against reading them with parseInt(), which would
+      // yield NaN -> 0 (see getSafeAreaInsets implementation).
+      styleEl = document.createElement('style');
+      styleEl.textContent =
+        '@supports (padding: max(env(safe-area-inset-top, 0px), 0px)) {' +
+        '  @media (orientation: portrait) { :root {' +
+        '    --iphonex-safe-area-inset-top-portrait: max(env(safe-area-inset-top, 0px), 44px);' +
+        '    --iphonex-safe-area-inset-right-portrait: env(safe-area-inset-right, 0px);' +
+        '    --iphonex-safe-area-inset-bottom-portrait: max(env(safe-area-inset-bottom, 0px), 34px);' +
+        '    --iphonex-safe-area-inset-left-portrait: env(safe-area-inset-left, 0px);' +
+        '  } }' +
+        '  @media (orientation: landscape) { :root {' +
+        '    --iphonex-safe-area-inset-top-landscape: env(safe-area-inset-top, 0px);' +
+        '    --iphonex-safe-area-inset-right-landscape: max(env(safe-area-inset-right, 0px), 44px);' +
+        '    --iphonex-safe-area-inset-bottom-landscape: max(env(safe-area-inset-bottom, 0px), 21px);' +
+        '    --iphonex-safe-area-inset-left-landscape: max(env(safe-area-inset-left, 0px), 44px);' +
+        '  } }' +
+        '}';
+      document.head.appendChild(styleEl);
+    });
+
+    afterEach(() => {
+      delete ons.platform.isIPhone;
+      styleEl.remove();
+    });
+
+    it('returns zero insets when not on an iPhone', () => {
+      ons.platform.isIPhone = () => false;
+      expect(ons.platform.getSafeAreaInsets()).to.eql({ top: 0, right: 0, bottom: 0, left: 0 });
+    });
+
+    it('resolves max()/env() custom properties to pixels instead of 0', () => {
+      ons.platform.isIPhone = () => true;
+      // No safe area exists in the test browser, so env() is 0 and the max()
+      // floors (44/34/21) win.
+      const isPortrait = window.innerHeight > window.innerWidth;
+      const expected = isPortrait
+        ? { top: 44, right: 0, bottom: 34, left: 0 }
+        : { top: 0, right: 44, bottom: 21, left: 44 };
+      expect(ons.platform.getSafeAreaInsets()).to.eql(expected);
+    });
+  });
+
   describe('#isIPad()', () => {
     it('returns false if platform is iPad', () => {
       expect(ons.platform.isIPad()).to.be.false;


### PR DESCRIPTION
## Problem

`ons.platform.getSafeAreaInsets()` returns `{top: 0, right: 0, bottom: 0, left: 0}` on every real iPhone (and in the published `onsenui@2.12.9-beta.0`).

## Root cause

The `--iphonex-safe-area-inset-*` custom properties hold unevaluated `max(env(...), <fallback>)` expressions (the `max()` wrapper was added so desktop browsers keep the hardcoded fallback). `getComputedStyle().getPropertyValue()` returns them as a literal string such as `"max(0px, 44px)"` — CSS does not evaluate math functions inside custom properties without `@property`. `parseInt("max(...")` is therefore `NaN`, and `|| 0` yields `0`.

This happens on any browser that supports `env()` (i.e. all real iPhones), while CSS rendering stays correct because `var()` used in real properties resolves at used-value time.

Confirmed on both Blink (Chrome) and WebKit (Safari): `getPropertyValue` returns `"max(0px, 44px)"` and `parseInt` returns `NaN`. Before the `max()` wrapper the properties were plain `env(...)`, which `parseInt` could read, so the regression was introduced together with the `max()` change.

## Fix

Apply the variables to a probe element's `padding` and read the computed pixels, so the browser resolves `max()`/`env()` at used-value time.

## Tests

Adds `#getSafeAreaInsets()` coverage in `platform.spec.js`: it resolves `max()`/`env()` custom properties to pixels, and returns zeros when not on an iPhone.

## Release

Bumps to `2.12.9-beta.1` so the fix ships on the `beta` dist-tag.
