### PR TITLE
chore(release): bump onsenui and binding peers to 2.12.9-beta.1

### DIFF
--- a/onsenui/package.json
+++ b/onsenui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onsenui",
-  "version": "2.12.9-beta.0",
+  "version": "2.12.9-beta.1",
   "description": "HTML5 Mobile Framework & UI Components",
   "private": false,
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39012,7 +39012,7 @@
       }
     },
     "onsenui": {
-      "version": "2.12.9-beta.0",
+      "version": "2.12.9-beta.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.15.0",
@@ -39262,7 +39262,7 @@
         "webpack": "^5.69.1"
       },
       "peerDependencies": {
-        "onsenui": "2.12.9-beta.0",
+        "onsenui": "2.12.9-beta.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
@@ -40033,7 +40033,7 @@
         "vue-template-compiler": "^2.6.11"
       },
       "peerDependencies": {
-        "onsenui": "2.12.9-beta.0",
+        "onsenui": "2.12.9-beta.1",
         "vue": "^3.0.6"
       }
     },

--- a/react-onsenui/package.json
+++ b/react-onsenui/package.json
@@ -80,7 +80,7 @@
     "webpack": "^5.69.1"
   },
   "peerDependencies": {
-    "onsenui": "2.12.9-beta.0",
+    "onsenui": "2.12.9-beta.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/vue3-onsenui/package.json
+++ b/vue3-onsenui/package.json
@@ -58,7 +58,7 @@
     ]
   },
   "peerDependencies": {
-    "onsenui": "2.12.9-beta.0",
+    "onsenui": "2.12.9-beta.1",
     "vue": "^3.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Coordinated version bump to release **onsenui@2.12.9-beta.1**, which ships the
`getSafeAreaInsets()` fix (#3095).

- `onsenui`: `2.12.9-beta.0` → `2.12.9-beta.1`
- `react-onsenui` / `vue3-onsenui` `peerDependencies.onsenui` pinned to `2.12.9-beta.1`
- `package-lock.json` updated for the new version (minimal diff)

The binding peers are bumped together because they exact-pin `onsenui`; bumping
`onsenui` alone breaks `npm ci` with an `ERESOLVE` peer conflict.

## After merge (publish)

From `./onsenui`:

```
npm run build
npm publish --tag beta
```

Then `npm dist-tag ls onsenui` should show `beta: 2.12.9-beta.1` (latest stays at 2.12.8).
