### PR TITLE
chore(ngx): widen onsenui peer to ~2.12.10 and release 7.1.1

### DIFF
--- a/ngx-onsenui/projects/ngx-onsenui/package.json
+++ b/ngx-onsenui/projects/ngx-onsenui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-onsenui",
-  "version": "7.1.1-beta.0",
+  "version": "7.1.1",
   "author": "Mitsunori Kubota <mitsunori@asial.co.jp>",
   "licenses": [
     {
@@ -24,6 +24,6 @@
   "peerDependencies": {
     "@angular/common": "^7.2.0",
     "@angular/core": "^7.2.0",
-    "onsenui": "2.12.9-beta.0"
+    "onsenui": "~2.12.10"
   }
 }


### PR DESCRIPTION
## Summary

Updates `ngx-onsenui`'s `onsenui` peer dependency so Angular apps and Monaca templates can finally move off the 2.11.x line.

- `version`: `7.1.1-beta.0` → `7.1.1`
- `peerDependencies.onsenui`: `2.12.9-beta.0` → `~2.12.10`

## Why

`ngx-onsenui`'s compiled fesm bundle does `import { PageLoader, _internal, notification, platform } from 'onsenui'` and relies on importing `'onsenui'` to register every element. Both work starting with **onsenui 2.12.10** (#3098), so the peer is moved onto that line.

A **tilde range** is used instead of the previous exact pin. The exact-pin convention is what forced every consuming app/template into an `ERESOLVE` failure whenever onsenui shipped a patch (this is why the angular2 templates were stuck on onsenui 2.11.2). `~2.12.10` (= `>=2.12.10 <2.13.0`):

- accepts onsenui **patch** releases (2.12.11, …) without re-bumping ngx in every consumer — no more `ERESOLVE` on onsenui patches;
- still **excludes** untested minor releases (2.13+) and older versions that lack the named exports / element registration.

> Note: this is intentionally looser than `react-onsenui` / `vue3-onsenui`, which exact-pin their onsenui peer. The tilde was chosen specifically to stop onsenui patch releases from re-freezing the Angular templates; aligning the other bindings to the same policy would be a reasonable follow-up.

## Dependency / merge order

This PR is **blocked on releasing onsenui 2.12.10** (which must include #3098). Order:

1. Merge #3098 (onsenui ESM: element registration + named exports)
2. Release **onsenui 2.12.10** — verify the published `esm/index.js` actually contains the element imports + named exports
3. Merge this PR and release **ngx-onsenui 7.1.1**
4. Update the angular2 templates to onsenui `2.12.10` + ngx-onsenui `^7.1.1`

## Verification

- semver: `~2.12.10` accepts `2.12.10 / 2.12.11`, rejects `2.11.2 / 2.12.9 / 2.13.0 / 3.0.0`.
- The shipped fesm bundle is unchanged; with onsenui 2.12.10 (#3098), a real angular2 template installs with no `ERESOLVE`, builds with no `was not found in 'onsenui'` webpack warnings, and renders correctly styled on the iOS simulator.