### PR TITLE
chore(release): bump to 2.12.9 (stable)

### DIFF
--- a/onsenui/CHANGELOG.md
+++ b/onsenui/CHANGELOG.md
@@ -3,6 +3,11 @@ CHANGELOG
 ====
 2.12.9
 ---
+### New Features
+
+* ons.platform.getSafeAreaInsets(): Add API that returns the current safe area insets in pixels ([#3091](https://github.com/OnsenUI/OnsenUI/pull/3091)).
+* css-components: Use CSS `env()` for iPhone safe area insets ([#3091](https://github.com/OnsenUI/OnsenUI/pull/3091)).
+
 ### Bug Fixes
 
 * ons.platform.isIPhoneX: Support iPhone 16 Pro, 16 Pro Max, 17, 17 Pro, 17 Pro Max, and iPhone Air ([#3089](https://github.com/OnsenUI/OnsenUI/pull/3089)).

--- a/onsenui/package.json
+++ b/onsenui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onsenui",
-  "version": "2.12.9-beta.1",
+  "version": "2.12.9",
   "description": "HTML5 Mobile Framework & UI Components",
   "private": false,
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39012,7 +39012,7 @@
       }
     },
     "onsenui": {
-      "version": "2.12.9-beta.1",
+      "version": "2.12.9",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.15.0",
@@ -39262,7 +39262,7 @@
         "webpack": "^5.69.1"
       },
       "peerDependencies": {
-        "onsenui": "2.12.9-beta.1",
+        "onsenui": "2.12.9",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
@@ -40033,7 +40033,7 @@
         "vue-template-compiler": "^2.6.11"
       },
       "peerDependencies": {
-        "onsenui": "2.12.9-beta.1",
+        "onsenui": "2.12.9",
         "vue": "^3.0.6"
       }
     },

--- a/react-onsenui/package.json
+++ b/react-onsenui/package.json
@@ -80,7 +80,7 @@
     "webpack": "^5.69.1"
   },
   "peerDependencies": {
-    "onsenui": "2.12.9-beta.1",
+    "onsenui": "2.12.9",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/vue3-onsenui/package.json
+++ b/vue3-onsenui/package.json
@@ -58,7 +58,7 @@
     ]
   },
   "peerDependencies": {
-    "onsenui": "2.12.9-beta.1",
+    "onsenui": "2.12.9",
     "vue": "^3.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Promote **onsenui** from `2.12.9-beta.1` to the stable **`2.12.9`** release.

- `onsenui`: `2.12.9-beta.1` → `2.12.9`
- `react-onsenui` / `vue3-onsenui` `peerDependencies.onsenui` → `2.12.9`
- `package-lock.json` updated (minimal diff)
- `CHANGELOG.md`: document the new `ons.platform.getSafeAreaInsets()` API and CSS `env()` safe-area support (the 2.12.9 section previously listed only the isIPhoneX device additions)

This is the stable release of the work validated on the `2.12.9-beta.1` prerelease (the `getSafeAreaInsets()` used-value fix from #3095).

## After merge (publish)

From `./onsenui`:

```
npm run build
npm publish
```

No `--tag`, so this publishes to `latest`. `npm dist-tag ls onsenui` should then show `latest: 2.12.9`.
